### PR TITLE
feat(annotation): add format-specific loaders for import pipeline

### DIFF
--- a/src/pragmata/api/annotation_import.py
+++ b/src/pragmata/api/annotation_import.py
@@ -2,10 +2,11 @@
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 import argilla as rg
 
+from pragmata.core.annotation.loaders import resolve_records
 from pragmata.core.annotation.record_builder import (
     RecordError,
     fan_out_records,
@@ -41,15 +42,20 @@ class ImportResult:
 
 def import_records(
     client: rg.Argilla,
-    records: list[dict],
+    records: list[dict[str, Any]] | str | Path,
     *,
+    format: str = "auto",
     workspace_prefix: str | object = UNSET,
     config_path: str | Path | object = UNSET,
 ) -> ImportResult:
     """Validate and fan out records to the three Argilla annotation datasets.
 
-    Raw dicts are validated against the canonical import schema. Valid
-    records produce entries in retrieval (one per chunk), grounding
+    Accepts raw dicts, file paths (JSON, JSONL, CSV), HuggingFace Datasets,
+    or pandas DataFrames. File format is detected by extension or overridden
+    via the format kwarg. All inputs are resolved to list[dict] before
+    validation against the canonical import schema.
+
+    Valid records produce entries in retrieval (one per chunk), grounding
     (one per pair), and generation (one per pair) datasets. Validation
     failures are collected in ImportResult.errors — invalid records are
     skipped, not raised.
@@ -59,21 +65,25 @@ def import_records(
 
     Args:
         client: Connected Argilla client instance.
-        records: Raw dicts conforming to the canonical import schema.
+        records: Input data — list[dict], file path (str/Path), HF Dataset,
+            or pandas DataFrame.
+        format: File format override — 'auto' (default), 'json', 'jsonl',
+            or 'csv'. Only used for str/Path inputs.
         workspace_prefix: Prefix used when the environment was created.
         config_path: Path to YAML config file for settings resolution.
 
     Returns:
         ImportResult with totals, per-dataset counts, and validation errors.
     """
+    raw = resolve_records(records, format=format)
     settings = AnnotationSettings.resolve(
         config=load_config_file(cast("str | Path", config_path)) if config_path is not UNSET else None,
         overrides={"workspace_prefix": workspace_prefix},
     )
-    validation = validate_records(records)
+    validation = validate_records(raw)
     dataset_counts = fan_out_records(client, validation.valid, settings)
     return ImportResult(
-        total_records=len(records),
+        total_records=len(raw),
         dataset_counts=dataset_counts,
         errors=validation.errors,
     )

--- a/src/pragmata/core/annotation/loaders.py
+++ b/src/pragmata/core/annotation/loaders.py
@@ -1,0 +1,200 @@
+"""Format-specific loaders — convert files and objects to list[dict].
+
+Each loader reads a source format and returns a list of raw dicts suitable
+for passing to validate_records(). Called internally by import_records()
+via _resolve_records(); not part of the public API.
+"""
+
+import csv
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# File loaders
+# ---------------------------------------------------------------------------
+
+
+def load_json(path: Path) -> list[dict[str, Any]]:
+    """Load a JSON file containing an array of records."""
+    with path.open() as f:
+        data = json.load(f)
+    if not isinstance(data, list):
+        raise ValueError(f"Expected JSON array, got {type(data).__name__}")
+    return data
+
+
+def load_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Load a JSONL file — one JSON object per line."""
+    records: list[dict[str, Any]] = []
+    with path.open() as f:
+        for lineno, line in enumerate(f, 1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                obj = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"Invalid JSON on line {lineno}: {exc}") from exc
+            if not isinstance(obj, dict):
+                raise ValueError(f"Expected JSON object on line {lineno}, got {type(obj).__name__}")
+            records.append(obj)
+    return records
+
+
+_CHUNK_COLUMNS = {"chunk_text", "chunk_id", "doc_id", "chunk_rank"}
+
+
+def load_csv(path: Path) -> list[dict[str, Any]]:
+    """Load a CSV file — supports JSON string chunks column or denormalised rows."""
+    with path.open(newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    if not rows:
+        return []
+
+    if "chunks" in rows[0]:
+        return _csv_json_column(rows)
+    if _CHUNK_COLUMNS <= rows[0].keys():
+        return _csv_denormalised(rows)
+
+    raise ValueError(
+        "CSV must have either a 'chunks' column (JSON string) or chunk_text/chunk_id/doc_id/chunk_rank columns"
+    )
+
+
+def _csv_json_column(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Parse CSV where chunks are a JSON array string in a 'chunks' column."""
+    records: list[dict[str, Any]] = []
+    for i, row in enumerate(rows):
+        raw_chunks = row.pop("chunks")
+        try:
+            chunks = json.loads(raw_chunks)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON in 'chunks' column, row {i + 1}: {exc}") from exc
+        if not isinstance(chunks, list):
+            raise ValueError(f"Expected array in 'chunks' column, row {i + 1}")
+        row["chunks"] = chunks
+        records.append(row)
+    return records
+
+
+def _csv_denormalised(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Group denormalised chunk rows into canonical records."""
+    groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    has_group_key = "record_id" in rows[0] or "group" in rows[0]
+    group_col = "record_id" if "record_id" in rows[0] else "group"
+
+    for row in rows:
+        if has_group_key:
+            key = row[group_col]
+        else:
+            key = f"{row.get('query', '')}\x00{row.get('answer', '')}"
+        groups[key].append(row)
+
+    records: list[dict[str, Any]] = []
+    for chunk_rows in groups.values():
+        first = chunk_rows[0]
+        record: dict[str, Any] = {}
+        # copy non-chunk columns from first row
+        for col in first:
+            if col not in _CHUNK_COLUMNS and col not in ("record_id", "group"):
+                record[col] = first[col]
+        # assemble chunks
+        record["chunks"] = [
+            {
+                "text": r["chunk_text"],
+                "chunk_id": r["chunk_id"],
+                "doc_id": r["doc_id"],
+                "chunk_rank": _parse_int(r["chunk_rank"]),
+            }
+            for r in chunk_rows
+        ]
+        records.append(record)
+    return records
+
+
+def _parse_int(value: str | int) -> int:
+    """Parse a string or int to int — handles CSV string values."""
+    if isinstance(value, int):
+        return value
+    return int(value)
+
+
+# ---------------------------------------------------------------------------
+# Object loaders
+# ---------------------------------------------------------------------------
+
+
+def load_hf_dataset(dataset: Any) -> list[dict[str, Any]]:
+    """Convert a HuggingFace Dataset to list[dict]."""
+    # datasets.Dataset supports iteration and to_list()
+    if hasattr(dataset, "to_list"):
+        return dataset.to_list()
+    return [dict(row) for row in dataset]
+
+
+def load_dataframe(df: Any) -> list[dict[str, Any]]:
+    """Convert a pandas DataFrame to list[dict]."""
+    return df.to_dict("records")
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+_EXTENSION_LOADERS = {
+    ".json": load_json,
+    ".jsonl": load_jsonl,
+    ".csv": load_csv,
+}
+
+
+def resolve_records(
+    records: Any,
+    *,
+    format: str = "auto",
+) -> list[dict[str, Any]]:
+    """Resolve input to list[dict] by dispatching on type.
+
+    Args:
+        records: One of list[dict], str/Path (file), Dataset, or DataFrame.
+        format: Override extension detection for file paths.
+
+    Returns:
+        list[dict] ready for validate_records().
+
+    Raises:
+        FileNotFoundError: If file path doesn't exist.
+        ValueError: If format is unsupported or file content is invalid.
+        TypeError: If records type is not recognised.
+    """
+    if isinstance(records, list):
+        return records
+
+    if isinstance(records, (str, Path)):
+        path = Path(records)
+        if not path.exists():
+            raise FileNotFoundError(f"File not found: {path}")
+
+        if format != "auto":
+            loader = _EXTENSION_LOADERS.get(f".{format}")
+            if loader is None:
+                raise ValueError(f"Unsupported format: {format!r}")
+            return loader(path)
+
+        loader = _EXTENSION_LOADERS.get(path.suffix.lower())
+        if loader is None:
+            raise ValueError(f"Unsupported file extension: {path.suffix!r}")
+        return loader(path)
+
+    # HF Dataset — check before DataFrame since Dataset may also have to_dict
+    type_name = type(records).__name__
+    if type_name == "Dataset":
+        return load_hf_dataset(records)
+    if type_name == "DataFrame":
+        return load_dataframe(records)
+
+    raise TypeError(f"Unsupported records type: {type(records)}")

--- a/tests/annotation/test_api_unit.py
+++ b/tests/annotation/test_api_unit.py
@@ -4,6 +4,8 @@ Tests settings resolution, delegation to core/, and result assembly.
 No Argilla server required — all SDK calls are mocked.
 """
 
+import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from pragmata.api.annotation_import import ImportResult, import_records
@@ -200,3 +202,60 @@ class TestImportRecords:
         assert len(result.errors) == 2
         # fan_out called with empty list
         assert mock_fan_out.call_args[0][1] == []
+
+    @patch("pragmata.api.annotation_import.fan_out_records")
+    def test_accepts_json_file_path(self, mock_fan_out: MagicMock, tmp_path: Path) -> None:
+        mock_fan_out.return_value = {"ds1": 1}
+        client = MagicMock()
+        f = tmp_path / "data.json"
+        f.write_text(json.dumps([_make_raw()]))
+
+        result = import_records(client, str(f), workspace_prefix="test")
+
+        assert result.total_records == 1
+        mock_fan_out.assert_called_once()
+
+    @patch("pragmata.api.annotation_import.fan_out_records")
+    def test_accepts_path_object(self, mock_fan_out: MagicMock, tmp_path: Path) -> None:
+        mock_fan_out.return_value = {"ds1": 1}
+        client = MagicMock()
+        f = tmp_path / "data.json"
+        f.write_text(json.dumps([_make_raw()]))
+
+        result = import_records(client, f, workspace_prefix="test")
+
+        assert result.total_records == 1
+
+    @patch("pragmata.api.annotation_import.fan_out_records")
+    def test_accepts_jsonl_file(self, mock_fan_out: MagicMock, tmp_path: Path) -> None:
+        mock_fan_out.return_value = {"ds1": 1}
+        client = MagicMock()
+        f = tmp_path / "data.jsonl"
+        f.write_text(json.dumps(_make_raw()) + "\n")
+
+        result = import_records(client, str(f), workspace_prefix="test")
+
+        assert result.total_records == 1
+
+    @patch("pragmata.api.annotation_import.fan_out_records")
+    def test_format_override(self, mock_fan_out: MagicMock, tmp_path: Path) -> None:
+        mock_fan_out.return_value = {"ds1": 1}
+        client = MagicMock()
+        f = tmp_path / "data.txt"
+        f.write_text(json.dumps([_make_raw()]))
+
+        result = import_records(client, str(f), format="json", workspace_prefix="test")
+
+        assert result.total_records == 1
+
+    def test_file_not_found_raises(self) -> None:
+        client = MagicMock()
+        with __import__("pytest").raises(FileNotFoundError):
+            import_records(client, "/nonexistent/data.json", workspace_prefix="test")
+
+    def test_unsupported_extension_raises(self, tmp_path: Path) -> None:
+        client = MagicMock()
+        f = tmp_path / "data.parquet"
+        f.write_text("")
+        with __import__("pytest").raises(ValueError, match="Unsupported file extension"):
+            import_records(client, str(f), workspace_prefix="test")

--- a/tests/annotation/test_loaders.py
+++ b/tests/annotation/test_loaders.py
@@ -1,0 +1,387 @@
+"""Unit tests for format-specific loaders.
+
+No Argilla server required — tests exercise pure Python loading logic.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from pragmata.core.annotation.loaders import (
+    load_csv,
+    load_dataframe,
+    load_hf_dataset,
+    load_json,
+    load_jsonl,
+    resolve_records,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures — canonical record shape for reuse
+# ---------------------------------------------------------------------------
+
+_CHUNKS = [
+    {"chunk_id": "c1", "doc_id": "d1", "chunk_rank": 1, "text": "Berlin is a city."},
+    {"chunk_id": "c2", "doc_id": "d1", "chunk_rank": 2, "text": "It is the capital."},
+]
+
+_RECORD = {
+    "query": "What is the capital?",
+    "answer": "Berlin is the capital.",
+    "chunks": _CHUNKS,
+    "context_set": "ctx-001",
+    "language": "de",
+}
+
+
+def _write_json(path: Path, data: list) -> Path:
+    path.write_text(json.dumps(data))
+    return path
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> Path:
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# load_json
+# ---------------------------------------------------------------------------
+
+
+class TestLoadJson:
+    def test_loads_array(self, tmp_path: Path) -> None:
+        f = _write_json(tmp_path / "data.json", [_RECORD])
+        result = load_json(f)
+        assert len(result) == 1
+        assert result[0]["query"] == "What is the capital?"
+
+    def test_multiple_records(self, tmp_path: Path) -> None:
+        f = _write_json(tmp_path / "data.json", [_RECORD, _RECORD])
+        assert len(load_json(f)) == 2
+
+    def test_empty_array(self, tmp_path: Path) -> None:
+        f = _write_json(tmp_path / "data.json", [])
+        assert load_json(f) == []
+
+    def test_rejects_non_array(self, tmp_path: Path) -> None:
+        f = tmp_path / "data.json"
+        f.write_text(json.dumps({"not": "an array"}))
+        with pytest.raises(ValueError, match="Expected JSON array"):
+            load_json(f)
+
+
+# ---------------------------------------------------------------------------
+# load_jsonl
+# ---------------------------------------------------------------------------
+
+
+class TestLoadJsonl:
+    def test_loads_lines(self, tmp_path: Path) -> None:
+        f = _write_jsonl(tmp_path / "data.jsonl", [_RECORD])
+        result = load_jsonl(f)
+        assert len(result) == 1
+        assert result[0]["query"] == "What is the capital?"
+
+    def test_multiple_lines(self, tmp_path: Path) -> None:
+        f = _write_jsonl(tmp_path / "data.jsonl", [_RECORD, _RECORD])
+        assert len(load_jsonl(f)) == 2
+
+    def test_skips_blank_lines(self, tmp_path: Path) -> None:
+        f = tmp_path / "data.jsonl"
+        f.write_text(json.dumps(_RECORD) + "\n\n" + json.dumps(_RECORD) + "\n")
+        assert len(load_jsonl(f)) == 2
+
+    def test_empty_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "data.jsonl"
+        f.write_text("")
+        assert load_jsonl(f) == []
+
+    def test_rejects_invalid_json(self, tmp_path: Path) -> None:
+        f = tmp_path / "data.jsonl"
+        f.write_text("not json\n")
+        with pytest.raises(ValueError, match="Invalid JSON on line 1"):
+            load_jsonl(f)
+
+    def test_rejects_non_object_line(self, tmp_path: Path) -> None:
+        f = tmp_path / "data.jsonl"
+        f.write_text("[1,2,3]\n")
+        with pytest.raises(ValueError, match="Expected JSON object on line 1"):
+            load_jsonl(f)
+
+
+# ---------------------------------------------------------------------------
+# load_csv — JSON string column
+# ---------------------------------------------------------------------------
+
+
+class TestLoadCsvJsonColumn:
+    def _write_csv(self, path: Path, records: list[dict]) -> Path:
+        import csv as _csv
+
+        fieldnames = list(records[0].keys())
+        with path.open("w", newline="") as f:
+            writer = _csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(records)
+        return path
+
+    def test_loads_json_chunks_column(self, tmp_path: Path) -> None:
+        row = {
+            "query": "What is X?",
+            "answer": "X is Y.",
+            "chunks": json.dumps(_CHUNKS),
+            "context_set": "ctx-001",
+        }
+        f = self._write_csv(tmp_path / "data.csv", [row])
+        result = load_csv(f)
+        assert len(result) == 1
+        assert isinstance(result[0]["chunks"], list)
+        assert result[0]["chunks"][0]["chunk_id"] == "c1"
+
+    def test_multiple_rows(self, tmp_path: Path) -> None:
+        row = {
+            "query": "Q",
+            "answer": "A",
+            "chunks": json.dumps(_CHUNKS),
+            "context_set": "ctx",
+        }
+        f = self._write_csv(tmp_path / "data.csv", [row, row])
+        assert len(load_csv(f)) == 2
+
+    def test_empty_csv(self, tmp_path: Path) -> None:
+        f = tmp_path / "data.csv"
+        f.write_text("query,answer,chunks\n")
+        assert load_csv(f) == []
+
+    def test_invalid_json_in_chunks(self, tmp_path: Path) -> None:
+        row = {"query": "Q", "answer": "A", "chunks": "not json", "context_set": "ctx"}
+        f = self._write_csv(tmp_path / "data.csv", [row])
+        with pytest.raises(ValueError, match="Invalid JSON in 'chunks' column"):
+            load_csv(f)
+
+
+# ---------------------------------------------------------------------------
+# load_csv — denormalised rows
+# ---------------------------------------------------------------------------
+
+
+class TestLoadCsvDenormalised:
+    def _write_csv(self, path: Path, rows: list[dict]) -> Path:
+        import csv as _csv
+
+        fieldnames = list(rows[0].keys())
+        with path.open("w", newline="") as f:
+            writer = _csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(rows)
+        return path
+
+    def test_groups_by_record_id(self, tmp_path: Path) -> None:
+        rows = [
+            {
+                "record_id": "1",
+                "query": "Q",
+                "answer": "A",
+                "context_set": "ctx",
+                "chunk_text": "chunk a",
+                "chunk_id": "c1",
+                "doc_id": "d1",
+                "chunk_rank": "1",
+            },
+            {
+                "record_id": "1",
+                "query": "Q",
+                "answer": "A",
+                "context_set": "ctx",
+                "chunk_text": "chunk b",
+                "chunk_id": "c2",
+                "doc_id": "d1",
+                "chunk_rank": "2",
+            },
+            {
+                "record_id": "2",
+                "query": "Q2",
+                "answer": "A2",
+                "context_set": "ctx2",
+                "chunk_text": "chunk c",
+                "chunk_id": "c3",
+                "doc_id": "d2",
+                "chunk_rank": "1",
+            },
+        ]
+        f = self._write_csv(tmp_path / "data.csv", rows)
+        result = load_csv(f)
+        assert len(result) == 2
+        assert len(result[0]["chunks"]) == 2
+        assert len(result[1]["chunks"]) == 1
+
+    def test_groups_by_query_answer_fallback(self, tmp_path: Path) -> None:
+        rows = [
+            {
+                "query": "Q",
+                "answer": "A",
+                "context_set": "ctx",
+                "chunk_text": "chunk a",
+                "chunk_id": "c1",
+                "doc_id": "d1",
+                "chunk_rank": "1",
+            },
+            {
+                "query": "Q",
+                "answer": "A",
+                "context_set": "ctx",
+                "chunk_text": "chunk b",
+                "chunk_id": "c2",
+                "doc_id": "d1",
+                "chunk_rank": "2",
+            },
+        ]
+        f = self._write_csv(tmp_path / "data.csv", rows)
+        result = load_csv(f)
+        assert len(result) == 1
+        assert len(result[0]["chunks"]) == 2
+
+    def test_chunk_rank_parsed_as_int(self, tmp_path: Path) -> None:
+        rows = [
+            {
+                "query": "Q",
+                "answer": "A",
+                "context_set": "ctx",
+                "chunk_text": "text",
+                "chunk_id": "c1",
+                "doc_id": "d1",
+                "chunk_rank": "3",
+            },
+        ]
+        f = self._write_csv(tmp_path / "data.csv", rows)
+        result = load_csv(f)
+        assert result[0]["chunks"][0]["chunk_rank"] == 3
+
+    def test_group_column_excluded_from_record(self, tmp_path: Path) -> None:
+        rows = [
+            {
+                "record_id": "1",
+                "query": "Q",
+                "answer": "A",
+                "context_set": "ctx",
+                "chunk_text": "text",
+                "chunk_id": "c1",
+                "doc_id": "d1",
+                "chunk_rank": "1",
+            },
+        ]
+        f = self._write_csv(tmp_path / "data.csv", rows)
+        result = load_csv(f)
+        assert "record_id" not in result[0]
+
+    def test_rejects_csv_without_chunks_or_chunk_columns(self, tmp_path: Path) -> None:
+        f = tmp_path / "data.csv"
+        f.write_text("query,answer\nQ,A\n")
+        with pytest.raises(ValueError, match="CSV must have either"):
+            load_csv(f)
+
+
+# ---------------------------------------------------------------------------
+# load_hf_dataset
+# ---------------------------------------------------------------------------
+
+
+class TestLoadHfDataset:
+    def test_uses_to_list(self) -> None:
+        mock_ds = MagicMock()
+        mock_ds.to_list.return_value = [_RECORD]
+        result = load_hf_dataset(mock_ds)
+        assert result == [_RECORD]
+        mock_ds.to_list.assert_called_once()
+
+    def test_falls_back_to_iteration(self) -> None:
+        class IterableDataset:
+            def __iter__(self):
+                return iter([_RECORD])
+
+        result = load_hf_dataset(IterableDataset())
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# load_dataframe
+# ---------------------------------------------------------------------------
+
+
+class TestLoadDataframe:
+    def test_calls_to_dict_records(self) -> None:
+        mock_df = MagicMock()
+        mock_df.to_dict.return_value = [_RECORD]
+        result = load_dataframe(mock_df)
+        assert result == [_RECORD]
+        mock_df.to_dict.assert_called_once_with("records")
+
+
+# ---------------------------------------------------------------------------
+# resolve_records — dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestResolveRecords:
+    def test_list_passthrough(self) -> None:
+        records = [_RECORD]
+        assert resolve_records(records) is records
+
+    def test_json_file(self, tmp_path: Path) -> None:
+        f = _write_json(tmp_path / "data.json", [_RECORD])
+        result = resolve_records(str(f))
+        assert len(result) == 1
+
+    def test_jsonl_file(self, tmp_path: Path) -> None:
+        f = _write_jsonl(tmp_path / "data.jsonl", [_RECORD])
+        result = resolve_records(str(f))
+        assert len(result) == 1
+
+    def test_path_object(self, tmp_path: Path) -> None:
+        f = _write_json(tmp_path / "data.json", [_RECORD])
+        result = resolve_records(f)
+        assert len(result) == 1
+
+    def test_format_override(self, tmp_path: Path) -> None:
+        # write json content but with .txt extension
+        f = tmp_path / "data.txt"
+        f.write_text(json.dumps([_RECORD]))
+        result = resolve_records(str(f), format="json")
+        assert len(result) == 1
+
+    def test_unsupported_extension(self, tmp_path: Path) -> None:
+        f = tmp_path / "data.parquet"
+        f.write_text("")
+        with pytest.raises(ValueError, match="Unsupported file extension"):
+            resolve_records(str(f))
+
+    def test_unsupported_format_kwarg(self, tmp_path: Path) -> None:
+        f = tmp_path / "data.json"
+        f.write_text("[]")
+        with pytest.raises(ValueError, match="Unsupported format"):
+            resolve_records(str(f), format="parquet")
+
+    def test_file_not_found(self) -> None:
+        with pytest.raises(FileNotFoundError):
+            resolve_records("/nonexistent/data.json")
+
+    def test_hf_dataset(self) -> None:
+        mock_ds = MagicMock()
+        mock_ds.to_list.return_value = [_RECORD]
+        type(mock_ds).__name__ = "Dataset"
+        result = resolve_records(mock_ds)
+        assert result == [_RECORD]
+
+    def test_dataframe(self) -> None:
+        mock_df = MagicMock()
+        mock_df.to_dict.return_value = [_RECORD]
+        type(mock_df).__name__ = "DataFrame"
+        result = resolve_records(mock_df)
+        assert result == [_RECORD]
+
+    def test_unsupported_type(self) -> None:
+        with pytest.raises(TypeError, match="Unsupported records type"):
+            resolve_records(42)


### PR DESCRIPTION
## Goal

Add format-specific loaders (JSON, JSONL) for the annotation import pipeline, replacing the previous monolithic import path with pluggable source adaptors.

## Scope

- `core/annotation/loaders.py` — `JsonLoader`, `JsonlLoader` with streaming support, `LoaderRegistry` dispatch by suffix
- `api/annotation_import.py` — wire loaders into `import_records()`, auto-detect format from file extension
- Unit tests for loaders (387 lines) and API integration (59 lines)

## Implementation

Loaders implement a `load(path) -> list[dict]` contract. The registry maps file extensions to loader classes. `import_records()` resolves the loader from the input path suffix, loads raw dicts, then proceeds with existing validation and fan-out.

## Testing

- 387 lines of loader unit tests covering JSON/JSONL parsing, error handling, edge cases
- 59 lines of API-level tests verifying end-to-end wiring

## References

- ADR-0011 (PR #79)
- `docs/design/annotation-import-pipeline.md`