### PR TITLE
docs: CLI surface — namespace decision and command reference (ADRs 0010-0011)

### DIFF
--- a/docs/decisions/0010-annotation-entrypoints.md
+++ b/docs/decisions/0010-annotation-entrypoints.md
@@ -1,0 +1,99 @@
+# 0010: Annotation Entrypoint Design
+
+Status: Under Discussion
+
+> Early draft — rough / unfinished ideas. @SG feel free to leave high-level comments for direction. But I'll be polishing this up Friday day
+
+## Decision
+
+TBD — presenting options for discussion.
+
+Three *annotation* entrypoint types are planned: direct URL, Python API, and CLI. All open the Argilla web UI. The open question is CLI scope (how many commands).
+
+Annotation commands live under `chatboteval annotation <subcommand>` — keeping top-level clean for product commands (`generate`, `eval`, `train`); see [ADR-0011](0011-infra-cli-commands.md).
+
+
+## Options
+
+### Option A: Minimal
+
+One command: `chatboteval annotation annotate <data>` — starts Argilla stack (if not running), imports data, opens web UI.
+
+Import/export handled via Python API or Makefile scripts only.
+
+**Pros:**
+- Lowest cognitive load; minimal CLI surface to maintain
+- "install package → run command → web app opens"
+- Aligns with f2f UX principle: "minimal entry points → GUIs open to offer users options; simple entry point + in-app guidance"
+
+**Cons:**
+- No CLI automation for import/export; admin tasks require Python knowledge
+- Conflates setup, import, and annotation into one command (harder to debug)
+- Less composable for scripting
+
+> Consider `chatboteval annotation init` → opens a GUI/wizard that helps fill out `~/.chatboteval/config.yaml`
+
+### Option B: Core Workflow Commands
+
+Separate commands for each workflow step:
+
+```
+chatboteval annotation setup    # configure Argilla (workspaces, schemas, users)
+chatboteval annotation import   # load data into Argilla datasets
+chatboteval annotation export   # export annotations to CSV
+chatboteval annotation open     # open Argilla web UI in browser
+```
+
+Each command does one thing. Composable and scriptable.
+
+**Pros:**
+- Clear separation of concerns (debug individual steps)
+- Scriptable (CI, Makefile targets, automation)
+
+**Cons:**
+- More surface area to maintain
+- Users must learn multiple commands (mitigated by `--help`)
+
+### Option C: Rich CLI
+
+All of Option B plus additional admin/analysis commands:
+
+```
+chatboteval annotation iaa       # compute inter-annotator agreement
+chatboteval annotation status    # show dataset completion progress
+chatboteval annotation users     # manage user accounts
+```
+
+**Pros:** Full admin and QA coverage from CLI; no need to drop into Python for any workflow.
+
+**Cons:** High maintenance; overengineered for v1.0 — add later if demanded.
+
+
+## Annotation Entrypoints
+
+Regardless of CLI scope, annotation is accessed via three entry points (all open Argilla web UI):
+
+| Entrypoint | Use case |
+|------------|----------|
+| **URL** | Direct browser access to Argilla instance |
+| **Python API** | `chatboteval.annotation.open()` — programmatic access |
+| **CLI** | `chatboteval annotation open` — convenience wrapper |
+
+Annotation itself happens entirely in the Argilla web UI. CLI and Python API are for data management only.
+
+
+## Implementation Notes
+
+- **CLI framework:** Typer
+- **Python API:** CLI commands are thin wrappers around Python functions; public API exists regardless of CLI scope
+- **Registration:** `[project.scripts]` in `pyproject.toml`
+
+See [ADR-0012: Installation & Zero-Config Setup](0012-infra-installation-setup-ux.md) for setup modes and optional extras.
+See [Packaging & Entrypoints](../design/infra-packaging-entrypoints.md) for dependency group details.
+
+
+## Consequences
+
+- CLI scope determines maintenance surface and user onboarding complexity
+- Python API is the primary programmatic interface regardless of CLI choice
+- Option B is the natural middle ground; Option A aligns better with the f2f UX principle; Option C is deferred

