### PR TITLE
fix: replace unsupported semver properties with default-days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,7 @@ updates:
       time: "06:00"
       timezone: "Europe/Berlin"
     cooldown:
-      semver-major-days: 30
-      semver-minor-days: 21
-      semver-patch-days: 14
+      default-days: 14
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps)"
@@ -34,9 +32,7 @@ updates:
       time: "06:00"
       timezone: "Europe/Berlin"
     cooldown:
-      semver-major-days: 30
-      semver-minor-days: 21
-      semver-patch-days: 14
+      default-days: 14
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(ci)"


### PR DESCRIPTION
**Summary**

Fix unsupported SemVer properties in github-actions by replacing version-tagged cooldown periods with overal default-days property.