### PR TITLE
feat(annotation): add structured logging across annotation tool

### DIFF
--- a/src/pragmata/__init__.py
+++ b/src/pragmata/__init__.py
@@ -3,7 +3,11 @@
 Only curated, stable symbols should be exposed here.
 """
 
+import logging
+
 from . import querygen
 from .api import get_version
 
 __all__ = ["get_version", "querygen"]
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/src/pragmata/api/_error_log.py
+++ b/src/pragmata/api/_error_log.py
@@ -1,4 +1,4 @@
-"""Scoped file handler that writes ERROR+ to base_dir/annotation/errors.log."""
+"""Scoped file handler that writes ERROR+ to a caller-supplied directory."""
 
 import logging
 from collections.abc import Generator
@@ -9,11 +9,10 @@ _FMT = "%(asctime)s | %(name)s | %(levelname)s | %(message)s"
 
 
 @contextmanager
-def error_log(base_dir: Path) -> Generator[None]:
+def error_log(log_dir: Path) -> Generator[None]:
     """Attach a file handler for the duration of a block, then clean up."""
-    log_dir = Path(base_dir).expanduser().resolve() / "annotation"
     log_dir.mkdir(parents=True, exist_ok=True)
-    handler = logging.FileHandler(log_dir / "errors.log", delay=True)
+    handler = logging.FileHandler(log_dir / "errors.log", delay=True, encoding="utf-8")
     handler.setLevel(logging.ERROR)
     handler.setFormatter(logging.Formatter(_FMT))
     root = logging.getLogger("pragmata")

--- a/src/pragmata/api/_error_log.py
+++ b/src/pragmata/api/_error_log.py
@@ -11,7 +11,6 @@ _FMT = "%(asctime)s | %(name)s | %(levelname)s | %(message)s"
 @contextmanager
 def error_log(log_dir: Path) -> Generator[None]:
     """Attach a file handler for the duration of a block, then clean up."""
-    log_dir.mkdir(parents=True, exist_ok=True)
     handler = logging.FileHandler(log_dir / "errors.log", delay=True, encoding="utf-8")
     handler.setLevel(logging.ERROR)
     handler.setFormatter(logging.Formatter(_FMT))

--- a/src/pragmata/api/_error_log.py
+++ b/src/pragmata/api/_error_log.py
@@ -1,0 +1,25 @@
+"""Scoped file handler that writes ERROR+ to base_dir/annotation/errors.log."""
+
+import logging
+from collections.abc import Generator
+from contextlib import contextmanager
+from pathlib import Path
+
+_FMT = "%(asctime)s | %(name)s | %(levelname)s | %(message)s"
+
+
+@contextmanager
+def error_log(base_dir: Path) -> Generator[None]:
+    """Attach a file handler for the duration of a block, then clean up."""
+    log_dir = Path(base_dir).expanduser().resolve() / "annotation"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    handler = logging.FileHandler(log_dir / "errors.log", delay=True)
+    handler.setLevel(logging.ERROR)
+    handler.setFormatter(logging.Formatter(_FMT))
+    root = logging.getLogger("pragmata")
+    root.addHandler(handler)
+    try:
+        yield
+    finally:
+        root.removeHandler(handler)
+        handler.close()

--- a/src/pragmata/api/annotation_export.py
+++ b/src/pragmata/api/annotation_export.py
@@ -7,7 +7,7 @@ import argilla as rg
 
 from pragmata.api._error_log import error_log
 from pragmata.core.annotation.export_runner import ExportResult, resolve_export_id, run_export
-from pragmata.core.paths.annotation_paths import resolve_annotation_paths, resolve_export_paths
+from pragmata.core.paths.annotation_paths import resolve_export_paths
 from pragmata.core.paths.paths import WorkspacePaths
 from pragmata.core.schemas.annotation_task import Task
 from pragmata.core.settings.annotation_settings import AnnotationSettings
@@ -48,11 +48,10 @@ def export_annotations(
     )
     resolved_id = resolve_export_id(settings, export_id if isinstance(export_id, str) else None)
     workspace = WorkspacePaths.from_base_dir(settings.base_dir)
-    annotation_paths = resolve_annotation_paths(workspace=workspace).ensure_dirs()
     export_paths = resolve_export_paths(workspace=workspace, export_id=resolved_id).ensure_dirs()
     resolved_tasks = tasks if tasks is not None else list(Task)
 
-    with error_log(annotation_paths.tool_root):
+    with error_log(export_paths.tool_root):
         result = run_export(client, settings, export_paths, resolved_tasks)
 
     logger.info(

--- a/src/pragmata/api/annotation_export.py
+++ b/src/pragmata/api/annotation_export.py
@@ -51,7 +51,7 @@ def export_annotations(
     paths = resolve_export_paths(workspace=workspace, export_id=resolved_id).ensure_dirs()
     resolved_tasks = tasks if tasks is not None else list(Task)
 
-    with error_log(settings.base_dir):
+    with error_log(workspace.tool_root("annotation")):
         result = run_export(client, settings, paths, resolved_tasks)
 
     logger.info(

--- a/src/pragmata/api/annotation_export.py
+++ b/src/pragmata/api/annotation_export.py
@@ -7,7 +7,7 @@ import argilla as rg
 
 from pragmata.api._error_log import error_log
 from pragmata.core.annotation.export_runner import ExportResult, resolve_export_id, run_export
-from pragmata.core.paths.annotation_paths import resolve_export_paths
+from pragmata.core.paths.annotation_paths import resolve_annotation_paths, resolve_export_paths
 from pragmata.core.paths.paths import WorkspacePaths
 from pragmata.core.schemas.annotation_task import Task
 from pragmata.core.settings.annotation_settings import AnnotationSettings
@@ -48,11 +48,12 @@ def export_annotations(
     )
     resolved_id = resolve_export_id(settings, export_id if isinstance(export_id, str) else None)
     workspace = WorkspacePaths.from_base_dir(settings.base_dir)
-    paths = resolve_export_paths(workspace=workspace, export_id=resolved_id).ensure_dirs()
+    annotation_paths = resolve_annotation_paths(workspace=workspace).ensure_dirs()
+    export_paths = resolve_export_paths(workspace=workspace, export_id=resolved_id).ensure_dirs()
     resolved_tasks = tasks if tasks is not None else list(Task)
 
-    with error_log(workspace.tool_root("annotation")):
-        result = run_export(client, settings, paths, resolved_tasks)
+    with error_log(annotation_paths.tool_root):
+        result = run_export(client, settings, export_paths, resolved_tasks)
 
     logger.info(
         "Export complete: %d task(s), %d total rows",

--- a/src/pragmata/api/annotation_export.py
+++ b/src/pragmata/api/annotation_export.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import argilla as rg
 
+from pragmata.api._error_log import error_log
 from pragmata.core.annotation.export_runner import ExportResult, resolve_export_id, run_export
 from pragmata.core.paths.annotation_paths import resolve_export_paths
 from pragmata.core.paths.paths import WorkspacePaths
@@ -50,7 +51,9 @@ def export_annotations(
     paths = resolve_export_paths(workspace=workspace, export_id=resolved_id).ensure_dirs()
     resolved_tasks = tasks if tasks is not None else list(Task)
 
-    result = run_export(client, settings, paths, resolved_tasks)
+    with error_log(settings.base_dir):
+        result = run_export(client, settings, paths, resolved_tasks)
+
     logger.info(
         "Export complete: %d task(s), %d total rows",
         len(result.row_counts),

--- a/src/pragmata/api/annotation_export.py
+++ b/src/pragmata/api/annotation_export.py
@@ -1,5 +1,6 @@
 """Annotation export API — fetch submitted responses and write flat CSVs per task."""
 
+import logging
 from pathlib import Path
 
 import argilla as rg
@@ -10,6 +11,8 @@ from pragmata.core.paths.paths import WorkspacePaths
 from pragmata.core.schemas.annotation_task import Task
 from pragmata.core.settings.annotation_settings import AnnotationSettings
 from pragmata.core.settings.settings_base import UNSET, Unset, load_config_file
+
+logger = logging.getLogger(__name__)
 
 
 def export_annotations(
@@ -47,4 +50,10 @@ def export_annotations(
     paths = resolve_export_paths(workspace=workspace, export_id=resolved_id).ensure_dirs()
     resolved_tasks = tasks if tasks is not None else list(Task)
 
-    return run_export(client, settings, paths, resolved_tasks)
+    result = run_export(client, settings, paths, resolved_tasks)
+    logger.info(
+        "Export complete: %d task(s), %d total rows",
+        len(result.row_counts),
+        sum(result.row_counts.values()),
+    )
+    return result

--- a/src/pragmata/api/annotation_import.py
+++ b/src/pragmata/api/annotation_import.py
@@ -13,6 +13,7 @@ from pragmata.core.annotation.record_builder import (
     fan_out_records,
     validate_records,
 )
+from pragmata.core.paths.annotation_paths import resolve_annotation_paths
 from pragmata.core.paths.paths import WorkspacePaths
 from pragmata.core.settings.annotation_settings import AnnotationSettings
 from pragmata.core.settings.settings_base import UNSET, Unset, load_config_file
@@ -87,7 +88,8 @@ def import_records(
         overrides={"workspace_prefix": workspace_prefix, "base_dir": base_dir},
     )
     workspace = WorkspacePaths.from_base_dir(settings.base_dir)
-    with error_log(workspace.tool_root("annotation")):
+    paths = resolve_annotation_paths(workspace=workspace).ensure_dirs()
+    with error_log(paths.tool_root):
         validation = validate_records(raw)
         if validation.errors:
             logger.warning("Validation failed for %d of %d records", len(validation.errors), len(raw))

--- a/src/pragmata/api/annotation_import.py
+++ b/src/pragmata/api/annotation_import.py
@@ -13,6 +13,7 @@ from pragmata.core.annotation.record_builder import (
     fan_out_records,
     validate_records,
 )
+from pragmata.core.paths.paths import WorkspacePaths
 from pragmata.core.settings.annotation_settings import AnnotationSettings
 from pragmata.core.settings.settings_base import UNSET, Unset, load_config_file
 
@@ -85,7 +86,8 @@ def import_records(
         config=load_config_file(config_path) if isinstance(config_path, (str, Path)) else None,
         overrides={"workspace_prefix": workspace_prefix, "base_dir": base_dir},
     )
-    with error_log(settings.base_dir):
+    workspace = WorkspacePaths.from_base_dir(settings.base_dir)
+    with error_log(workspace.tool_root("annotation")):
         validation = validate_records(raw)
         if validation.errors:
             logger.warning("Validation failed for %d of %d records", len(validation.errors), len(raw))

--- a/src/pragmata/api/annotation_import.py
+++ b/src/pragmata/api/annotation_import.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import argilla as rg
 
+from pragmata.api._error_log import error_log
 from pragmata.core.annotation.loaders import RecordInput, resolve_records
 from pragmata.core.annotation.record_builder import (
     RecordError,
@@ -48,6 +49,7 @@ def import_records(
     *,
     format: str = "auto",
     workspace_prefix: str | Unset = UNSET,
+    base_dir: str | Path | Unset = UNSET,
     config_path: str | Path | Unset = UNSET,
 ) -> ImportResult:
     """Validate and fan out records to the three Argilla annotation datasets.
