### PR TITLE
docs: restore annotation design doc content

### DIFF
--- a/docs/design/annotation-export-schema.md
+++ b/docs/design/annotation-export-schema.md
@@ -17,8 +17,6 @@ Each task produces a separate CSV. Columns are task-specific; shared metadata co
 
 > **Note:** Export schemas define what downstream pipelines need. They are not a mirror of what annotators see in the annotation interface (field naming and structure may differ).
 
-> **SSOT:** [Annotation Protocol](../methodology/annotation-protocol.md) is the single source of truth for label semantics. In case of drift, the protocol takes precedence.
-
 ### Shared metadata columns (all tasks)
 
 | Column | Type | Description |

--- a/docs/design/annotation-presentation.md
+++ b/docs/design/annotation-presentation.md
@@ -30,8 +30,6 @@ All labels for a task are presented simultaneously (joint labelling). For each t
 
 Question wording is locked here and reflects label semantics from the [Annotation Protocol](../methodology/annotation-protocol.md). English is the default display language for annotators; German translations are available as an optional display language. Wording may evolve as label semantics stabilise in the protocol; this document should be updated in sync.
 
-> **SSOT:** [Annotation Protocol](../methodology/annotation-protocol.md) is the single source of truth for label semantics. In case of drift, the protocol takes precedence.
-
 ### Task 1: Retrieval
 
 Unit of annotation: query–chunk pair $(q_i, c_{ik})$ — see [Annotation Protocol §Task 1](../methodology/annotation-protocol.md)


### PR DESCRIPTION
## Summary
- Restores full specification content to `annotation-export-schema.md` and `annotation-presentation.md` that was stripped during ADR conversion in #4
- Adds back: export schema tables (all 3 tasks), visibility contract table, EN/DE question wording tables, optional fields section
- Updates cross-references to current file locations, genericises source-system-specific field descriptions

Follows up on review feedback from #4.