### PR TITLE
fix(annotation): render CustomField text in collapsible template

### DIFF
--- a/src/pragmata/core/annotation/collapsible_field.html
+++ b/src/pragmata/core/annotation/collapsible_field.html
@@ -27,7 +27,8 @@
 </details>
 <script>
   var field = record.fields["$field_name"];
-  document.getElementById("content").textContent = field || "";
+  var text = (typeof field === "object" && field !== null) ? (field.text || "") : (field || "");
+  document.getElementById("content").textContent = text;
   document.getElementById("wrapper").addEventListener("toggle", function () {
     parent.postMessage({ type: "resize" }, "*");
   });


### PR DESCRIPTION
## Goal
Fix collapsible fields (generated answer, query, context set) displaying `[object Object]` instead of actual text in the Argilla annotation UI.

## Scope
Single file: `src/pragmata/core/annotation/collapsible_field.html`

## Implementation
`CustomField` values are passed as `{"text": "..."}` dicts (required by Argilla's `CustomField` API). The HTML template read `record.fields["name"]` directly and set it as `textContent`, which rendered the dict as `[object Object]`. Now extracts `.text` from the dict before rendering.

## Testing
- Discovered during UAT of the annotation pipeline
- Verified fix renders correctly in the Argilla UI
- Existing unit tests for record builder and task definitions still pass (they validate the dict shape, not the rendered HTML)

## References
- `src/pragmata/core/annotation/record_builder.py` — builds `{"text": ...}` values for `CustomField`s
- `tests/unit/core/annotation/test_import.py:92` — asserts `{"text": pair.answer}` format