### PR TITLE
feat(annotation): add IAA runner, API, and public re-exports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ type = [
     "mypy>=1.19",
     "types-PyYAML",
 ]
-annotation = ["argilla>=2.0,<3.0",]
+annotation = ["argilla>=2.0,<3.0", "numpy>=1.26"]
 cohere = ["langchain-cohere"]
 deepseek = ["langchain-deepseek"]
 openai = ["langchain-openai"]

--- a/src/pragmata/annotation/__init__.py
+++ b/src/pragmata/annotation/__init__.py
@@ -3,6 +3,9 @@
 from pragmata.api.annotation_export import (
     export_annotations as export_annotations,
 )
+from pragmata.api.annotation_iaa import (
+    compute_iaa as compute_iaa,
+)
 from pragmata.api.annotation_import import (
     ImportResult as ImportResult,
 )
@@ -20,6 +23,9 @@ from pragmata.core.annotation.export_runner import (
 )
 from pragmata.core.annotation.setup import (
     SetupResult as SetupResult,
+)
+from pragmata.core.schemas.iaa_report import (
+    IaaReport as IaaReport,
 )
 from pragmata.core.settings.annotation_settings import (
     UserSpec as UserSpec,

--- a/src/pragmata/api/annotation_iaa.py
+++ b/src/pragmata/api/annotation_iaa.py
@@ -1,0 +1,65 @@
+"""Annotation IAA API — compute inter-annotator agreement from export CSVs."""
+
+import logging
+from pathlib import Path
+
+from pragmata.api._error_log import error_log
+from pragmata.core.annotation.iaa_runner import run_iaa
+from pragmata.core.paths.annotation_paths import resolve_export_paths, resolve_iaa_paths
+from pragmata.core.paths.paths import WorkspacePaths
+from pragmata.core.schemas.annotation_task import Task
+from pragmata.core.schemas.iaa_report import IaaReport
+from pragmata.core.settings.annotation_settings import AnnotationSettings
+from pragmata.core.settings.settings_base import UNSET, Unset, load_config_file
+
+logger = logging.getLogger(__name__)
+
+
+def compute_iaa(
+    export_id: str,
+    *,
+    base_dir: str | Path | Unset = UNSET,
+    tasks: list[Task] | None = None,
+    workspace_prefix: str | Unset = UNSET,
+    n_resamples: int = 1000,
+    ci: float = 0.95,
+    seed: int | None = None,
+    config_path: str | Path | Unset = UNSET,
+) -> IaaReport:
+    """Compute inter-annotator agreement metrics from an existing export.
+
+    Reads the export CSVs for the given ``export_id``, computes per-label
+    Krippendorff's alpha with bootstrap CIs and pairwise Cohen's kappa,
+    and writes a JSON report.
+
+    Args:
+        export_id: Identifier of a previous export run whose CSVs to analyse.
+        base_dir: Workspace base directory. Defaults to cwd.
+        tasks: Tasks to analyse. Defaults to all three tasks.
+        workspace_prefix: Prefix used when the environment was created.
+        n_resamples: Number of bootstrap iterations for CIs.
+        ci: Confidence level (e.g. 0.95 for 95% CI).
+        seed: Optional RNG seed for reproducible bootstrap.
+        config_path: Path to YAML config file for settings resolution.
+
+    Returns:
+        IaaReport with per-label alpha, CIs, and pairwise kappas.
+    """
+    settings = AnnotationSettings.resolve(
+        config=load_config_file(config_path) if isinstance(config_path, (str, Path)) else None,
+        overrides={"workspace_prefix": workspace_prefix, "base_dir": base_dir},
+    )
+    workspace = WorkspacePaths.from_base_dir(settings.base_dir)
+    export_paths = resolve_export_paths(workspace=workspace, export_id=export_id)
+    iaa_paths = resolve_iaa_paths(export_paths=export_paths).ensure_dirs()
+    resolved_tasks = tasks if tasks is not None else list(Task)
+
+    with error_log(export_paths.tool_root):
+        report = run_iaa(export_paths, iaa_paths, resolved_tasks, n_resamples=n_resamples, ci=ci, seed=seed)
+
+    logger.info(
+        "IAA complete: %d task(s) analysed, report at %s",
+        len(report.tasks),
+        iaa_paths.report,
+    )
+    return report

--- a/src/pragmata/core/annotation/iaa_runner.py
+++ b/src/pragmata/core/annotation/iaa_runner.py
@@ -1,0 +1,195 @@
+"""Orchestrate IAA computation from exported annotation CSVs."""
+
+from __future__ import annotations
+
+import csv
+import logging
+import math
+from datetime import datetime, timezone
+from itertools import combinations
+from pathlib import Path
+
+import numpy as np
+
+from pragmata.core.annotation.iaa import (
+    bootstrap_alpha,
+    cohen_kappa,
+    krippendorff_alpha_nominal,
+    percentage_agreement,
+)
+from pragmata.core.paths.annotation_paths import AnnotationExportPaths, IaaPaths
+from pragmata.core.schemas.annotation_task import Task
+from pragmata.core.schemas.iaa_report import (
+    AnnotatorPair,
+    IaaReport,
+    LabelAgreement,
+    TaskAgreement,
+)
+
+logger = logging.getLogger(__name__)
+
+TASK_LABELS: dict[Task, list[str]] = {
+    Task.RETRIEVAL: ["topically_relevant", "evidence_sufficient", "misleading"],
+    Task.GROUNDING: [
+        "support_present",
+        "unsupported_claim_present",
+        "contradicted_claim_present",
+        "source_cited",
+        "fabricated_source",
+    ],
+    Task.GENERATION: ["proper_action", "response_on_topic", "helpful", "incomplete", "unsafe_content"],
+}
+
+_TASK_CSV: dict[Task, str] = {
+    Task.RETRIEVAL: "retrieval_annotation_csv",
+    Task.GROUNDING: "grounding_annotation_csv",
+    Task.GENERATION: "generation_annotation_csv",
+}
+
+
+def _read_csv(path: Path) -> list[dict[str, str]]:
+    """Read a CSV file into a list of row dicts."""
+    with path.open(newline="", encoding="utf-8") as f:
+        return list(csv.DictReader(f))
+
+
+def _to_bool(value: str) -> bool:
+    return value.lower() == "true"
+
+
+def _pivot_label(rows: list[dict[str, str]], label: str) -> tuple[np.ndarray, list[str]]:
+    """Pivot long-format rows into a wide (annotators x items) matrix.
+
+    Returns:
+        Tuple of (data matrix with NaN for missing, sorted annotator IDs).
+    """
+    records: dict[str, dict[str, bool]] = {}
+    annotators: set[str] = set()
+    for row in rows:
+        rid = row["record_uuid"]
+        aid = row["annotator_id"]
+        annotators.add(aid)
+        records.setdefault(rid, {})[aid] = _to_bool(row[label])
+
+    ann_list = sorted(annotators)
+    item_list = sorted(records.keys())
+    ann_idx = {a: i for i, a in enumerate(ann_list)}
+
+    data = np.full((len(ann_list), len(item_list)), np.nan)
+    for j, rid in enumerate(item_list):
+        for aid, val in records[rid].items():
+            data[ann_idx[aid], j] = float(val)
+
+    return data, ann_list
+
+
+def _compute_pairwise_kappa(
+    rows: list[dict[str, str]], labels: list[str], annotators: list[str]
+) -> list[AnnotatorPair]:
+    """Compute mean Cohen's kappa across labels for each annotator pair."""
+    # Build per-record, per-annotator label vectors.
+    by_annotator: dict[str, dict[str, dict[str, bool]]] = {}
+    for row in rows:
+        aid = row["annotator_id"]
+        rid = row["record_uuid"]
+        by_annotator.setdefault(aid, {})[rid] = {lab: _to_bool(row[lab]) for lab in labels}
+
+    pairs: list[AnnotatorPair] = []
+    for a, b in combinations(annotators, 2):
+        shared = sorted(set(by_annotator.get(a, {})) & set(by_annotator.get(b, {})))
+        if not shared:
+            continue
+        kappas = []
+        for lab in labels:
+            arr_a = np.array([by_annotator[a][r][lab] for r in shared], dtype=np.int8)
+            arr_b = np.array([by_annotator[b][r][lab] for r in shared], dtype=np.int8)
+            k = cohen_kappa(arr_a, arr_b)
+            if not np.isnan(k):
+                kappas.append(k)
+        if not kappas:
+            continue
+        mean_kappa = float(np.mean(kappas))
+        pairs.append(AnnotatorPair(annotator_a=a, annotator_b=b, kappa=mean_kappa, n_shared_items=len(shared)))
+
+    return pairs
+
+
+def run_iaa(
+    export_paths: AnnotationExportPaths,
+    iaa_paths: IaaPaths,
+    tasks: list[Task],
+    *,
+    n_resamples: int = 1000,
+    ci: float = 0.95,
+    seed: int | None = None,
+) -> IaaReport:
+    """Run IAA analysis on exported annotation CSVs.
+
+    Args:
+        export_paths: Resolved export path bundle (CSVs must exist).
+        iaa_paths: Resolved IAA output path bundle.
+        tasks: Tasks to analyse.
+        n_resamples: Bootstrap iterations for confidence intervals.
+        ci: Confidence level for bootstrap CIs.
+        seed: Optional RNG seed for reproducible bootstrap.
+
+    Returns:
+        Populated IAA report, also written to ``iaa_paths.report``.
+    """
+    task_results: list[TaskAgreement] = []
+
+    for task in tasks:
+        csv_path: Path = getattr(export_paths, _TASK_CSV[task])
+        if not csv_path.exists():
+            logger.warning("Skipping %s: CSV not found at %s", task.value, csv_path)
+            continue
+
+        rows = _read_csv(csv_path)
+        if not rows:
+            logger.warning("Skipping %s: CSV is empty", task.value)
+            continue
+
+        labels = TASK_LABELS[task]
+        label_results: list[LabelAgreement] = []
+        all_annotators: list[str] = []
+
+        for label in labels:
+            data, annotators = _pivot_label(rows, label)
+            if not all_annotators:
+                all_annotators = annotators
+
+            alpha = krippendorff_alpha_nominal(data)
+            ci_lower, ci_upper = bootstrap_alpha(data, n_resamples=n_resamples, ci=ci, seed=seed)
+            pct = percentage_agreement(data)
+
+            # Count items with >= 2 annotations.
+            n_items = int(np.sum(np.sum(~np.isnan(data), axis=0) >= 2))
+
+            label_results.append(
+                LabelAgreement(
+                    label=label,
+                    alpha=None if math.isnan(alpha) else alpha,
+                    ci_lower=None if math.isnan(ci_lower) else ci_lower,
+                    ci_upper=None if math.isnan(ci_upper) else ci_upper,
+                    n_items=n_items,
+                    n_annotators=len(annotators),
+                    pct_agreement=None if math.isnan(pct) else pct,
+                )
+            )
+
+        pairwise = _compute_pairwise_kappa(rows, labels, all_annotators)
+        task_results.append(TaskAgreement(task=task, labels=label_results, pairwise_kappa=pairwise))
+        logger.info("IAA for %s: %d labels, %d annotator pairs", task.value, len(label_results), len(pairwise))
+
+    report = IaaReport(
+        export_id=export_paths.export_dir.name,
+        created_at=datetime.now(timezone.utc),
+        tasks=task_results,
+        n_bootstrap_resamples=n_resamples,
+        ci_level=ci,
+    )
+
+    iaa_paths.report.write_text(report.model_dump_json(indent=2), encoding="utf-8")
+    logger.info("IAA report written to %s", iaa_paths.report)
+
+    return report

--- a/tests/unit/core/annotation/test_iaa_runner.py
+++ b/tests/unit/core/annotation/test_iaa_runner.py
@@ -1,0 +1,186 @@
+"""Unit tests for the IAA runner (orchestration + report writing)."""
+
+import csv
+import json
+from pathlib import Path
+
+import pytest
+
+from pragmata.core.annotation.iaa_runner import TASK_LABELS, run_iaa
+from pragmata.core.paths.annotation_paths import (
+    AnnotationExportPaths,
+    IaaPaths,
+    resolve_iaa_paths,
+)
+from pragmata.core.schemas.annotation_task import Task
+from pragmata.core.schemas.iaa_report import IaaReport
+
+
+def _write_csv(path: Path, task: Task, rows: list[dict]) -> None:
+    """Write a minimal export CSV for a task."""
+    labels = TASK_LABELS[task]
+    fieldnames = ["record_uuid", "annotator_id", "task"] + labels + ["constraint_violated", "constraint_details"]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def _make_row(record_uuid: str, annotator_id: str, task: Task, label_values: dict[str, bool]) -> dict:
+    row: dict[str, str] = {
+        "record_uuid": record_uuid,
+        "annotator_id": annotator_id,
+        "task": task.value,
+        "constraint_violated": "false",
+        "constraint_details": "",
+    }
+    for label, val in label_values.items():
+        row[label] = "true" if val else "false"
+    return row
+
+
+@pytest.fixture()
+def export_dir(tmp_path: Path) -> AnnotationExportPaths:
+    export = tmp_path / "exports" / "test_export"
+    return AnnotationExportPaths(
+        export_dir=export,
+        tool_root=tmp_path,
+        retrieval_annotation_csv=export / "retrieval.csv",
+        grounding_annotation_csv=export / "grounding.csv",
+        generation_annotation_csv=export / "generation.csv",
+    )
+
+
+@pytest.fixture()
+def iaa_dir(export_dir: AnnotationExportPaths) -> IaaPaths:
+    return resolve_iaa_paths(export_paths=export_dir).ensure_dirs()
+
+
+class TestRunIaa:
+    """Tests for the IAA runner."""
+
+    def test_basic_retrieval_report(self, export_dir: AnnotationExportPaths, iaa_dir: IaaPaths):
+        labels = {
+            "topically_relevant": True,
+            "evidence_sufficient": True,
+            "misleading": False,
+        }
+        labels_b = {
+            "topically_relevant": True,
+            "evidence_sufficient": False,
+            "misleading": False,
+        }
+        rows = [
+            _make_row("r1", "ann1", Task.RETRIEVAL, labels),
+            _make_row("r1", "ann2", Task.RETRIEVAL, labels),
+            _make_row("r2", "ann1", Task.RETRIEVAL, labels),
+            _make_row("r2", "ann2", Task.RETRIEVAL, labels_b),
+            _make_row("r3", "ann1", Task.RETRIEVAL, labels_b),
+            _make_row("r3", "ann2", Task.RETRIEVAL, labels),
+        ]
+        _write_csv(export_dir.retrieval_annotation_csv, Task.RETRIEVAL, rows)
+
+        report = run_iaa(export_dir, iaa_dir, [Task.RETRIEVAL], n_resamples=50, seed=42)
+
+        assert len(report.tasks) == 1
+        task_result = report.tasks[0]
+        assert task_result.task == Task.RETRIEVAL
+        assert len(task_result.labels) == 3
+        assert all(la.n_items == 3 for la in task_result.labels)
+        assert all(la.n_annotators == 2 for la in task_result.labels)
+
+    def test_report_written_to_disk(self, export_dir: AnnotationExportPaths, iaa_dir: IaaPaths):
+        labels = {"topically_relevant": True, "evidence_sufficient": True, "misleading": False}
+        rows = [
+            _make_row("r1", "ann1", Task.RETRIEVAL, labels),
+            _make_row("r1", "ann2", Task.RETRIEVAL, labels),
+        ]
+        _write_csv(export_dir.retrieval_annotation_csv, Task.RETRIEVAL, rows)
+
+        run_iaa(export_dir, iaa_dir, [Task.RETRIEVAL], n_resamples=50, seed=42)
+
+        assert iaa_dir.report.exists()
+        data = json.loads(iaa_dir.report.read_text(encoding="utf-8"))
+        parsed = IaaReport.model_validate(data)
+        assert parsed.export_id == "test_export"
+
+    def test_pairwise_kappa_included(self, export_dir: AnnotationExportPaths, iaa_dir: IaaPaths):
+        labels_a = {"topically_relevant": True, "evidence_sufficient": True, "misleading": False}
+        labels_b = {"topically_relevant": False, "evidence_sufficient": True, "misleading": False}
+        rows = [
+            _make_row("r1", "ann1", Task.RETRIEVAL, labels_a),
+            _make_row("r1", "ann2", Task.RETRIEVAL, labels_a),
+            _make_row("r2", "ann1", Task.RETRIEVAL, labels_a),
+            _make_row("r2", "ann2", Task.RETRIEVAL, labels_b),
+            _make_row("r3", "ann1", Task.RETRIEVAL, labels_b),
+            _make_row("r3", "ann2", Task.RETRIEVAL, labels_a),
+        ]
+        _write_csv(export_dir.retrieval_annotation_csv, Task.RETRIEVAL, rows)
+
+        report = run_iaa(export_dir, iaa_dir, [Task.RETRIEVAL], n_resamples=50, seed=42)
+
+        pairs = report.tasks[0].pairwise_kappa
+        assert len(pairs) == 1
+        assert pairs[0].annotator_a == "ann1"
+        assert pairs[0].annotator_b == "ann2"
+        assert pairs[0].n_shared_items == 3
+
+    def test_missing_csv_skipped(self, export_dir: AnnotationExportPaths, iaa_dir: IaaPaths):
+        report = run_iaa(export_dir, iaa_dir, [Task.RETRIEVAL], n_resamples=50, seed=42)
+        assert len(report.tasks) == 0
+
+    def test_empty_csv_skipped(self, export_dir: AnnotationExportPaths, iaa_dir: IaaPaths):
+        _write_csv(export_dir.retrieval_annotation_csv, Task.RETRIEVAL, [])
+        report = run_iaa(export_dir, iaa_dir, [Task.RETRIEVAL], n_resamples=50, seed=42)
+        assert len(report.tasks) == 0
+
+    def test_multiple_tasks(self, export_dir: AnnotationExportPaths, iaa_dir: IaaPaths):
+        ret_labels = {"topically_relevant": True, "evidence_sufficient": True, "misleading": False}
+        gen_labels = {
+            "proper_action": True,
+            "response_on_topic": True,
+            "helpful": True,
+            "incomplete": False,
+            "unsafe_content": False,
+        }
+        _write_csv(
+            export_dir.retrieval_annotation_csv,
+            Task.RETRIEVAL,
+            [
+                _make_row("r1", "ann1", Task.RETRIEVAL, ret_labels),
+                _make_row("r1", "ann2", Task.RETRIEVAL, ret_labels),
+            ],
+        )
+        _write_csv(
+            export_dir.generation_annotation_csv,
+            Task.GENERATION,
+            [
+                _make_row("r1", "ann1", Task.GENERATION, gen_labels),
+                _make_row("r1", "ann2", Task.GENERATION, gen_labels),
+            ],
+        )
+
+        report = run_iaa(export_dir, iaa_dir, [Task.RETRIEVAL, Task.GENERATION], n_resamples=50, seed=42)
+        assert len(report.tasks) == 2
+        assert {t.task for t in report.tasks} == {Task.RETRIEVAL, Task.GENERATION}
+
+    def test_three_annotators(self, export_dir: AnnotationExportPaths, iaa_dir: IaaPaths):
+        labels = {"topically_relevant": True, "evidence_sufficient": True, "misleading": False}
+        labels_diff = {"topically_relevant": False, "evidence_sufficient": True, "misleading": False}
+        rows = [
+            _make_row("r1", "ann1", Task.RETRIEVAL, labels),
+            _make_row("r1", "ann2", Task.RETRIEVAL, labels),
+            _make_row("r1", "ann3", Task.RETRIEVAL, labels_diff),
+            _make_row("r2", "ann1", Task.RETRIEVAL, labels),
+            _make_row("r2", "ann2", Task.RETRIEVAL, labels_diff),
+            _make_row("r2", "ann3", Task.RETRIEVAL, labels),
+        ]
+        _write_csv(export_dir.retrieval_annotation_csv, Task.RETRIEVAL, rows)
+
+        report = run_iaa(export_dir, iaa_dir, [Task.RETRIEVAL], n_resamples=50, seed=42)
+
+        assert report.tasks[0].labels[0].n_annotators == 3
+        # 3 annotators -> 3 pairs
+        assert len(report.tasks[0].pairwise_kappa) == 3

--- a/uv.lock
+++ b/uv.lock
@@ -1766,6 +1766,7 @@ dependencies = [
 [package.optional-dependencies]
 annotation = [
     { name = "argilla" },
+    { name = "numpy" },
 ]
 anthropic = [
     { name = "langchain-anthropic" },
@@ -1779,6 +1780,7 @@ deepseek = [
 dev = [
     { name = "argilla" },
     { name = "mypy" },
+    { name = "numpy" },
     { name = "pytest" },
     { name = "ruff" },
     { name = "types-pyyaml" },
@@ -1813,6 +1815,7 @@ requires-dist = [
     { name = "langchain-mistralai" },
     { name = "langchain-openai", marker = "extra == 'openai'" },
     { name = "mypy", marker = "extra == 'type'", specifier = ">=1.19" },
+    { name = "numpy", marker = "extra == 'annotation'", specifier = ">=1.26" },
     { name = "pragmata", extras = ["test", "lint", "type", "annotation"], marker = "extra == 'dev'" },
     { name = "pydantic", specifier = ">=2.0,<3.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0" },


### PR DESCRIPTION
## Goal

Wire up the IAA computation layer (from #114) into the full pipeline: CSV reading, orchestration, API entrypoint, and public facade re-exports.

## Scope

- **Runner** (`core/annotation/iaa_runner.py`): Reads export CSVs, pivots to wide format per label, computes all metrics, writes structured JSON report. Includes `TASK_LABELS` mapping and pairwise kappa computation across annotator pairs.
- **API** (`api/annotation_iaa.py`): `compute_iaa()` entrypoint following existing settings resolution pattern (mirrors `export_annotations`).
- **Re-exports** (`annotation/__init__.py`): `compute_iaa` and `IaaReport` added to public facade.

## Implementation

- Runner handles missing/empty CSVs gracefully (skip with warning)
- NaN metrics converted to `None` before Pydantic serialisation
- Pairwise kappa pairs omitted when degenerate (not NaN)
- API resolves paths from `export_id`, verifies export exists

## Testing

- 7 unit tests for runner (report structure, disk write, missing/empty CSVs, multi-task, 3-annotator pairwise)
- Full suite: 426 passed

## References

- Depends on #114 (core metrics, schemas, path bundle)
- Design: `docs/design/annotation-e2e-flow.md` (QA step)

## Out of scope

- CLI command (dedicated phase)
- Drift monitoring / windowed alpha (deferred indefinitely)