### PR TITLE
docs: setup, deployment, and optional deps

### DIFF
--- a/docs/decisions/0012-infra-installation-setup-ux.md
+++ b/docs/decisions/0012-infra-installation-setup-ux.md
@@ -1,0 +1,85 @@
+# 0012: Installation & Zero-Config Setup
+
+Status: Draft
+
+> Early draft — rough / unfinished ideas. @SG feel free to leave high-level comments for direction. But I'll be polishing this up Friday day
+>
+> Extended research on wizard UX, progressive disclosure, library recommendations (Questionary), idempotency patterns, config location, and open questions: `.hb-scratch/research-setup-ux.md`
+
+## Decision
+
+**No installation surprises.** Users explicitly opt in to heavy dependencies. Base `pip install chatboteval` installs only core; all feature-gated functionality behind named extras.
+
+Annotation setup has three modes: 
+- **local** (Docker Compose on user's machine)
+- **hosted** (existing remote Argilla instance)
+- **cloud** [indefinitely deferred/remove?] HF Spaces — optional, paid) 
+
+
+## Optional Extras
+
+```bash
+pip install chatboteval                    # core only (data loading, CSV I/O)
+pip install chatboteval[annotation]        # + Argilla SDK (annotation interface)
+pip install chatboteval[finetune]          # + torch, transformers (standard fine-tuning)
+pip install chatboteval[finetune-peft]     # + peft, bitsandbytes (LoRA / QLoRA)
+pip install chatboteval[finetune-optuna]   # + optuna (hyperparameter optimisation)
+pip install chatboteval[dev]               # + pytest, ruff, mypy
+```
+
+Extras can be combined: `pip install chatboteval[annotation,finetune]`.
+
+**Fail-fast on missing extras:** Attempting to use a feature without its extra raises a clear, actionable error — not a cryptic import traceback:
+
+```
+ArgillaNotInstalledError: Argilla is not installed.
+Install with: pip install chatboteval[annotation]
+```
+
+Import guards are at the call site, not at module import (so `import chatboteval` always works).
+
+
+## Annotation Setup Modes
+
+Three modes for `chatboteval annotation setup` (or `make setup`):
+
+| Mode | Command | What it does |
+|------|---------|--------------|
+| **Local** | `chatboteval annotation setup --local` | Writes `docker-compose.yml` + `.env` to `./apps/annotation/`; runs `docker compose up` |
+| **Hosted** | `chatboteval annotation setup --hosted --url <url>` | Writes URL + credentials to `~/.chatboteval/config.yaml`; validates connection |
+| **Cloud** | `chatboteval annotation setup --cloud` | Guides through HuggingFace Spaces setup (optional, paid) |
+
+For v1.0 (BF pilot), only **Local** and **Hosted** modes are required. Cloud is documented for future open-source users.
+
+**Makefile abstraction:** `make setup` chains Docker startup + SDK configuration as a convenience target (see [Deployment design doc](../design/infra-deployment.md)):
+
+```
+make up       → start Docker containers
+chatboteval annotation setup → configure Argilla via SDK
+make setup    → both, sequentially
+```
+
+
+## Rationale
+
+**No installation surprises:** `torch`, `argilla`, and `bitsandbytes` are large, sometimes GPU-specific packages. Forcing them on users who only need CSV export or evaluation would cause dependency conflicts and long installs. Optional extras let users install exactly what they need. From the 17-02 f2f: "our package installation should be the same: optional dependencies — no huge installation surprises."
+
+**Three setup modes:** Different deployment contexts have fundamentally different setup flows. Flags make this explicit; a single `setup` command that silently guesses the mode would be harder to debug.
+
+**Hosted mode for BF pilot:** Annotation will run on BF infrastructure, not the developer's laptop. `--hosted` allows connecting `chatboteval` to an existing Argilla instance without running Docker locally.
+
+
+## Consequences
+
+- `pyproject.toml` is the authoritative source for defined extras
+- All optional import guards must be at call site, not module level
+- `~/.chatboteval/config.yaml` is the config file location for hosted/cloud modes
+- Local mode requires Docker on the user's machine (documented prerequisite)
+- Cloud mode (HF Spaces) is out of scope for v1.0; documented for open-source users
+
+## References
+
+- [ADR-0010: Annotation Entrypoints](0010-annotation-entrypoints.md) — annotation command structure
+- [ADR-0011: CLI Commands](0011-infra-cli-commands.md) — full CLI reference and optional deps
+- [Deployment](../design/infra-deployment.md) — Docker Compose stack and Makefile targets
+- [Packaging & Entrypoints](../design/infra-packaging-entrypoints.md) — dependency groups and design doc

