### PR TITLE
feat: implement output contract layer for synthetic query generation

### DIFF
--- a/src/chatboteval/core/schemas/querygen_output.py
+++ b/src/chatboteval/core/schemas/querygen_output.py
@@ -12,7 +12,7 @@ NonEmptyStr = Annotated[
 
 
 class SyntheticQueryRow(BaseModel):
-    """Schema for one synthetic query CSV row."""
+    """Schema for one synthetic query."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -37,4 +37,5 @@ class SyntheticQueriesMeta(BaseModel):
     created_at: datetime
     n_queries: PositiveInt
     model_provider: str
-    model: str
+    planning_model: str
+    realization_model: str

--- a/tests/test_querygen_output.py
+++ b/tests/test_querygen_output.py
@@ -33,7 +33,8 @@ def valid_meta_payload() -> dict[str, object]:
         "created_at": "2026-03-09T10:30:00Z",
         "n_queries": 25,
         "model_provider": "openai",
-        "model": "gpt-4.1-mini",
+        "planning_model": "gpt-4.1-mini",
+        "realization_model": "gpt-4.1-mini",
     }
 
 
@@ -100,6 +101,9 @@ def test_synthetic_queries_meta_accepts_valid_payload(valid_meta_payload: dict[s
     assert meta.run_id == "run_20260309_001"
     assert meta.created_at == datetime(2026, 3, 9, 10, 30, tzinfo=timezone.utc)
     assert meta.n_queries == 25
+    assert meta.model_provider == "openai"
+    assert meta.planning_model == "gpt-4.1-mini"
+    assert meta.realization_model == "gpt-4.1-mini"
 
 
 def test_synthetic_queries_meta_rejects_non_positive_n_queries(valid_meta_payload: dict[str, object]) -> None:


### PR DESCRIPTION
## Summary
Implements the Pydantic v2 output contract for synthetic query generation.

## Changes
- add `SyntheticQueryRow` in `src/chatboteval/core/schemas/querygen_output.py`
- add `SyntheticQueriesMeta` in `src/chatboteval/core/schemas/querygen_output.py`
- enforce non-empty `query_id` and `query`
- use `PositiveInt` for `n_queries`
- derive CSV column order from `SyntheticQueryRow.model_fields.keys()`
- add unit tests for contract validation behavior

## Notes
- No file I/O or CSV helper logic added. 
- schema remains the single source of truth for output structure

## Tests
```bash
pytest -q tests/test_querygen_output.py
pytest -q tests/test_querygen_input.py tests/test_querygen_output.py
```

Closes #20 