### PR TITLE
refactor(core): extract shared NonEmptyStr type

### DIFF
--- a/src/chatboteval/core/schemas/annotation_import.py
+++ b/src/chatboteval/core/schemas/annotation_import.py
@@ -1,13 +1,8 @@
 """Boundary schemas for canonical annotation import records."""
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field
 
-
-def _non_empty(v: str) -> str:
-    v = v.strip()
-    if not v:
-        raise ValueError("must not be empty or whitespace-only")
-    return v
+from chatboteval.core.types import NonEmptyStr
 
 
 class Chunk(BaseModel):
@@ -15,15 +10,10 @@ class Chunk(BaseModel):
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    chunk_id: str
-    doc_id: str
+    chunk_id: NonEmptyStr
+    doc_id: NonEmptyStr
     chunk_rank: int = Field(ge=1)
-    text: str
-
-    @field_validator("chunk_id", "doc_id", "text", mode="before")
-    @classmethod
-    def _non_empty(cls, v: str) -> str:
-        return _non_empty(v)
+    text: NonEmptyStr
 
 
 class QueryResponsePair(BaseModel):
@@ -31,13 +21,8 @@ class QueryResponsePair(BaseModel):
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    query: str
-    answer: str
+    query: NonEmptyStr
+    answer: NonEmptyStr
     chunks: list[Chunk] = Field(min_length=1)
-    context_set: str
+    context_set: NonEmptyStr
     language: str | None = None
-
-    @field_validator("query", "answer", "context_set", mode="before")
-    @classmethod
-    def _non_empty(cls, v: str) -> str:
-        return _non_empty(v)

--- a/src/chatboteval/core/schemas/querygen_output.py
+++ b/src/chatboteval/core/schemas/querygen_output.py
@@ -1,14 +1,10 @@
 """Output contract for synthetic query generation."""
 
 from datetime import datetime
-from typing import Annotated
 
-from pydantic import BaseModel, ConfigDict, PositiveInt, StringConstraints
+from pydantic import BaseModel, ConfigDict, PositiveInt
 
-NonEmptyStr = Annotated[
-    str,
-    StringConstraints(strip_whitespace=True, min_length=1),
-]
+from chatboteval.core.types import NonEmptyStr
 
 
 class SyntheticQueryRow(BaseModel):

--- a/src/chatboteval/core/types.py
+++ b/src/chatboteval/core/types.py
@@ -1,0 +1,10 @@
+"""Shared type aliases for boundary schemas."""
+
+from typing import Annotated
+
+from pydantic import StringConstraints
+
+NonEmptyStr = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1),
+]


### PR DESCRIPTION
## Summary

- Extracts `NonEmptyStr` type alias from `querygen_output.py` into shared `core/types.py` module
- Replaces `annotation_import.py`'s `_non_empty` helper + `@field_validator` pattern with `NonEmptyStr` type annotations
- Both schema modules now import from the single shared definition

Addresses review feedback from #42.

## Test plan

- [x] All existing tests pass (99 passed)
- [x] Behaviour unchanged — `NonEmptyStr` uses identical strip + min_length=1 logic