### PR TITLE
feat: add candidate-ID alignment filtering for query generation

### DIFF
--- a/src/pragmata/core/querygen/filtering.py
+++ b/src/pragmata/core/querygen/filtering.py
@@ -1,4 +1,4 @@
-"""Validation and filtering for positional candidate-ID alignment."""
+"""Filtering for positional candidate-ID alignment."""
 
 from pragmata.core.types import CandidateItemT
 

--- a/src/pragmata/core/querygen/filtering.py
+++ b/src/pragmata/core/querygen/filtering.py
@@ -1,0 +1,26 @@
+"""Validation and filtering for positional candidate-ID alignment."""
+
+from pragmata.core.types import CandidateItemT
+
+
+def filter_aligned_candidate_ids(
+    items: list[CandidateItemT],
+    expected_candidate_ids: list[str],
+) -> list[CandidateItemT]:
+    """Filter items by positional candidate-ID agreement.
+
+    Args:
+        items: Generated items carrying ``candidate_id`` attributes.
+        expected_candidate_ids: Ordered candidate IDs expected for the current
+            stage output.
+
+    Returns:
+        A filtered list containing only positionally aligned items.
+    """
+    kept_items: list[CandidateItemT] = []
+
+    for expected_candidate_id, item in zip(expected_candidate_ids, items, strict=False):
+        if item.candidate_id == expected_candidate_id:
+            kept_items.append(item)
+
+    return kept_items

--- a/src/pragmata/core/types.py
+++ b/src/pragmata/core/types.py
@@ -1,6 +1,6 @@
 """Shared type aliases and typing utilities for core modules."""
 
-from typing import Annotated, TypeVar
+from typing import Annotated, Protocol, TypeVar
 
 from pydantic import BaseModel, StringConstraints
 
@@ -10,3 +10,12 @@ NonEmptyStr = Annotated[
 ]
 
 M = TypeVar("M", bound=BaseModel)
+
+
+class HasCandidateId(Protocol):
+    """Structural type for objects carrying a candidate ID."""
+
+    candidate_id: str
+
+
+CandidateItemT = TypeVar("CandidateItemT", bound=HasCandidateId)

--- a/tests/unit/core/querygen/test_filtering.py
+++ b/tests/unit/core/querygen/test_filtering.py
@@ -1,0 +1,72 @@
+"""Tests for deterministic positional candidate-ID alignment filtering."""
+
+import pytest
+
+from pragmata.core.querygen.filtering import filter_aligned_candidate_ids
+from pragmata.core.schemas.querygen_plan import QueryBlueprint
+from pragmata.core.schemas.querygen_realize import RealizedQuery
+
+
+def _blueprint(candidate_id: str) -> QueryBlueprint:
+    return QueryBlueprint(
+        candidate_id=candidate_id,
+        domain="healthcare",
+        role="patient",
+        language="en",
+        topic="insurance coverage",
+        intent="understand benefits",
+        task="ask a question",
+        difficulty=None,
+        format=None,
+        user_scenario="I need to understand whether a treatment is covered.",
+        information_need="What coverage rules apply to my treatment?",
+    )
+
+
+def _realized_query(candidate_id: str) -> RealizedQuery:
+    return RealizedQuery(
+        candidate_id=candidate_id,
+        query=f"query for {candidate_id}",
+    )
+
+
+@pytest.mark.parametrize(
+    ("item_candidate_ids", "expected_candidate_ids", "kept_candidate_ids"),
+    [
+        (["c001", "c002", "c003"], ["c001", "c002", "c003"], ["c001", "c002", "c003"]),
+        (["c001", "c999", "c003"], ["c001", "c002", "c003"], ["c001", "c003"]),
+        (["c002", "c001", "c003"], ["c001", "c002", "c003"], ["c003"]),
+        (["c001", "c002"], ["c001", "c002", "c003"], ["c001", "c002"]),
+        (["c001", "c002", "c003"], ["c001", "c002"], ["c001", "c002"]),
+        ([], ["c001", "c002"], []),
+    ],
+)
+def test_filter_aligned_candidate_ids_for_query_blueprints(
+    item_candidate_ids: list[str],
+    expected_candidate_ids: list[str],
+    kept_candidate_ids: list[str],
+) -> None:
+    items = [_blueprint(candidate_id) for candidate_id in item_candidate_ids]
+
+    result = filter_aligned_candidate_ids(
+        items=items,
+        expected_candidate_ids=expected_candidate_ids,
+    )
+
+    assert [item.candidate_id for item in result] == kept_candidate_ids
+
+
+def test_filter_aligned_candidate_ids_supports_realized_queries() -> None:
+    items = [
+        _realized_query("c001"),
+        _realized_query("c999"),
+        _realized_query("c003"),
+    ]
+
+    result = filter_aligned_candidate_ids(
+        items=items,
+        expected_candidate_ids=["c001", "c002", "c003"],
+    )
+
+    assert [item.candidate_id for item in result] == ["c001", "c003"]
+    assert result == [items[0], items[2]]


### PR DESCRIPTION
**Summary**

Introduce a deterministic filtering step for candidate-ID alignment in the synthetic query generation workflow. This enforces positional agreement between expected candidate IDs and LLM outputs.

**Key changes**

- Add `core/querygen/filtering.py`:
  - `filter_aligned_candidate_ids()` for positional candidate-ID reconciliation
  - keeps only items whose `candidate_id` matches the expected ID at the same position
  - drops misaligned items without attempting reordering or heuristic repair
  - works for both planning (`QueryBlueprint`) and realization (`RealizedQuery`) outputs via a shared `candidate_id` field

**Design notes**

- Alignment is treated as a hard positional contract:
  - shifted or mismatched IDs are considered invalid and are dropped
  - no attempt is made to repair drift, as this can silently corrupt downstream joins

- This helper operates as a deterministic aggregate step:
  - not applied per batch
  - intended for use after concatenating stage outputs

**Orchestration note**

The intended call pattern in `api/querygen.py` is:

- stage 1 (planning)
- filtering (against pre-defined candidate IDs)
- deduplication
- stage 2 (realization)
- filtering (against post–stage-1 selected candidate IDs)

**Status**

Ready for review.