### PR TITLE
docs: fix workspace topology default

### DIFF
--- a/docs/design/annotation-user-management.md
+++ b/docs/design/annotation-user-management.md
@@ -6,7 +6,7 @@ Argilla user account provisioning and credential management for the annotation p
 
 **In scope:**
 - Create and assign annotator accounts in Argilla
-- Assign users to workspaces (workspace names are deployment config; defaults: `retrieval_grounding`, `generation`)
+- Assign users to workspaces (workspace names are deployment config; defaults: `retrieval`, `grounding`, `generation`)
 - Manage API key for import/export scripts
 - Handle password resets
 


### PR DESCRIPTION
## Goal

Align workspace default documentation with ADR-0010 and implementation.

## Scope

Single-line fix in `docs/design/annotation-user-management.md`: update default workspace names from `retrieval_grounding, generation` (2 workspaces) to `retrieval, grounding, generation` (3 workspaces).

## References

- `docs/decisions/0010-annotation-multi-dataset-architecture.md` — one dataset per task (3 datasets → 3 workspaces)
- `src/chatboteval/core/settings/annotation_settings.py` — implementation uses 3 separate workspaces