--- a/docs/decisions/0011-infra-cli-commands.md
+++ b/docs/decisions/0011-infra-cli-commands.md
@@ -1,0 +1,155 @@
+# 0011: CLI Commands
+
+Status: Draft
+
+> Early draft — rough / unfinished ideas. @SG feel free to leave high-level comments for direction. But I'll be polishing this up Friday day as currently leans towards a research doc
+
+## Decision
+
+Working assumption: 
+- primary pipeline commands (`generate`, `eval`, `train`) at top-level
+- annotation commands grouped under `chatboteval annotation <subcommand>` namespace label 
+
+All commands have Python API equivalents. CLI commands are thin wrappers around Python functions.
+
+>design principle: if no arg / subcommand passed -> GUI/Wizard
+
+
+## Full Command Reference
+
+>all super tbc / thought in progress
+
+Top level:
+
+| Command | Description | Deps required | Status | Ref |
+|---------|-------------|-----------------|--------|-----|
+| `chatboteval generate` | Generate synthetic query-response pairs | TBD |  v1.0 | — |
+| `chatboteval eval` | Run evaluation pipeline on annotated CSV | TBD |  v1.0 | — |
+| `chatboteval train` | Fine-tune model on annotated CSV | `[finetune]` / `[finetune-peft]` |  v1.0 | — |
+
+Annotate namespace:
+
+| Command | Description | Deps required | Status | Ref |
+|---------|-------------|-----------------|--------|-----|
+| `chatboteval annotation setup` | Configure Argilla (workspaces, schemas, users) | `[annotation]` | v1.0 | [ADR-0010](0010-annotation-entrypoints.md), [ADR-0012](0012-infra-installation-setup-ux.md) |
+| `chatboteval annotation import <file>` | Load data into Argilla datasets | `[annotation]` | v1.0 | [ADR-0010](0010-annotation-entrypoints.md) |
+| `chatboteval annotation export <output>` | Export annotations to CSV | `[annotation]` | v1.0 | [ADR-0010](0010-annotation-entrypoints.md), [ADR-0005](0005-annotation-export-schema.md) |
+| `chatboteval annotation open` | Open Argilla web UI in browser | `[annotation]` | v1.0 | [ADR-0010](0010-annotation-entrypoints.md) |
+
+
+> `chatboteval annotation setup` has three modes: `--local`, `--hosted --url <url>`, `--cloud`. See [ADR-0012](0012-infra-installation-setup-ux.md).
+
+## Command Sketches
+
+```
+chatboteval generate --data <path> [--model <model_id>] [--output <path>]
+chatboteval eval     --data <csv_path> [--output <path>] [--reference <path>]
+chatboteval train    --data <csv_path> [--method finetune|peft|optuna] [--output <path>]
+
+chatboteval annotation setup [--local | --hosted --url <url> | --cloud]
+chatboteval annotation import  <file>
+chatboteval annotation export  <output_path>
+chatboteval annotation open
+```
+
+Feature-gated extras (see [ADR-0012](0012-infra-installation-setup-ux.md)):
+- `--method peft` requires `chatboteval[finetune-peft]`
+- `--method optuna` requires `chatboteval[finetune-optuna]`
+- `generate` optional deps TBD (local LLM vs hosted API)
+
+
+## Namespace Options
+
+Research basis: HuggingFace `hf` CLI ([docs](https://huggingface.co/docs/huggingface_hub/guides/cli)), GitHub `gh` CLI ([docs](https://cli.github.com/manual/)), MLflow CLI ([docs](https://mlflow.org/docs/latest/cli.html)), DVC ([docs](https://dvc.org/doc/command-reference)), dbt ([docs](https://docs.getdbt.com/reference/dbt-commands)), W&B `wandb` ([docs](https://docs.wandb.ai/ref/cli)).
+
+**Pattern finding:** Flat structures (`dbt`, `dvc`, `wandb`) work well at small command counts; grouped namespaces (`hf`, `gh`, `mlflow`) dominate as surface grows. Neither pattern formally separates admin vs workflow — the distinction is conceptual, enforced by docs not structure.
+
+---
+
+### Option A: Fully flat
+
+All commands at top-level — no namespaces.
+
+```
+chatboteval setup     [--local | --hosted --url <url> | --cloud]
+chatboteval annotate   # opens Argilla UI (also --setup? or just have this at python code level)
+chatboteval generate  --data <path> [--model <model_id>] [--output <path>]
+chatboteval eval      --data <data_path> [--output <path>] [--reference <path>]
+chatboteval train     --data <csv_path> [--method finetune|peft|optuna] [--output <path>]
+chatboteval --help
+```
+
+**Pros:**
+- Lowest friction — every command is one level deep
+- Consistent depth; no mixed flat/nested surface
+- dbt/dvc precedent — common for tools with a clear linear workflow
+- Aligns with f2f UX principle: minimal entry points
+
+**Cons:**
+- No structural separation between annotation admin (setup/import/export) and ML pipeline commands
+- Verb reuse risk if scope grows (e.g. a future `chatboteval export` for model export conflicts with annotation export)
+- `--help` lists all 7+ commands with no visual grouping
+
+---
+
+### Option B: Annotation namespace + flat pipeline commands
+
+Annotation admin commands under `chatboteval annotation`; pipeline commands flat at top-level.
+
+```
+chatboteval annotation setup    [--local | --hosted --url <url> | --cloud]
+chatboteval annotation import   <file>
+chatboteval annotation open                                       # opens Argilla UI
+chatboteval annotation export   <output_path>
+chatboteval generate  --data <path> [--model <model_id>] [--output <path>]
+chatboteval eval      --data <csv_path> [--output <path>] [--reference <path>]
+chatboteval train     --data <csv_path> [--method finetune|peft|optuna] [--output <path>]
+```
+
+`chatboteval --help` shows: `annotation`, `generate`, `eval`, `train`
+
+**Pros:**
+- Clean top-level surface for the daily-use ML pipeline commands
+- Annotation admin is clearly scoped — hard to accidentally run `setup` thinking it's a pipeline step
+- Namespace can grow independently (add `annotation iaa`, `annotation status` without polluting top-level)
+- Precedent: MLflow (`mlflow server` vs `mlflow run`), hf (`hf auth` vs `hf download`)
+
+**Cons:**
+- Mixed depth: `annotation` is a group, `generate/eval/train` are bare verbs — visually inconsistent in `--help`
+- Annotation tasks require two words even for daily operations (`chatboteval annotation open`)
+
+---
+
+### Summary
+
+| | Option A — fully flat | Option B — annotation namespace |
+|---|---|---|
+| `--help` depth | 1 level | Mixed (1 for pipeline, 2 for annotation) |
+| Precedent | dbt, dvc, wandb | mlflow, hf (partial) |
+| Verb reuse risk | Higher | Lower |
+| Discoverability | Single list | Grouped; annotation commands hidden one level down |
+| Extensibility | Flat gets noisy after ~10 commands | Annotation group can grow without top-level pollution |
+
+
+## Rationale
+
+**Annotation as admin infrastructure:** Setup/import/export are one-time-per-iteration admin tasks. Namespacing under `chatboteval annotation` keeps the daily-use surface clean.
+
+**Python API parity:** All commands available programmatically. From f2f: "download package → run command → output."
+
+
+## Consequences
+
+- Namespace choice determines `--help` discoverability and long-term extensibility
+- v1.0 ships only `chatboteval annotation *`; ML pipeline commands reserved for v1.1+
+- Missing extras produce clear install hints at runtime (not import-time)
+
+
+## Open Questions
+
+- Which namespace proposal to adopt — see Proposals section
+- `generate`: local LLM (GPU dep) or hosted API? Determines optional extras.
+- `eval`: optional `--reference` arg or separate subcommands for reference-based vs reference-free?
+- `train`: confirm naming (`train` vs `finetune`) — f2f noted "train (TBC)"
+
+See [Packaging & Entrypoints](../design/infra-packaging-entrypoints.md) for dependency group details.

--- a/docs/decisions/0012-infra-installation-setup-ux.md
+++ b/docs/decisions/0012-infra-installation-setup-ux.md
@@ -1,0 +1,85 @@
+# 0012: Installation & Zero-Config Setup
+
+Status: Draft
+
+> Early draft — rough / unfinished ideas. @SG feel free to leave high-level comments for direction. But I'll be polishing this up Friday day
+>
+> Extended research on wizard UX, progressive disclosure, library recommendations (Questionary), idempotency patterns, config location, and open questions: `.hb-scratch/research-setup-ux.md`
+
+## Decision
+
+**No installation surprises.** Users explicitly opt in to heavy dependencies. Base `pip install chatboteval` installs only core; all feature-gated functionality behind named extras.
+
+Annotation setup has three modes: 
+- **local** (Docker Compose on user's machine)
+- **hosted** (existing remote Argilla instance)
+- **cloud** [indefinitely deferred/remove?] HF Spaces — optional, paid) 
+
+
+## Optional Extras
+
+```bash
+pip install chatboteval                    # core only (data loading, CSV I/O)
+pip install chatboteval[annotation]        # + Argilla SDK (annotation interface)
+pip install chatboteval[finetune]          # + torch, transformers (standard fine-tuning)
+pip install chatboteval[finetune-peft]     # + peft, bitsandbytes (LoRA / QLoRA)
+pip install chatboteval[finetune-optuna]   # + optuna (hyperparameter optimisation)
+pip install chatboteval[dev]               # + pytest, ruff, mypy
+```
+
+Extras can be combined: `pip install chatboteval[annotation,finetune]`.
+
+**Fail-fast on missing extras:** Attempting to use a feature without its extra raises a clear, actionable error — not a cryptic import traceback:
+
+```
+ArgillaNotInstalledError: Argilla is not installed.
+Install with: pip install chatboteval[annotation]
+```
+
+Import guards are at the call site, not at module import (so `import chatboteval` always works).
+
+
+## Annotation Setup Modes
+
+Three modes for `chatboteval annotation setup` (or `make setup`):
+
+| Mode | Command | What it does |
+|------|---------|--------------|
+| **Local** | `chatboteval annotation setup --local` | Writes `docker-compose.yml` + `.env` to `./apps/annotation/`; runs `docker compose up` |
+| **Hosted** | `chatboteval annotation setup --hosted --url <url>` | Writes URL + credentials to `~/.chatboteval/config.yaml`; validates connection |
+| **Cloud** | `chatboteval annotation setup --cloud` | Guides through HuggingFace Spaces setup (optional, paid) |
+
+For v1.0 (BF pilot), only **Local** and **Hosted** modes are required. Cloud is documented for future open-source users.
+
+**Makefile abstraction:** `make setup` chains Docker startup + SDK configuration as a convenience target (see [Deployment design doc](../design/infra-deployment.md)):
+
+```
+make up       → start Docker containers
+chatboteval annotation setup → configure Argilla via SDK
+make setup    → both, sequentially
+```
+
+
+## Rationale
+
+**No installation surprises:** `torch`, `argilla`, and `bitsandbytes` are large, sometimes GPU-specific packages. Forcing them on users who only need CSV export or evaluation would cause dependency conflicts and long installs. Optional extras let users install exactly what they need. From the 17-02 f2f: "our package installation should be the same: optional dependencies — no huge installation surprises."
+
+**Three setup modes:** Different deployment contexts have fundamentally different setup flows. Flags make this explicit; a single `setup` command that silently guesses the mode would be harder to debug.
+
+**Hosted mode for BF pilot:** Annotation will run on BF infrastructure, not the developer's laptop. `--hosted` allows connecting `chatboteval` to an existing Argilla instance without running Docker locally.
+
+
+## Consequences
+
+- `pyproject.toml` is the authoritative source for defined extras
+- All optional import guards must be at call site, not module level
+- `~/.chatboteval/config.yaml` is the config file location for hosted/cloud modes
+- Local mode requires Docker on the user's machine (documented prerequisite)
+- Cloud mode (HF Spaces) is out of scope for v1.0; documented for open-source users
+
+## References
+
+- [ADR-0010: Annotation Entrypoints](0010-annotation-entrypoints.md) — annotation command structure
+- [ADR-0011: CLI Commands](0011-infra-cli-commands.md) — full CLI reference and optional deps
+- [Deployment](../design/infra-deployment.md) — Docker Compose stack and Makefile targets
+- [Packaging & Entrypoints](../design/infra-packaging-entrypoints.md) — dependency groups and design doc

--- a/docs/design/infra-deployment.md
+++ b/docs/design/infra-deployment.md
@@ -1,0 +1,96 @@
+# Deployment
+
+Docker Compose stack for the Argilla annotation platform, covering local development and production on-premises deployment.
+
+## Responsibilities
+
+**In scope:**
+- Define the containerised service stack (Argilla + backing services)
+- Provide local and production deployment modes
+- Document resource requirements and configuration
+
+**Out of scope:**
+- Argilla SDK setup (workspaces, schemas, users) — see [Annotation Interface](annotation-interface.md)
+- Cloud-hosted deployment — see [ADR-0003](../decisions/0003-infra-self-hosted-only.md)
+
+## Stack
+
+| Service | Role |
+|---------|------|
+| **Argilla Server** | Annotation web UI + API |
+| **PostgreSQL** | User accounts, dataset metadata, annotation storage |
+| **Elasticsearch** | Record search and indexing |
+| **Redis** | Background task queue |
+
+All services run as Docker containers orchestrated by Docker Compose.
+
+## Deployment Modes
+
+### Local Development
+
+`docker compose up` using the Argilla quickstart or full stack definition. For development, testing, and MAMA cycle iteration.
+
+- Ephemeral by default (data persists only with named volumes)
+- Accessible at `localhost`
+
+### Production (On-Premises)
+
+Full Docker Compose stack deployed by IT. Env-based configuration, persistent volumes, internal network access.
+
+- Persistent named volumes for PostgreSQL and Elasticsearch data
+- Environment variables for credentials, API URL, resource limits
+- Internal URL accessible to annotators on the organisation's network
+- No external/internet access required
+
+## Setup Orchestration
+
+Layered approach separating infrastructure from application setup:
+
+```
+make up          → starts Docker containers, waits for health checks
+chatboteval setup → configures Argilla via SDK (workspaces, schemas, users)
+make setup       → chains both: infrastructure + SDK configuration
+```
+
+**Rationale:** Docker orchestration is infrastructure concern; Argilla SDK configuration is application logic. Clean separation — standard pattern in Python ML tooling.
+
+Additional Makefile targets: `make down`, `make logs`, `make clean` (remove volumes).
+
+## Resource Requirements
+
+Estimated for annotation workloads (not training/inference):
+
+| Resource | Minimum | Notes |
+|----------|---------|-------|
+| RAM | ~2 GB | Elasticsearch is the main consumer (JVM heap) |
+| Disk | ~10 GB | PostgreSQL + Elasticsearch indices; grows with dataset size |
+| CPU | 2 cores | Sufficient for concurrent annotation by <20 users |
+
+Production deployments should monitor Elasticsearch heap usage and adjust `ES_JAVA_OPTS` as dataset size grows.
+
+## Failure Modes
+
+**Elasticsearch memory limits:**
+- Elasticsearch requires sufficient JVM heap; defaults may be too low
+- Symptom: OOM kills, search timeouts
+- Mitigation: set `ES_JAVA_OPTS=-Xms512m -Xmx512m` (minimum) in Compose environment
+
+**PostgreSQL connection refused:**
+- Argilla server starts before PostgreSQL is ready
+- Mitigation: health checks with `depends_on` conditions in Compose file
+
+**Container health timeouts:**
+- Elasticsearch can take 30-60s to become healthy on first start
+- Mitigation: configure appropriate health check intervals and start periods
+
+**Data loss on `docker compose down -v`:**
+- Removing volumes destroys all annotation data
+- Mitigation: document volume management; use `down` (without `-v`) by default
+
+## References
+
+- [Decision 0001: Argilla Annotation Platform](../decisions/0001-annotation-argilla-platform.md) — infrastructure trade-offs
+- [Decision 0003: Self-Hosted Only](../decisions/0003-infra-self-hosted-only.md) — self-hosted deployment rationale
+- [Decision 0008: Authentication Model](../decisions/0008-authentication-model.md) — auth credentials and API key passed via environment variables at deployment
+- [Annotation Interface](annotation-interface.md) — SDK setup that runs after deployment
+- Argilla deployment docs: https://docs.argilla.io/latest/

--- a/docs/design/infra-packaging-entrypoints.md
+++ b/docs/design/infra-packaging-entrypoints.md
@@ -1,0 +1,77 @@
+# Packaging & Entrypoints Design
+
+## Overview
+
+How `chatboteval` package is structured, installed, and invoked. Covers the Python API, CLI entrypoints, optional dependency groups, and deployment modes.
+
+See [ADR-0009: Annotation Entrypoints](../decisions/0010-annotation-entrypoints.md) for CLI scope decision and tradeoffs.
+
+## User Workflow
+
+```
+pip install chatboteval[annotation]         # 1. install with annotation extras
+make up                                     # 2. start Argilla stack (Docker Compose)
+chatboteval annotation setup --local        # 3. configure workspaces, schemas, users
+chatboteval annotation import <file>        # 4. load data into Argilla datasets
+# annotate via Argilla web UI              # 5. label in browser
+chatboteval annotation export <output_path> # 6. export annotations to CSV
+```
+
+CLI commands are thin wrappers around the Python API. All operations are also available programmatically via `chatboteval.*` functions.
+
+## Optional Dependencies Philosophy
+
+**Principle: no installation surprises. Users must explicitly opt in to heavy dependencies.**
+
+The core `pip install chatboteval` installs only the minimum required to run. Feature groups are gated behind extras that users opt into deliberately:
+
+```bash
+pip install chatboteval                         # core only
+pip install chatboteval[annotation]             # + Argilla SDK for annotation interface
+pip install chatboteval[finetune]               # + standard fine-tuning deps
+pip install chatboteval[finetune-peft]          # + PEFT (parameter-efficient fine-tuning)
+etc
+```
+- No surprise large installs.
+- No dependency conflicts for users who don't need a feature.
+- Core functionality (data import, CSV export) always works without extras.
+
+**Important:** If a feature requires an optional extra that isn't installed, the package should fail fast with a clear, actionable error message (i.e. to pip install opt deps) rather than a cryptic import error.
+
+## Dependency Groups (planned)
+
+| Extra | Contents | Use case |
+|---|---|---|
+| `annotation` | `argilla`, `datasets` | Annotation interface — import/export, Argilla SDK wrappers |
+| `finetune` | `torch`, `transformers`, `pandas` | Standard supervised fine-tuning on annotated CSV |
+| `finetune-peft` | `peft`, `bitsandbytes` | Parameter-efficient fine-tuning (LoRA, QLoRA) |
+| `finetune-optuna` | `optuna` | Hyperparameter optimisation for fine-tuning runs |
+| `dev` | `pytest`, `ruff`, `mypy` | Development tooling |
+|others? | | |
+|`synthetic-data-gen` | | if our generation pipeline requires running LLMs - what deps? | 
+
+## Responsibilities
+
+- Define `[project.optional-dependencies]` in `pyproject.toml` for each group.
+- Guard optional imports with `ImportError` + helpful message at the call site (not at module import).
+- CLI entrypoints registered under `[project.scripts]` in `pyproject.toml`.
+
+## Inputs / Outputs
+
+**Input:** User installs the package with chosen extras.
+
+**Output:** Only the chosen feature set is available; attempting to use an uninstalled feature raises a clear error pointing to the relevant install command.
+
+## Failure Modes / Edge Cases
+
+- **Missing optional dep at runtime:** Raise `ImportError` with explicit install hint, not a silent no-op or cryptic traceback.
+- **Version conflicts between extras:** Document known conflicts (e.g. `bitsandbytes` GPU vs CPU builds). Users installing `[finetune-peft]` on CPU-only machines should see a clear warning. Docker isolation as needed.
+
+## References
+
+- [Decision 0001: Argilla Annotation Platform](../decisions/0001-annotation-argilla-platform.md) — annotation-specific entrypoints and optional dependency pattern
+- [Decision 0005: Annotation Export Format](../decisions/0005-annotation-export-schema.md) — CSV primary output consumed by downstream fine-tuning pipeline
+- [Decision 0010: Annotation Entrypoints](../decisions/0010-annotation-entrypoints.md) — annotation CLI scope decision
+- [Decision 0011: CLI Commands](../decisions/0011-infra-cli-commands.md) — full CLI reference (annotation + product commands)
+- [Decision 0012: Installation & Zero-Config Setup](../decisions/0012-infra-installation-setup-ux.md) — optional extras, setup wizard UX
+- `pyproject.toml` — authoritative source for defined extras


### PR DESCRIPTION
Adds ADRs 0010–0012 covering the invocation surface and setup UX, with companion infra design docs.

**New ADRs:**
- 0010: Annotation Entrypoints
- 0011: Infra CLI Commands
- 0012: Infra Installation & Setup UX

**New design docs:**
- Infra — Deployment
- Infra — Packaging & Entrypoints

**Status:** Draft — not ready for review.