@@ -72,6 +74,7 @@ def import_records(
         format: File format override — 'auto' (default), 'json', 'jsonl',
             or 'csv'. Only used for str/Path inputs.
         workspace_prefix: Prefix used when the environment was created.
+        base_dir: Workspace base directory. Defaults to cwd.
         config_path: Path to YAML config file for settings resolution.
 
     Returns:
@@ -80,12 +83,13 @@ def import_records(
     raw = resolve_records(records, format=format)
     settings = AnnotationSettings.resolve(
         config=load_config_file(config_path) if isinstance(config_path, (str, Path)) else None,
-        overrides={"workspace_prefix": workspace_prefix},
+        overrides={"workspace_prefix": workspace_prefix, "base_dir": base_dir},
     )
-    validation = validate_records(raw)
-    if validation.errors:
-        logger.warning("Validation failed for %d of %d records", len(validation.errors), len(raw))
-    dataset_counts = fan_out_records(client, validation.valid, settings)
+    with error_log(settings.base_dir):
+        validation = validate_records(raw)
+        if validation.errors:
+            logger.warning("Validation failed for %d of %d records", len(validation.errors), len(raw))
+        dataset_counts = fan_out_records(client, validation.valid, settings)
     logger.info("Import complete: %d records across %d datasets", len(raw), len(dataset_counts))
     return ImportResult(
         total_records=len(raw),

--- a/src/pragmata/api/annotation_import.py
+++ b/src/pragmata/api/annotation_import.py
@@ -1,5 +1,6 @@
 """Annotation import API — thin orchestration over core/ implementation."""
 
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -13,6 +14,8 @@ from pragmata.core.annotation.record_builder import (
 )
 from pragmata.core.settings.annotation_settings import AnnotationSettings
 from pragmata.core.settings.settings_base import UNSET, Unset, load_config_file
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Result types
@@ -80,7 +83,10 @@ def import_records(
         overrides={"workspace_prefix": workspace_prefix},
     )
     validation = validate_records(raw)
+    if validation.errors:
+        logger.warning("Validation failed for %d of %d records", len(validation.errors), len(raw))
     dataset_counts = fan_out_records(client, validation.valid, settings)
+    logger.info("Import complete: %d records across %d datasets", len(raw), len(dataset_counts))
     return ImportResult(
         total_records=len(raw),
         dataset_counts=dataset_counts,

--- a/src/pragmata/api/annotation_setup.py
+++ b/src/pragmata/api/annotation_setup.py
@@ -7,6 +7,7 @@ import argilla as rg
 
 from pragmata.api._error_log import error_log
 from pragmata.core.annotation.setup import SetupResult, provision_users, setup_datasets, teardown_resources
+from pragmata.core.paths.annotation_paths import resolve_annotation_paths
 from pragmata.core.paths.paths import WorkspacePaths
 from pragmata.core.settings.annotation_settings import AnnotationSettings, UserSpec
 from pragmata.core.settings.settings_base import UNSET, Unset, load_config_file
@@ -52,7 +53,8 @@ def setup(
         },
     )
     workspace = WorkspacePaths.from_base_dir(settings.base_dir)
-    with error_log(workspace.tool_root("annotation")):
+    paths = resolve_annotation_paths(workspace=workspace).ensure_dirs()
+    with error_log(paths.tool_root):
         ds_result = setup_datasets(client, settings)
         user_result = provision_users(client, users or [], settings)
     merged = ds_result.merge(user_result)
@@ -89,7 +91,8 @@ def teardown(
         overrides={"workspace_prefix": workspace_prefix, "base_dir": base_dir},
     )
     workspace = WorkspacePaths.from_base_dir(settings.base_dir)
+    paths = resolve_annotation_paths(workspace=workspace).ensure_dirs()
     logger.info("Starting teardown (prefix=%r)", settings.workspace_prefix)
-    with error_log(workspace.tool_root("annotation")):
+    with error_log(paths.tool_root):
         teardown_resources(client, settings)
     logger.info("Teardown complete")

--- a/src/pragmata/api/annotation_setup.py
+++ b/src/pragmata/api/annotation_setup.py
@@ -7,6 +7,7 @@ import argilla as rg
 
 from pragmata.api._error_log import error_log
 from pragmata.core.annotation.setup import SetupResult, provision_users, setup_datasets, teardown_resources
+from pragmata.core.paths.paths import WorkspacePaths
 from pragmata.core.settings.annotation_settings import AnnotationSettings, UserSpec
 from pragmata.core.settings.settings_base import UNSET, Unset, load_config_file
 
@@ -50,7 +51,8 @@ def setup(
             "base_dir": base_dir,
         },
     )
-    with error_log(settings.base_dir):
+    workspace = WorkspacePaths.from_base_dir(settings.base_dir)
+    with error_log(workspace.tool_root("annotation")):
         ds_result = setup_datasets(client, settings)
         user_result = provision_users(client, users or [], settings)
     merged = ds_result.merge(user_result)
@@ -86,6 +88,8 @@ def teardown(
         config=load_config_file(config_path) if isinstance(config_path, (str, Path)) else None,
         overrides={"workspace_prefix": workspace_prefix, "base_dir": base_dir},
     )
+    workspace = WorkspacePaths.from_base_dir(settings.base_dir)
     logger.info("Starting teardown (prefix=%r)", settings.workspace_prefix)
-    with error_log(settings.base_dir):
+    with error_log(workspace.tool_root("annotation")):
         teardown_resources(client, settings)
+    logger.info("Teardown complete")

--- a/src/pragmata/api/annotation_setup.py
+++ b/src/pragmata/api/annotation_setup.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import argilla as rg
 
+from pragmata.api._error_log import error_log
 from pragmata.core.annotation.setup import SetupResult, provision_users, setup_datasets, teardown_resources
 from pragmata.core.settings.annotation_settings import AnnotationSettings, UserSpec
 from pragmata.core.settings.settings_base import UNSET, Unset, load_config_file
@@ -18,6 +19,7 @@ def setup(
     *,
     workspace_prefix: str | Unset = UNSET,
     min_submitted: int | Unset = UNSET,
+    base_dir: str | Path | Unset = UNSET,
     config_path: str | Path | Unset = UNSET,
 ) -> SetupResult:
     """Create the full Argilla annotation environment idempotently.
@@ -34,6 +36,7 @@ def setup(
         users: User accounts to provision. Pass None to skip user setup.
         workspace_prefix: Prefix prepended to workspace and dataset names.
         min_submitted: Minimum annotations required per record.
+        base_dir: Workspace base directory. Defaults to cwd.
         config_path: Path to YAML config file for settings resolution.
 
     Returns:
@@ -44,10 +47,12 @@ def setup(
         overrides={
             "workspace_prefix": workspace_prefix,
             "min_submitted": min_submitted,
+            "base_dir": base_dir,
         },
     )
-    ds_result = setup_datasets(client, settings)
-    user_result = provision_users(client, users or [], settings)
+    with error_log(settings.base_dir):
+        ds_result = setup_datasets(client, settings)
+        user_result = provision_users(client, users or [], settings)
     merged = ds_result.merge(user_result)
     logger.info(
         "Setup complete: %d workspaces, %d datasets, %d users created",
@@ -62,6 +67,7 @@ def teardown(
     client: rg.Argilla,
     *,
     workspace_prefix: str | Unset = UNSET,
+    base_dir: str | Path | Unset = UNSET,
     config_path: str | Path | Unset = UNSET,
 ) -> None:
     """Remove the Argilla annotation environment.
@@ -73,11 +79,13 @@ def teardown(
     Args:
         client: Connected Argilla client instance.
         workspace_prefix: Prefix used when the environment was created.
+        base_dir: Workspace base directory. Defaults to cwd.
         config_path: Path to YAML config file for settings resolution.
     """
     settings = AnnotationSettings.resolve(
         config=load_config_file(config_path) if isinstance(config_path, (str, Path)) else None,
-        overrides={"workspace_prefix": workspace_prefix},
+        overrides={"workspace_prefix": workspace_prefix, "base_dir": base_dir},
     )
     logger.info("Starting teardown (prefix=%r)", settings.workspace_prefix)
-    teardown_resources(client, settings)
+    with error_log(settings.base_dir):
+        teardown_resources(client, settings)

--- a/src/pragmata/api/annotation_setup.py
+++ b/src/pragmata/api/annotation_setup.py
@@ -1,5 +1,6 @@
 """Argilla annotation setup API — thin orchestration over core/ implementation."""
 
+import logging
 from pathlib import Path
 
 import argilla as rg
@@ -7,6 +8,8 @@ import argilla as rg
 from pragmata.core.annotation.setup import SetupResult, provision_users, setup_datasets, teardown_resources
 from pragmata.core.settings.annotation_settings import AnnotationSettings, UserSpec
 from pragmata.core.settings.settings_base import UNSET, Unset, load_config_file
+
+logger = logging.getLogger(__name__)
 
 
 def setup(
@@ -45,7 +48,14 @@ def setup(
     )
     ds_result = setup_datasets(client, settings)
     user_result = provision_users(client, users or [], settings)
-    return ds_result.merge(user_result)
+    merged = ds_result.merge(user_result)
+    logger.info(
+        "Setup complete: %d workspaces, %d datasets, %d users created",
+        len(merged.created_workspaces),
+        len(merged.created_datasets),
+        len(merged.created_users),
+    )
+    return merged
 
 
 def teardown(
@@ -69,4 +79,5 @@ def teardown(
         config=load_config_file(config_path) if isinstance(config_path, (str, Path)) else None,
         overrides={"workspace_prefix": workspace_prefix},
     )
+    logger.info("Starting teardown (prefix=%r)", settings.workspace_prefix)
     teardown_resources(client, settings)

--- a/src/pragmata/cli/app.py
+++ b/src/pragmata/cli/app.py
@@ -1,5 +1,7 @@
 """Typer CLI application for pragmata."""
 
+import logging
+
 import typer
 
 from pragmata.api import get_version
@@ -7,6 +9,15 @@ from pragmata.cli.commands.querygen import querygen_app
 
 app = typer.Typer(add_completion=False)
 app.add_typer(querygen_app, name="querygen")
+
+
+def _configure_logging(verbosity: int) -> None:
+    """Set up root logging for CLI usage. Verbosity: 0=WARNING, 1=INFO, 2+=DEBUG."""
+    level = (logging.WARNING, logging.INFO, logging.DEBUG)[min(verbosity, 2)]
+    logging.basicConfig(
+        format="%(levelname)s | %(name)s | %(message)s",
+        level=level,
+    )
 
 
 @app.callback(invoke_without_command=True)
@@ -18,8 +29,16 @@ def main(
         help="Print the installed pragmata version and exit.",
         is_eager=True,
     ),
+    verbose: int = typer.Option(
+        0,
+        "--verbose",
+        "-v",
+        count=True,
+        help="Increase log verbosity (-v for INFO, -vv for DEBUG).",
+    ),
 ) -> None:
     """Run the pragmata CLI."""
+    _configure_logging(verbose)
     if version:
         typer.echo(get_version())
         raise typer.Exit(code=0)

--- a/src/pragmata/core/annotation/export_runner.py
+++ b/src/pragmata/core/annotation/export_runner.py
@@ -1,6 +1,7 @@
 """Annotation export orchestration: fetch from Argilla, write CSVs, return ExportResult."""
 
 import csv
+import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -18,6 +19,8 @@ from pragmata.core.schemas.annotation_export import (
     RetrievalAnnotation,
 )
 from pragmata.core.schemas.annotation_task import Task
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from pragmata.core.settings.annotation_settings import AnnotationSettings
@@ -81,7 +84,9 @@ def write_export_csv(
                 row["constraint_details"] = ";".join(violations)
                 writer.writerow(row)
         tmp.rename(path)
+        logger.info("Wrote %d rows to %s", len(rows), path)
     except Exception:
+        logger.error("Failed writing CSV %s — cleaning up temp file", path)
         tmp.unlink(missing_ok=True)
         raise
 
@@ -110,6 +115,7 @@ def run_export(
             write_export_csv(task_rows[task], task_paths[task], task)
             written.append(task_paths[task])
     except Exception:
+        logger.error("Export failed — rolling back %d written file(s)", len(written))
         for p in written:
             p.unlink(missing_ok=True)
         raise

--- a/src/pragmata/core/annotation/loaders.py
+++ b/src/pragmata/core/annotation/loaders.py
@@ -150,7 +150,7 @@ def _load_hf_dataset(dataset: Dataset) -> list[dict[str, Any]]:
 
 def _load_dataframe(df: pd.DataFrame) -> list[dict[str, Any]]:
     """Convert a pandas DataFrame to list[dict]."""
-    return df.to_dict("records")
+    return df.to_dict("records")  # type: ignore[return-value]
 
 
 # ---------------------------------------------------------------------------

--- a/src/pragmata/core/annotation/loaders.py
+++ b/src/pragmata/core/annotation/loaders.py
@@ -12,7 +12,7 @@ import json
 import logging
 from collections import defaultdict
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypeAlias, cast
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 logger = logging.getLogger(__name__)
 
@@ -150,7 +150,7 @@ def _load_hf_dataset(dataset: Dataset) -> list[dict[str, Any]]:
 
 def _load_dataframe(df: pd.DataFrame) -> list[dict[str, Any]]:
     """Convert a pandas DataFrame to list[dict]."""
-    return cast(list[dict[str, Any]], df.to_dict("records"))
+    return [{str(k): v for k, v in row.items()} for row in df.to_dict("records")]
 
 
 # ---------------------------------------------------------------------------

--- a/src/pragmata/core/annotation/loaders.py
+++ b/src/pragmata/core/annotation/loaders.py
@@ -12,7 +12,7 @@ import json
 import logging
 from collections import defaultdict
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypeAlias
+from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
 logger = logging.getLogger(__name__)
 
@@ -150,7 +150,7 @@ def _load_hf_dataset(dataset: Dataset) -> list[dict[str, Any]]:
 
 def _load_dataframe(df: pd.DataFrame) -> list[dict[str, Any]]:
     """Convert a pandas DataFrame to list[dict]."""
-    return df.to_dict("records")  # type: ignore[return-value]
+    return cast(list[dict[str, Any]], df.to_dict("records"))
 
 
 # ---------------------------------------------------------------------------

--- a/src/pragmata/core/annotation/loaders.py
+++ b/src/pragmata/core/annotation/loaders.py
@@ -9,9 +9,12 @@ from __future__ import annotations
 
 import csv
 import json
+import logging
 from collections import defaultdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeAlias
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -192,12 +195,16 @@ def resolve_records(
             loader = _EXTENSION_LOADERS.get(f".{format}")
             if loader is None:
                 raise ValueError(f"Unsupported format: {format!r}")
-            return loader(path)
+            result = loader(path)
+            logger.info("Loaded %d records from %s (format=%s)", len(result), path, format)
+            return result
 
         loader = _EXTENSION_LOADERS.get(path.suffix.lower())
         if loader is None:
             raise ValueError(f"Unsupported file extension: {path.suffix!r}")
-        return loader(path)
+        result = loader(path)
+        logger.info("Loaded %d records from %s", len(result), path)
+        return result
 
     # HF Dataset — check before DataFrame since Dataset may also have to_dict
     try:

--- a/src/pragmata/core/paths/annotation_paths.py
+++ b/src/pragmata/core/paths/annotation_paths.py
@@ -41,12 +41,14 @@ class AnnotationExportPaths:
 
     Attributes:
         export_dir: Root directory for the export.
+        tool_root: Root directory for the tool data.
         retrieval_annotation_csv: Output path for retrieval task annotations.
         grounding_annotation_csv: Output path for grounding task annotations.
         generation_annotation_csv: Output path for generation task annotations.
     """
 
     export_dir: Path
+    tool_root: Path
     retrieval_annotation_csv: Path
     grounding_annotation_csv: Path
     generation_annotation_csv: Path
@@ -54,6 +56,7 @@ class AnnotationExportPaths:
     def ensure_dirs(self) -> Self:
         """Create the export directory scaffold."""
         self.export_dir.mkdir(parents=True, exist_ok=True)
+        self.tool_root.mkdir(parents=True, exist_ok=True)
         return self
 
 
@@ -70,6 +73,7 @@ def resolve_export_paths(*, workspace: WorkspacePaths, export_id: str) -> Annota
     export_dir = workspace.tool_root("annotation") / "exports" / export_id
     return AnnotationExportPaths(
         export_dir=export_dir,
+        tool_root=workspace.tool_root,
         retrieval_annotation_csv=export_dir / "retrieval.csv",
         grounding_annotation_csv=export_dir / "grounding.csv",
         generation_annotation_csv=export_dir / "generation.csv",

--- a/src/pragmata/core/paths/annotation_paths.py
+++ b/src/pragmata/core/paths/annotation_paths.py
@@ -56,7 +56,6 @@ class AnnotationExportPaths:
     def ensure_dirs(self) -> Self:
         """Create the export directory scaffold."""
         self.export_dir.mkdir(parents=True, exist_ok=True)
-        self.tool_root.mkdir(parents=True, exist_ok=True)
         return self
 
 

--- a/src/pragmata/core/paths/annotation_paths.py
+++ b/src/pragmata/core/paths/annotation_paths.py
@@ -8,6 +8,34 @@ from pragmata.core.paths.paths import WorkspacePaths
 
 
 @dataclass(frozen=True, slots=True)
+class AnnotationPaths:
+    """Path bundle for the annotation tool root.
+
+    Attributes:
+        tool_root: Root directory for annotation artifacts.
+    """
+
+    tool_root: Path
+
+    def ensure_dirs(self) -> Self:
+        """Create the annotation tool root directory."""
+        self.tool_root.mkdir(parents=True, exist_ok=True)
+        return self
+
+
+def resolve_annotation_paths(*, workspace: WorkspacePaths) -> AnnotationPaths:
+    """Build the path bundle for the annotation tool.
+
+    Args:
+        workspace: Workspace path bundle.
+
+    Returns:
+        Path bundle for the annotation tool root.
+    """
+    return AnnotationPaths(tool_root=workspace.tool_root("annotation"))
+
+
+@dataclass(frozen=True, slots=True)
 class AnnotationExportPaths:
     """Path bundle for an annotation export run.
 

--- a/src/pragmata/core/paths/annotation_paths.py
+++ b/src/pragmata/core/paths/annotation_paths.py
@@ -1,28 +1,10 @@
-"""Path bundles for annotation import and export runs."""
+"""Path bundles for annotation tool and export runs."""
 
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Self
 
 from pragmata.core.paths.paths import WorkspacePaths
-
-
-@dataclass(frozen=True, slots=True)
-class AnnotationImportPaths:
-    """Path bundle for an annotation import run.
-
-    Attributes:
-        import_dir: Root directory for the import.
-        import_result_json: Output path for the import result JSON.
-    """
-
-    import_dir: Path
-    import_result_json: Path
-
-    def ensure_dirs(self) -> Self:
-        """Create the import directory scaffold."""
-        self.import_dir.mkdir(parents=True, exist_ok=True)
-        return self
 
 
 @dataclass(frozen=True, slots=True)
@@ -45,20 +27,6 @@ class AnnotationExportPaths:
         """Create the export directory scaffold."""
         self.export_dir.mkdir(parents=True, exist_ok=True)
         return self
-
-
-def resolve_import_paths(*, workspace: WorkspacePaths, import_id: str) -> AnnotationImportPaths:
-    """Build the path bundle for an annotation import run.
-
-    Args:
-        workspace: Workspace path bundle.
-        import_id: Unique import identifier.
-
-    Returns:
-        Path bundle for the import run.
-    """
-    import_dir = workspace.tool_root("annotation") / "imports" / import_id
-    return AnnotationImportPaths(import_dir=import_dir, import_result_json=import_dir / "import_result.json")
 
 
 def resolve_export_paths(*, workspace: WorkspacePaths, export_id: str) -> AnnotationExportPaths:

--- a/src/pragmata/core/paths/annotation_paths.py
+++ b/src/pragmata/core/paths/annotation_paths.py
@@ -73,7 +73,7 @@ def resolve_export_paths(*, workspace: WorkspacePaths, export_id: str) -> Annota
     export_dir = workspace.tool_root("annotation") / "exports" / export_id
     return AnnotationExportPaths(
         export_dir=export_dir,
-        tool_root=workspace.tool_root,
+        tool_root=workspace.tool_root("annotation"),
         retrieval_annotation_csv=export_dir / "retrieval.csv",
         grounding_annotation_csv=export_dir / "grounding.csv",
         generation_annotation_csv=export_dir / "generation.csv",

--- a/tests/unit/api/test_error_log.py
+++ b/tests/unit/api/test_error_log.py
@@ -9,7 +9,9 @@ from pragmata.api._error_log import error_log
 
 @pytest.fixture()
 def log_dir(tmp_path):
-    return tmp_path / "annotation"
+    d = tmp_path / "annotation"
+    d.mkdir()
+    return d
 
 
 def _log_file(log_dir):

--- a/tests/unit/api/test_error_log.py
+++ b/tests/unit/api/test_error_log.py
@@ -9,11 +9,11 @@ from pragmata.api._error_log import error_log
 
 @pytest.fixture()
 def log_dir(tmp_path):
-    return tmp_path
+    return tmp_path / "annotation"
 
 
-def _log_file(base):
-    return base / "annotation" / "errors.log"
+def _log_file(log_dir):
+    return log_dir / "errors.log"
 
 
 class TestErrorLog:

--- a/tests/unit/api/test_error_log.py
+++ b/tests/unit/api/test_error_log.py
@@ -1,0 +1,86 @@
+"""Unit tests for the _error_log context manager."""
+
+import logging
+
+import pytest
+
+from pragmata.api._error_log import error_log
+
+
+@pytest.fixture()
+def log_dir(tmp_path):
+    return tmp_path
+
+
+def _log_file(base):
+    return base / "annotation" / "errors.log"
+
+
+class TestErrorLog:
+    def test_error_written_to_file(self, log_dir):
+        logger = logging.getLogger("pragmata.test")
+        with error_log(log_dir):
+            logger.error("something broke")
+
+        lines = _log_file(log_dir).read_text().strip().splitlines()
+        assert len(lines) == 1
+        assert "something broke" in lines[0]
+
+    def test_critical_written_to_file(self, log_dir):
+        logger = logging.getLogger("pragmata.test")
+        with error_log(log_dir):
+            logger.critical("fatal failure")
+
+        assert "fatal failure" in _log_file(log_dir).read_text()
+
+    def test_info_and_warning_excluded(self, log_dir):
+        logger = logging.getLogger("pragmata.test")
+        with error_log(log_dir):
+            logger.info("info msg")
+            logger.warning("warning msg")
+
+        assert not _log_file(log_dir).exists()
+
+    def test_no_file_when_no_errors(self, log_dir):
+        logger = logging.getLogger("pragmata.test")
+        with error_log(log_dir):
+            logger.info("all good")
+
+        assert not _log_file(log_dir).exists()
+
+    def test_handler_removed_after_exit(self, log_dir):
+        root = logging.getLogger("pragmata")
+        before = len(root.handlers)
+        with error_log(log_dir):
+            pass
+        assert len(root.handlers) == before
+
+    def test_handler_removed_on_exception(self, log_dir):
+        root = logging.getLogger("pragmata")
+        before = len(root.handlers)
+        with pytest.raises(ValueError, match="boom"):
+            with error_log(log_dir):
+                raise ValueError("boom")
+        assert len(root.handlers) == before
+
+    def test_multiple_calls_append(self, log_dir):
+        logger = logging.getLogger("pragmata.test")
+        with error_log(log_dir):
+            logger.error("first")
+        with error_log(log_dir):
+            logger.error("second")
+
+        lines = _log_file(log_dir).read_text().strip().splitlines()
+        assert len(lines) == 2
+        assert "first" in lines[0]
+        assert "second" in lines[1]
+
+    def test_format_includes_timestamp_and_logger_name(self, log_dir):
+        logger = logging.getLogger("pragmata.core.annotation.setup")
+        with error_log(log_dir):
+            logger.error("format check")
+
+        line = _log_file(log_dir).read_text().strip()
+        assert "pragmata.core.annotation.setup" in line
+        assert "ERROR" in line
+        assert "format check" in line

--- a/tests/unit/core/annotation/test_export_runner.py
+++ b/tests/unit/core/annotation/test_export_runner.py
@@ -223,6 +223,7 @@ class TestExportResult:
     def test_constructable(self, tmp_path: Path) -> None:
         paths = AnnotationExportPaths(
             export_dir=tmp_path,
+            tool_root=tmp_path,
             retrieval_annotation_csv=tmp_path / "retrieval.csv",
             grounding_annotation_csv=tmp_path / "grounding.csv",
             generation_annotation_csv=tmp_path / "generation.csv",
@@ -239,6 +240,7 @@ class TestExportResult:
     def test_frozen(self, tmp_path: Path) -> None:
         paths = AnnotationExportPaths(
             export_dir=tmp_path,
+            tool_root=tmp_path,
             retrieval_annotation_csv=tmp_path / "retrieval.csv",
             grounding_annotation_csv=tmp_path / "grounding.csv",
             generation_annotation_csv=tmp_path / "generation.csv",

--- a/tests/unit/core/paths/test_annotation_paths.py
+++ b/tests/unit/core/paths/test_annotation_paths.py
@@ -1,51 +1,16 @@
-"""Unit tests for annotation import/export path bundles."""
+"""Unit tests for annotation path bundles."""
 
 from pathlib import Path
 
 import pytest
 
-from pragmata.core.paths.annotation_paths import (
-    resolve_export_paths,
-    resolve_import_paths,
-)
+from pragmata.core.paths.annotation_paths import resolve_export_paths
 from pragmata.core.paths.paths import WorkspacePaths
 
 
 @pytest.fixture()
 def workspace(tmp_path: Path) -> WorkspacePaths:
     return WorkspacePaths.from_base_dir(tmp_path)
-
-
-# ---------------------------------------------------------------------------
-# AnnotationImportPaths
-# ---------------------------------------------------------------------------
-
-
-class TestAnnotationImportPaths:
-    def test_resolve_import_paths_structure(self, workspace: WorkspacePaths) -> None:
-        paths = resolve_import_paths(workspace=workspace, import_id="imp1")
-        expected_dir = workspace.tool_root("annotation") / "imports" / "imp1"
-        assert paths.import_dir == expected_dir
-
-    def test_import_result_json_path(self, workspace: WorkspacePaths) -> None:
-        paths = resolve_import_paths(workspace=workspace, import_id="imp1")
-        assert paths.import_result_json == paths.import_dir / "import_result.json"
-
-    def test_ensure_dirs_creates_import_dir(self, workspace: WorkspacePaths) -> None:
-        paths = resolve_import_paths(workspace=workspace, import_id="imp1")
-        assert not paths.import_dir.exists()
-        paths.ensure_dirs()
-        assert paths.import_dir.exists()
-
-    def test_ensure_dirs_returns_self(self, workspace: WorkspacePaths) -> None:
-        paths = resolve_import_paths(workspace=workspace, import_id="imp1")
-        result = paths.ensure_dirs()
-        assert result is paths
-
-    def test_frozen(self, workspace: WorkspacePaths, tmp_path: Path) -> None:
-        paths = resolve_import_paths(workspace=workspace, import_id="imp1")
-        with pytest.raises((AttributeError, TypeError)):
-            paths.import_dir = tmp_path  # type: ignore[misc]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/core/paths/test_annotation_paths.py
+++ b/tests/unit/core/paths/test_annotation_paths.py
@@ -4,13 +4,39 @@ from pathlib import Path
 
 import pytest
 
-from pragmata.core.paths.annotation_paths import resolve_export_paths
+from pragmata.core.paths.annotation_paths import resolve_annotation_paths, resolve_export_paths
 from pragmata.core.paths.paths import WorkspacePaths
 
 
 @pytest.fixture()
 def workspace(tmp_path: Path) -> WorkspacePaths:
     return WorkspacePaths.from_base_dir(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# AnnotationPaths
+# ---------------------------------------------------------------------------
+
+
+class TestAnnotationPaths:
+    def test_tool_root(self, workspace: WorkspacePaths) -> None:
+        paths = resolve_annotation_paths(workspace=workspace)
+        assert paths.tool_root == workspace.tool_root("annotation")
+
+    def test_ensure_dirs_creates_tool_root(self, workspace: WorkspacePaths) -> None:
+        paths = resolve_annotation_paths(workspace=workspace)
+        assert not paths.tool_root.exists()
+        paths.ensure_dirs()
+        assert paths.tool_root.exists()
+
+    def test_ensure_dirs_returns_self(self, workspace: WorkspacePaths) -> None:
+        paths = resolve_annotation_paths(workspace=workspace)
+        assert paths.ensure_dirs() is paths
+
+    def test_frozen(self, workspace: WorkspacePaths, tmp_path: Path) -> None:
+        paths = resolve_annotation_paths(workspace=workspace)
+        with pytest.raises((AttributeError, TypeError)):
+            paths.tool_root = tmp_path  # type: ignore[misc]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Goal

Add structured Python logging across annotation tool (querygen handled separately) so operations are observable via CLI output and container logs (Docker captures stderr by default).

## Scope

- **Library root** — `NullHandler` on `pragmata` logger (standard lib convention)
- **CLI** — `--verbose` / `-v` flag (`-v`=INFO, `-vv`=DEBUG, default=WARNING) via `logging.basicConfig` to stderr
- **Core** — loggers + log calls in `export_runner` (CSV write success/failure, rollback) and `loaders` (record count after file load). Existing loggers in `argilla_ops`, `setup`, `record_builder`, `export_fetcher` unchanged.
- **API** — orchestration-level summaries: import completion + validation warnings, setup counts, teardown start, export totals. No duplication of core-level logs.

## Implementation

Follows Python logging best practice for libs:
- `core/` emits logs at point of context (where errors occur, where I/O happens)
- `api/` emits orchestration summaries only
- Logger hierarchy propagates automatically — no manual error forwarding
- CLI configures the root handler; library consumers configure their own

## Testing

- [x] All files compile (`py_compile`)
- [x] Ruff lint passes (pre-commit hook)
- [ ] Existing test suite (CI)

## References

- Python logging HOWTO: library pattern with `NullHandler`
- Architecture: `docs/design/packaging-invocation-surface.md` (cli → api → core dependency direction)