--- a/docs/design/infra-deployment.md
+++ b/docs/design/infra-deployment.md
@@ -1,0 +1,96 @@
+# Deployment
+
+Docker Compose stack for the Argilla annotation platform, covering local development and production on-premises deployment.
+
+## Responsibilities
+
+**In scope:**
+- Define the containerised service stack (Argilla + backing services)
+- Provide local and production deployment modes
+- Document resource requirements and configuration
+
+**Out of scope:**
+- Argilla SDK setup (workspaces, schemas, users) — see [Annotation Interface](annotation-interface.md)
+- Cloud-hosted deployment — see [ADR-0003](../decisions/0003-infra-self-hosted-only.md)
+
+## Stack
+
+| Service | Role |
+|---------|------|
+| **Argilla Server** | Annotation web UI + API |
+| **PostgreSQL** | User accounts, dataset metadata, annotation storage |
+| **Elasticsearch** | Record search and indexing |
+| **Redis** | Background task queue |
+
+All services run as Docker containers orchestrated by Docker Compose.
+
+## Deployment Modes
+
+### Local Development
+
+`docker compose up` using the Argilla quickstart or full stack definition. For development, testing, and MAMA cycle iteration.
+
+- Ephemeral by default (data persists only with named volumes)
+- Accessible at `localhost`
+
+### Production (On-Premises)
+
+Full Docker Compose stack deployed by IT. Env-based configuration, persistent volumes, internal network access.
+
+- Persistent named volumes for PostgreSQL and Elasticsearch data
+- Environment variables for credentials, API URL, resource limits
+- Internal URL accessible to annotators on the organisation's network
+- No external/internet access required
+
+## Setup Orchestration
+
+Layered approach separating infrastructure from application setup:
+
+```
+make up          → starts Docker containers, waits for health checks
+chatboteval setup → configures Argilla via SDK (workspaces, schemas, users)
+make setup       → chains both: infrastructure + SDK configuration
+```
+
+**Rationale:** Docker orchestration is infrastructure concern; Argilla SDK configuration is application logic. Clean separation — standard pattern in Python ML tooling.
+
+Additional Makefile targets: `make down`, `make logs`, `make clean` (remove volumes).
+
+## Resource Requirements
+
+Estimated for annotation workloads (not training/inference):
+
+| Resource | Minimum | Notes |
+|----------|---------|-------|
+| RAM | ~2 GB | Elasticsearch is the main consumer (JVM heap) |
+| Disk | ~10 GB | PostgreSQL + Elasticsearch indices; grows with dataset size |
+| CPU | 2 cores | Sufficient for concurrent annotation by <20 users |
+
+Production deployments should monitor Elasticsearch heap usage and adjust `ES_JAVA_OPTS` as dataset size grows.
+
+## Failure Modes
+
+**Elasticsearch memory limits:**
+- Elasticsearch requires sufficient JVM heap; defaults may be too low
+- Symptom: OOM kills, search timeouts
+- Mitigation: set `ES_JAVA_OPTS=-Xms512m -Xmx512m` (minimum) in Compose environment
+
+**PostgreSQL connection refused:**
+- Argilla server starts before PostgreSQL is ready
+- Mitigation: health checks with `depends_on` conditions in Compose file
+
+**Container health timeouts:**
+- Elasticsearch can take 30-60s to become healthy on first start
+- Mitigation: configure appropriate health check intervals and start periods
+
+**Data loss on `docker compose down -v`:**
+- Removing volumes destroys all annotation data
+- Mitigation: document volume management; use `down` (without `-v`) by default
+
+## References
+
+- [Decision 0001: Argilla Annotation Platform](../decisions/0001-annotation-argilla-platform.md) — infrastructure trade-offs
+- [Decision 0003: Self-Hosted Only](../decisions/0003-infra-self-hosted-only.md) — self-hosted deployment rationale
+- [Decision 0008: Authentication Model](../decisions/0008-authentication-model.md) — auth credentials and API key passed via environment variables at deployment
+- [Annotation Interface](annotation-interface.md) — SDK setup that runs after deployment
+- Argilla deployment docs: https://docs.argilla.io/latest/


### PR DESCRIPTION
Adds Docker Compose deployment design and zero-config setup UX ADR.

**New docs:**
- Infra — Deployment (Docker Compose stack, setup modes)
- ADR-0012: Installation & Setup UX (zero-config wizard, --local/--hosted flags)

**Status:** Draft — not ready for review.