### PR TITLE
docs: drop numbered prefixes from dataset names

### DIFF
--- a/docs/decisions/0010-annotation-multi-dataset-architecture.md
+++ b/docs/decisions/0010-annotation-multi-dataset-architecture.md
@@ -9,9 +9,9 @@ Three separate Argilla datasets — one per annotation task:
 
 | Dataset | Task | Record unit |
 |---------|------|-------------|
-| `task1_retrieval` | Retrieval quality | One record per (query, chunk) |
-| `task2_grounding` | Grounding quality | One record per (answer, context set) |
-| `task3_generation` | Generation quality | One record per (query, answer) |
+| `task_retrieval` | Retrieval quality | One record per (query, chunk) |
+| `task_grounding` | Grounding quality | One record per (answer, context set) |
+| `task_generation` | Generation quality | One record per (query, answer) |
 
 All datasets are assigned to workspaces (see [Workspace & Task Distribution](../design/annotation-workspace-task-distribution.md)). Records from the same input are linked across datasets via `record_uuid` metadata.
 

--- a/docs/design/annotation-export-pipeline.md
+++ b/docs/design/annotation-export-pipeline.md
@@ -20,15 +20,15 @@ Data pipeline to export completed annotations from Argilla records to structured
 ```
 Argilla PostgreSQL
         │
-        ├── task1_retrieval ──────────────────────────────► retrieval.csv
+        ├── task_retrieval ───────────────────────────────► retrieval.csv
         │   (workspace_a)                    (query, chunk, chunk_id,
         │                                                    chunk_rank, labels...)
         │
-        ├── task2_grounding ──────────────────────────────► grounding.csv
+        ├── task_grounding ───────────────────────────────► grounding.csv
         │   (workspace_a)                    (answer, context_set,
         │                                                    labels...)
         │
-        └── task3_generation ─────────────────────────────► generation.csv
+        └── task_generation ──────────────────────────────► generation.csv
             (workspace_b)                      (query, answer, labels...)
 ```
 >**Pending** - exact API / CLI wrapper wording below are TBC, TODO update when decided.
@@ -42,9 +42,9 @@ Three Argilla datasets, accessed via Argilla SDK. Filter: `status == "submitted"
 
 | Dataset | Records |
 |---------|---------|
-| `task1_retrieval` | One record per query–chunk pair |
-| `task2_grounding` | One record per answer-context set pair |
-| `task3_generation` | One record per query–answer pair |
+| `task_retrieval` | One record per query–chunk pair |
+| `task_grounding` | One record per answer-context set pair |
+| `task_generation` | One record per query–answer pair |
 
 > NB: Workspace setup and associated task assignment are deployment configuration, not fixed architecture (see [Workspace & Task Distribution](annotation-workspace-task-distribution.md)).
 

--- a/docs/design/annotation-import-pipeline.md
+++ b/docs/design/annotation-import-pipeline.md
@@ -108,7 +108,7 @@ One record per RAG query-response cycle:
 
 Three Argilla datasets, each receiving records from every import:
 
-### `task1_retrieval` — one record per chunk
+### `task_retrieval` — one record per chunk
 
 **Fields (shown to annotators):**
 - `query` ← canonical `query`
@@ -124,7 +124,7 @@ Three Argilla datasets, each receiving records from every import:
 
 ---
 
-### `task2_grounding` — one record per answer-context set pair
+### `task_grounding` — one record per answer-context set pair
 
 **Fields (shown to annotators):**
 - `query` ← canonical `query`
@@ -137,7 +137,7 @@ Three Argilla datasets, each receiving records from every import:
 
 ---
 
-### `task3_generation` — one record per query-answer pair
+### `task_generation` — one record per query-answer pair
 
 **Fields (shown to annotators):**
 - `query` ← canonical `query`

--- a/docs/design/annotation-interface.md
+++ b/docs/design/annotation-interface.md
@@ -167,7 +167,7 @@ Each task dataset includes one optional free-text field per annotated unit:
 
 - Supporting context fields (`answer` for Task 1; `query` for Task 2; `retrieved_passages` for Task 3) must be included in the Argilla field configuration, positioned after primary content fields
 - Workspace and annotator group assignment (who sees which dataset) is a configurable operational decision - see [Workspace & Task Distribution](annotation-workspace-task-distribution.md)
-- Three Argilla datasets required: `task1_retrieval`, `task2_grounding`, `task3_generation`
+- Three Argilla datasets required: `task_retrieval`, `task_grounding`, `task_generation`
 - Export schema ([Export Pipeline](annotation-export-pipeline.md)) must include one binary field per label and the optional notes field
 - Schema can be revised after the first annotation iteration based on IAA results and annotator feedback
 


### PR DESCRIPTION
## Goal

Remove spurious numeric prefixes from Argilla dataset names in docs (`task1_retrieval` → `task_retrieval`, etc.).

## Scope

- `docs/decisions/0010-annotation-multi-dataset-architecture.md`
- `docs/design/annotation-export-pipeline.md`
- `docs/design/annotation-import-pipeline.md`
- `docs/design/annotation-interface.md`

## Rationale

The numbering implied a sequential ordering that doesn't exist — these are independent annotation tasks. The descriptive name alone (`task_retrieval`) is unambiguous and doesn't carry a false connotation of pipeline ordering.

## Notes

PR #51 (`feat/annotation-dataset-schemas-v2`) introduces the corresponding code-side names and will need rebasing to match after this merges.