### PR TITLE
feat(annotation): add annotation export and import path bundles

### DIFF
--- a/src/pragmata/core/paths/annotation_paths.py
+++ b/src/pragmata/core/paths/annotation_paths.py
@@ -1,10 +1,28 @@
-"""Path bundles for annotation export and import runs."""
+"""Path bundles for annotation import and export runs."""
 
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Self
 
 from pragmata.core.paths.paths import WorkspacePaths
+
+
+@dataclass(frozen=True, slots=True)
+class AnnotationImportPaths:
+    """Path bundle for an annotation import run.
+
+    Attributes:
+        import_dir: Root directory for the import.
+        import_result_json: Output path for the import result JSON.
+    """
+
+    import_dir: Path
+    import_result_json: Path
+
+    def ensure_dirs(self) -> Self:
+        """Create the import directory scaffold."""
+        self.import_dir.mkdir(parents=True, exist_ok=True)
+        return self
 
 
 @dataclass(frozen=True, slots=True)
@@ -29,22 +47,18 @@ class AnnotationExportPaths:
         return self
 
 
-@dataclass(frozen=True, slots=True)
-class AnnotationImportPaths:
-    """Path bundle for an annotation import run.
+def resolve_import_paths(*, workspace: WorkspacePaths, import_id: str) -> AnnotationImportPaths:
+    """Build the path bundle for an annotation import run.
 
-    Attributes:
-        import_dir: Root directory for the import.
-        result_json: Output path for the import result JSON.
+    Args:
+        workspace: Workspace path bundle.
+        import_id: Unique import identifier.
+
+    Returns:
+        Path bundle for the import run.
     """
-
-    import_dir: Path
-    result_json: Path
-
-    def ensure_dirs(self) -> Self:
-        """Create the import directory scaffold."""
-        self.import_dir.mkdir(parents=True, exist_ok=True)
-        return self
+    import_dir = workspace.tool_root("annotation") / "imports" / import_id
+    return AnnotationImportPaths(import_dir=import_dir, import_result_json=import_dir / "import_result.json")
 
 
 def resolve_export_paths(*, workspace: WorkspacePaths, export_id: str) -> AnnotationExportPaths:
@@ -64,17 +78,3 @@ def resolve_export_paths(*, workspace: WorkspacePaths, export_id: str) -> Annota
         grounding_annotation_csv=export_dir / "grounding.csv",
         generation_annotation_csv=export_dir / "generation.csv",
     )
-
-
-def resolve_import_paths(*, workspace: WorkspacePaths, import_id: str) -> AnnotationImportPaths:
-    """Build the path bundle for an annotation import run.
-
-    Args:
-        workspace: Workspace path bundle.
-        import_id: Unique import identifier.
-
-    Returns:
-        Path bundle for the import run.
-    """
-    import_dir = workspace.tool_root("annotation") / "imports" / import_id
-    return AnnotationImportPaths(import_dir=import_dir, result_json=import_dir / "import_result.json")

--- a/tests/unit/core/annotation/test_annotation_paths.py
+++ b/tests/unit/core/annotation/test_annotation_paths.py
@@ -1,4 +1,4 @@
-"""Unit tests for annotation export/import path bundles."""
+"""Unit tests for annotation import/export path bundles."""
 
 from pathlib import Path
 
@@ -14,6 +14,38 @@ from pragmata.core.paths.paths import WorkspacePaths
 @pytest.fixture()
 def workspace(tmp_path: Path) -> WorkspacePaths:
     return WorkspacePaths.from_base_dir(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# AnnotationImportPaths
+# ---------------------------------------------------------------------------
+
+
+class TestAnnotationImportPaths:
+    def test_resolve_import_paths_structure(self, workspace: WorkspacePaths) -> None:
+        paths = resolve_import_paths(workspace=workspace, import_id="imp1")
+        expected_dir = workspace.tool_root("annotation") / "imports" / "imp1"
+        assert paths.import_dir == expected_dir
+
+    def test_import_result_json_path(self, workspace: WorkspacePaths) -> None:
+        paths = resolve_import_paths(workspace=workspace, import_id="imp1")
+        assert paths.import_result_json == paths.import_dir / "import_result.json"
+
+    def test_ensure_dirs_creates_import_dir(self, workspace: WorkspacePaths) -> None:
+        paths = resolve_import_paths(workspace=workspace, import_id="imp1")
+        assert not paths.import_dir.exists()
+        paths.ensure_dirs()
+        assert paths.import_dir.exists()
+
+    def test_ensure_dirs_returns_self(self, workspace: WorkspacePaths) -> None:
+        paths = resolve_import_paths(workspace=workspace, import_id="imp1")
+        result = paths.ensure_dirs()
+        assert result is paths
+
+    def test_frozen(self, workspace: WorkspacePaths, tmp_path: Path) -> None:
+        paths = resolve_import_paths(workspace=workspace, import_id="imp1")
+        with pytest.raises((AttributeError, TypeError)):
+            paths.import_dir = tmp_path  # type: ignore[misc]
 
 
 # ---------------------------------------------------------------------------
@@ -48,35 +80,3 @@ class TestAnnotationExportPaths:
         paths = resolve_export_paths(workspace=workspace, export_id="run1")
         with pytest.raises((AttributeError, TypeError)):
             paths.export_dir = tmp_path  # type: ignore[misc]
-
-
-# ---------------------------------------------------------------------------
-# AnnotationImportPaths
-# ---------------------------------------------------------------------------
-
-
-class TestAnnotationImportPaths:
-    def test_resolve_import_paths_structure(self, workspace: WorkspacePaths) -> None:
-        paths = resolve_import_paths(workspace=workspace, import_id="imp1")
-        expected_dir = workspace.tool_root("annotation") / "imports" / "imp1"
-        assert paths.import_dir == expected_dir
-
-    def test_result_json_path(self, workspace: WorkspacePaths) -> None:
-        paths = resolve_import_paths(workspace=workspace, import_id="imp1")
-        assert paths.result_json == paths.import_dir / "import_result.json"
-
-    def test_ensure_dirs_creates_import_dir(self, workspace: WorkspacePaths) -> None:
-        paths = resolve_import_paths(workspace=workspace, import_id="imp1")
-        assert not paths.import_dir.exists()
-        paths.ensure_dirs()
-        assert paths.import_dir.exists()
-
-    def test_ensure_dirs_returns_self(self, workspace: WorkspacePaths) -> None:
-        paths = resolve_import_paths(workspace=workspace, import_id="imp1")
-        result = paths.ensure_dirs()
-        assert result is paths
-
-    def test_frozen(self, workspace: WorkspacePaths, tmp_path: Path) -> None:
-        paths = resolve_import_paths(workspace=workspace, import_id="imp1")
-        with pytest.raises((AttributeError, TypeError)):
-            paths.import_dir = tmp_path  # type: ignore[misc]


### PR DESCRIPTION
## Goal

Add path resolution types for annotation export and import directories.

## Scope

- `core/paths/annotation_paths.py` — `AnnotationExportPaths` and `AnnotationImportPaths` frozen dataclasses resolving under `tool_root("annotation") / exports|imports / {id}`
- Both provide `from_dir()` factory and `ensure_dirs()` for directory creation

## Testing

- 98 lines: path resolution, `from_dir()` construction, `ensure_dirs()` behaviour

## References

- `docs/design/annotation-export-pipeline.md`