### PR TITLE
feat(annotation): add core import implementation

### DIFF
--- a/src/chatboteval/core/annotation/record_builder.py
+++ b/src/chatboteval/core/annotation/record_builder.py
@@ -9,7 +9,7 @@ import hashlib
 import logging
 
 import argilla as rg
-from argilla.records._dataset_records import RecordErrorHandling  # no public import path in argilla v2
+from argilla.records._dataset_records import RecordErrorHandling  # no public re-export in argilla v2; pinned to ==2.6.0
 
 from chatboteval.core.annotation.argilla_ops import apply_prefix
 from chatboteval.core.annotation.argilla_settings import DATASET_NAMES
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 def derive_record_uuid(pair: QueryResponsePair) -> str:
     """SHA-256 digest of canonical content fields — stable across calls for identical pairs."""
+    # chunk_ids sorted for order invariance — same chunks in any order produce the same UUID
     chunk_ids = "|".join(sorted(c.chunk_id for c in pair.chunks))
     canonical = f"{pair.query}\x00{pair.answer}\x00{pair.context_set}\x00{chunk_ids}"
     return hashlib.sha256(canonical.encode()).hexdigest()
@@ -85,6 +86,26 @@ def build_generation_record(pair: QueryResponsePair, record_uuid: str) -> rg.Rec
     )
 
 
+def _invert_workspace_map(workspace_dataset_map: dict[str, list[Task]]) -> dict[Task, str]:
+    """Invert workspace_dataset_map to task → workspace_base lookup."""
+    task_to_ws: dict[Task, str] = {}
+    for ws_base, tasks in workspace_dataset_map.items():
+        for task in tasks:
+            task_to_ws[task] = ws_base
+    return task_to_ws
+
+
+def _build_batches(records: list[QueryResponsePair]) -> dict[Task, list[rg.Record]]:
+    """Build Argilla records per task from canonical input pairs."""
+    batches: dict[Task, list[rg.Record]] = {task: [] for task in Task}
+    for pair in records:
+        record_uuid = derive_record_uuid(pair)
+        batches[Task.RETRIEVAL].extend(build_retrieval_records(pair, record_uuid))
+        batches[Task.GROUNDING].append(build_grounding_record(pair, record_uuid))
+        batches[Task.GENERATION].append(build_generation_record(pair, record_uuid))
+    return batches
+
+
 def fan_out_records(
     client: rg.Argilla,
     records: list[QueryResponsePair],
@@ -96,21 +117,8 @@ def fan_out_records(
     record failures are logged as warnings by Argilla but not reflected in counts).
     """
     prefix = settings.workspace_prefix
-
-    # Build inverse map task -> ws_base from workspace_dataset_map
-    task_to_ws: dict[Task, str] = {}
-    for ws_base, tasks in settings.workspace_dataset_map.items():
-        for task in tasks:
-            task_to_ws[task] = ws_base
-
-    # Accumulate rg.Record objects per task
-    batches: dict[Task, list[rg.Record]] = {task: [] for task in Task}
-
-    for pair in records:
-        record_uuid = derive_record_uuid(pair)
-        batches[Task.RETRIEVAL].extend(build_retrieval_records(pair, record_uuid))
-        batches[Task.GROUNDING].append(build_grounding_record(pair, record_uuid))
-        batches[Task.GENERATION].append(build_generation_record(pair, record_uuid))
+    task_to_ws = _invert_workspace_map(settings.workspace_dataset_map)
+    batches = _build_batches(records)
 
     dataset_counts: dict[str, int] = {}
 

--- a/tests/annotation/test_import_unit.py
+++ b/tests/annotation/test_import_unit.py
@@ -63,7 +63,7 @@ class TestDeriveRecordUuid:
     def test_returns_hex_string(self) -> None:
         result = derive_record_uuid(_make_pair())
         assert isinstance(result, str)
-        assert len(result) > 0
+        assert len(result) == 64
         assert all(c in "0123456789abcdef" for c in result)
 
 


### PR DESCRIPTION
## Summary

- Add `core/annotation/record_builder.py` — record building and fan-out logic for the 3 annotation datasets
- Content-hash UUID derivation for idempotent upsert

Stacked on #63.

## Scope

| File | Purpose |
|------|---------|
| `core/annotation/record_builder.py` | `derive_record_uuid`, `build_*_records`, `fan_out_records` |
| `tests/annotation/test_import_unit.py` | Pure Python tests (no server) |

## Open question

`context_set` as supporting context in generation dataset — see PR comment for discussion.

## References

- `docs/design/annotation-import-pipeline.md`
- `docs/design/annotation-interface.md`
- ADR-0010