### PR TITLE
feat: implement assembly layer for synthetic query generation output

### DIFF
--- a/src/pragmata/core/querygen/assembly.py
+++ b/src/pragmata/core/querygen/assembly.py
@@ -1,0 +1,90 @@
+"""Assembly of synthetic query generation output."""
+
+from datetime import UTC, datetime
+
+from pragmata.core.schemas.querygen_output import SyntheticQueriesMeta, SyntheticQueryRow
+from pragmata.core.schemas.querygen_plan import QueryBlueprint
+from pragmata.core.schemas.querygen_realize import RealizedQuery
+
+
+def _build_query_ids(
+    run_id: str,
+    n_queries: int,
+) -> list[str]:
+    """Build deterministic final query IDs for assembled synthetic queries.
+
+    Args:
+        run_id: Stable run identifier for the current synthetic-query run.
+        n_queries: Number of final query IDs to generate.
+
+    Returns:
+        Deterministically ordered final query IDs.
+    """
+    return [f"{run_id}_q{index}" for index in range(1, n_queries + 1)]
+
+
+def assemble_query_rows(
+    blueprints: list[QueryBlueprint],
+    realized_queries: list[RealizedQuery],
+    run_id: str,
+) -> list[SyntheticQueryRow]:
+    """Assemble final synthetic query rows from stage-1 blueprints and stage-2 realized queries.
+
+    Args:
+        blueprints: Selected post-deduplication stage-1 blueprints.
+        realized_queries: Filtered stage-2 realized queries.
+        run_id: Stable run identifier used for final query ID generation.
+
+    Returns:
+        Final assembled synthetic query rows, ordered by ``realized_queries``.
+    """
+    blueprint_by_candidate_id = {blueprint.candidate_id: blueprint for blueprint in blueprints}
+    query_ids = _build_query_ids(run_id=run_id, n_queries=len(realized_queries))
+
+    return [
+        SyntheticQueryRow(
+            query_id=query_id,
+            query=realized_query.query,
+            domain=blueprint_by_candidate_id[realized_query.candidate_id].domain,
+            role=blueprint_by_candidate_id[realized_query.candidate_id].role,
+            language=blueprint_by_candidate_id[realized_query.candidate_id].language,
+            topic=blueprint_by_candidate_id[realized_query.candidate_id].topic,
+            intent=blueprint_by_candidate_id[realized_query.candidate_id].intent,
+            task=blueprint_by_candidate_id[realized_query.candidate_id].task,
+            difficulty=blueprint_by_candidate_id[realized_query.candidate_id].difficulty,
+            format=blueprint_by_candidate_id[realized_query.candidate_id].format,
+        )
+        for query_id, realized_query in zip(query_ids, realized_queries, strict=True)
+    ]
+
+
+def assemble_queries_meta(
+    run_id: str,
+    n_requested_queries: int,
+    n_returned_queries: int,
+    model_provider: str,
+    planning_model: str,
+    realization_model: str,
+) -> SyntheticQueriesMeta:
+    """Assemble dataset-level metadata for a synthetic-query run.
+
+    Args:
+        run_id: Stable run identifier.
+        n_requested_queries: Number of queries requested for the run.
+        n_returned_queries: Number of final returned queries.
+        model_provider: Configured chat-model provider.
+        planning_model: Model identifier used for stage 1 planning.
+        realization_model: Model identifier used for stage 2 realization.
+
+    Returns:
+        Dataset-level metadata with internally stamped creation time.
+    """
+    return SyntheticQueriesMeta(
+        run_id=run_id,
+        created_at=datetime.now(UTC),
+        n_requested_queries=n_requested_queries,
+        n_returned_queries=n_returned_queries,
+        model_provider=model_provider,
+        planning_model=planning_model,
+        realization_model=realization_model,
+    )

--- a/src/pragmata/core/schemas/querygen_output.py
+++ b/src/pragmata/core/schemas/querygen_output.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, NonNegativeInt, PositiveInt
+from pydantic import BaseModel, ConfigDict, NonNegativeInt, PositiveInt, model_validator
 
 from pragmata.core.types import NonEmptyStr
 
@@ -36,3 +36,10 @@ class SyntheticQueriesMeta(BaseModel):
     model_provider: str
     planning_model: str
     realization_model: str
+
+    @model_validator(mode="after")
+    def validate_query_counts(self) -> "SyntheticQueriesMeta":
+        """Enforce logical consistency between requested and returned counts."""
+        if self.n_returned_queries > self.n_requested_queries:
+            raise ValueError("n_returned_queries must be less than or equal to n_requested_queries")
+        return self

--- a/src/pragmata/core/schemas/querygen_output.py
+++ b/src/pragmata/core/schemas/querygen_output.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, PositiveInt
+from pydantic import BaseModel, ConfigDict, NonNegativeInt, PositiveInt
 
 from pragmata.core.types import NonEmptyStr
 
@@ -31,7 +31,8 @@ class SyntheticQueriesMeta(BaseModel):
 
     run_id: str
     created_at: datetime
-    n_queries: PositiveInt
+    n_requested_queries: PositiveInt
+    n_returned_queries: NonNegativeInt
     model_provider: str
     planning_model: str
     realization_model: str

--- a/tests/unit/core/querygen/test_assembly.py
+++ b/tests/unit/core/querygen/test_assembly.py
@@ -1,0 +1,251 @@
+"""Unit tests for synthetic query output assembly."""
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from pragmata.core.querygen.assembly import (
+    _build_query_ids,
+    assemble_queries_meta,
+    assemble_query_rows,
+)
+from pragmata.core.schemas.querygen_plan import QueryBlueprint
+from pragmata.core.schemas.querygen_realize import RealizedQuery
+
+
+def _make_blueprint(
+    candidate_id: str,
+    *,
+    domain: str = "foundation publications",
+    role: str = "program officer",
+    language: str = "en",
+    topic: str = "education outcomes",
+    intent: str = "understand",
+    task: str = "summarize",
+    difficulty: str | None = None,
+    format: str | None = None,
+    user_scenario: str = "I am preparing for an internal briefing.",
+    information_need: str = "I need a concise overview of the main findings.",
+) -> QueryBlueprint:
+    """Build a valid QueryBlueprint for tests."""
+    return QueryBlueprint(
+        candidate_id=candidate_id,
+        domain=domain,
+        role=role,
+        language=language,
+        topic=topic,
+        intent=intent,
+        task=task,
+        difficulty=difficulty,
+        format=format,
+        user_scenario=user_scenario,
+        information_need=information_need,
+    )
+
+
+def _make_realized_query(
+    candidate_id: str,
+    query: str,
+) -> RealizedQuery:
+    """Build a valid RealizedQuery for tests."""
+    return RealizedQuery(
+        candidate_id=candidate_id,
+        query=query,
+    )
+
+
+def test_build_query_ids_returns_deterministic_run_scoped_ids() -> None:
+    """_build_query_ids should generate deterministic final query IDs."""
+    assert _build_query_ids(run_id="run123", n_queries=3) == [
+        "run123_q1",
+        "run123_q2",
+        "run123_q3",
+    ]
+
+
+def test_build_query_ids_returns_empty_list_for_zero_queries() -> None:
+    """_build_query_ids should return an empty list when no queries are requested."""
+    assert _build_query_ids(run_id="run123", n_queries=0) == []
+
+
+def test_assemble_query_rows_joins_realized_queries_to_blueprints() -> None:
+    """assemble_query_rows should join stage-2 queries to stage-1 metadata by candidate_id."""
+    blueprints = [
+        _make_blueprint(
+            "c001",
+            domain="foundation research",
+            role="research associate",
+            language="en",
+            topic="school climate",
+            intent="understand",
+            task="summarize",
+            difficulty="medium",
+            format="bullet list",
+        ),
+        _make_blueprint(
+            "c002",
+            domain="foundation strategy",
+            role="program manager",
+            language="de",
+            topic="youth participation",
+            intent="compare",
+            task="analyze",
+            difficulty=None,
+            format=None,
+        ),
+    ]
+    realized_queries = [
+        _make_realized_query(
+            "c001",
+            "Summarize the main findings on school climate as a bullet list.",
+        ),
+        _make_realized_query(
+            "c002",
+            "Vergleiche die wichtigsten Erkenntnisse zur Jugendbeteiligung.",
+        ),
+    ]
+
+    rows = assemble_query_rows(
+        blueprints=blueprints,
+        realized_queries=realized_queries,
+        run_id="run123",
+    )
+
+    assert [row.query_id for row in rows] == ["run123_q1", "run123_q2"]
+    assert [row.query for row in rows] == [
+        "Summarize the main findings on school climate as a bullet list.",
+        "Vergleiche die wichtigsten Erkenntnisse zur Jugendbeteiligung.",
+    ]
+
+    assert rows[0].model_dump(exclude={"query_id", "query"}) == {
+        "domain": "foundation research",
+        "role": "research associate",
+        "language": "en",
+        "topic": "school climate",
+        "intent": "understand",
+        "task": "summarize",
+        "difficulty": "medium",
+        "format": "bullet list",
+    }
+    assert rows[1].model_dump(exclude={"query_id", "query"}) == {
+        "domain": "foundation strategy",
+        "role": "program manager",
+        "language": "de",
+        "topic": "youth participation",
+        "intent": "compare",
+        "task": "analyze",
+        "difficulty": None,
+        "format": None,
+    }
+
+
+def test_assemble_query_rows_preserves_realized_query_order() -> None:
+    """assemble_query_rows should preserve the order of filtered stage-2 realized queries."""
+    blueprints = [
+        _make_blueprint("c001", topic="teacher retention"),
+        _make_blueprint("c002", topic="digital literacy"),
+    ]
+    realized_queries = [
+        _make_realized_query("c002", "Compare digital literacy interventions."),
+        _make_realized_query("c001", "What are the main issues in teacher retention?"),
+    ]
+
+    rows = assemble_query_rows(
+        blueprints=blueprints,
+        realized_queries=realized_queries,
+        run_id="run123",
+    )
+
+    assert [row.model_dump(include={"query_id", "query", "topic"}) for row in rows] == [
+        {
+            "query_id": "run123_q1",
+            "query": "Compare digital literacy interventions.",
+            "topic": "digital literacy",
+        },
+        {
+            "query_id": "run123_q2",
+            "query": "What are the main issues in teacher retention?",
+            "topic": "teacher retention",
+        },
+    ]
+
+
+def test_assemble_query_rows_returns_empty_list_for_empty_realized_queries() -> None:
+    """assemble_query_rows should return an empty list when no realized queries are present."""
+    blueprints = [_make_blueprint("c001")]
+
+    rows = assemble_query_rows(
+        blueprints=blueprints,
+        realized_queries=[],
+        run_id="run123",
+    )
+
+    assert rows == []
+
+
+def test_assemble_queries_meta_builds_dataset_level_metadata() -> None:
+    """assemble_queries_meta should construct validated dataset-level metadata."""
+    meta = assemble_queries_meta(
+        run_id="run123",
+        n_requested_queries=50,
+        n_returned_queries=37,
+        model_provider="mistralai",
+        planning_model="magistral-medium-latest",
+        realization_model="mistral-medium-latest",
+    )
+
+    assert meta.model_dump(exclude={"created_at"}) == {
+        "run_id": "run123",
+        "n_requested_queries": 50,
+        "n_returned_queries": 37,
+        "model_provider": "mistralai",
+        "planning_model": "magistral-medium-latest",
+        "realization_model": "mistral-medium-latest",
+    }
+    assert isinstance(meta.created_at, datetime)
+    assert meta.created_at.tzinfo == UTC
+
+
+def test_assemble_queries_meta_stamps_created_at_in_utc_now_range() -> None:
+    """assemble_queries_meta should stamp created_at internally at construction time."""
+    before = datetime.now(UTC)
+
+    meta = assemble_queries_meta(
+        run_id="run123",
+        n_requested_queries=10,
+        n_returned_queries=8,
+        model_provider="mistralai",
+        planning_model="plan-model",
+        realization_model="realize-model",
+    )
+
+    after = datetime.now(UTC)
+
+    assert before <= meta.created_at <= after
+
+
+def test_assemble_queries_meta_rejects_non_positive_requested_queries() -> None:
+    """assemble_queries_meta should surface schema validation for invalid requested counts."""
+    with pytest.raises(ValidationError):
+        assemble_queries_meta(
+            run_id="run123",
+            n_requested_queries=0,
+            n_returned_queries=0,
+            model_provider="mistralai",
+            planning_model="plan-model",
+            realization_model="realize-model",
+        )
+
+
+def test_assemble_queries_meta_rejects_negative_returned_queries() -> None:
+    """assemble_queries_meta should surface schema validation for invalid returned counts."""
+    with pytest.raises(ValidationError):
+        assemble_queries_meta(
+            run_id="run123",
+            n_requested_queries=10,
+            n_returned_queries=-1,
+            model_provider="mistralai",
+            planning_model="plan-model",
+            realization_model="realize-model",
+        )

--- a/tests/unit/core/schemas/test_querygen_output.py
+++ b/tests/unit/core/schemas/test_querygen_output.py
@@ -31,7 +31,8 @@ def valid_meta_payload() -> dict[str, object]:
     return {
         "run_id": "run_20260309_001",
         "created_at": "2026-03-09T10:30:00Z",
-        "n_queries": 25,
+        "n_requested_queries": 25,
+        "n_returned_queries": 21,
         "model_provider": "openai",
         "planning_model": "gpt-4.1-mini",
         "realization_model": "gpt-4.1-mini",
@@ -100,7 +101,8 @@ def test_synthetic_queries_meta_accepts_valid_payload(valid_meta_payload: dict[s
     meta = SyntheticQueriesMeta.model_validate(valid_meta_payload)
     assert meta.run_id == "run_20260309_001"
     assert meta.created_at == datetime(2026, 3, 9, 10, 30, tzinfo=timezone.utc)
-    assert meta.n_queries == 25
+    assert meta.n_requested_queries == 25
+    assert meta.n_returned_queries == 21
     assert meta.model_provider == "openai"
     assert meta.planning_model == "gpt-4.1-mini"
     assert meta.realization_model == "gpt-4.1-mini"
@@ -109,7 +111,17 @@ def test_synthetic_queries_meta_accepts_valid_payload(valid_meta_payload: dict[s
 def test_synthetic_queries_meta_rejects_non_positive_n_queries(valid_meta_payload: dict[str, object]) -> None:
     """n_queries must be strictly positive."""
     payload = dict(valid_meta_payload)
-    payload["n_queries"] = 0
+    payload["n_requested_queries"] = 0
+    with pytest.raises(ValidationError):
+        SyntheticQueriesMeta.model_validate(payload)
+
+
+def test_synthetic_queries_meta_rejects_negative_n_returned_queries(
+    valid_meta_payload: dict[str, object],
+) -> None:
+    """n_returned_queries must be non-negative."""
+    payload = dict(valid_meta_payload)
+    payload["n_returned_queries"] = -1
     with pytest.raises(ValidationError):
         SyntheticQueriesMeta.model_validate(payload)
 

--- a/tests/unit/core/schemas/test_querygen_output.py
+++ b/tests/unit/core/schemas/test_querygen_output.py
@@ -1,6 +1,6 @@
 """Unit tests for the synthetic query generation output contract."""
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 
 import pytest
 from pydantic import ValidationError
@@ -132,3 +132,29 @@ def test_synthetic_queries_meta_rejects_extra_keys(valid_meta_payload: dict[str,
     payload["unexpected"] = "boom"
     with pytest.raises(ValidationError):
         SyntheticQueriesMeta.model_validate(payload)
+
+    meta = SyntheticQueriesMeta(
+        run_id="run_123",
+        created_at=datetime.now(UTC),
+        n_requested_queries=5,
+        n_returned_queries=0,
+        model_provider="mistralai",
+        planning_model="magistral-medium-latest",
+        realization_model="mistral-medium-latest",
+    )
+
+    assert meta.n_requested_queries == 5
+    assert meta.n_returned_queries == 0
+
+
+def test_synthetic_queries_meta_rejects_returned_queries_above_requested() -> None:
+    with pytest.raises(ValidationError, match="n_returned_queries must be less than or equal to n_requested_queries"):
+        SyntheticQueriesMeta(
+            run_id="run_123",
+            created_at=datetime.now(UTC),
+            n_requested_queries=5,
+            n_returned_queries=6,
+            model_provider="mistralai",
+            planning_model="magistral-medium-latest",
+            realization_model="mistral-medium-latest",
+        )

--- a/tests/unit/core/schemas/test_querygen_output.py
+++ b/tests/unit/core/schemas/test_querygen_output.py
@@ -109,7 +109,7 @@ def test_synthetic_queries_meta_accepts_valid_payload(valid_meta_payload: dict[s
 
 
 def test_synthetic_queries_meta_rejects_non_positive_n_queries(valid_meta_payload: dict[str, object]) -> None:
-    """n_queries must be strictly positive."""
+    """n_requested_queries must be strictly positive."""
     payload = dict(valid_meta_payload)
     payload["n_requested_queries"] = 0
     with pytest.raises(ValidationError):


### PR DESCRIPTION
**Summary**

Implement the assembly layer for synthetic query generation output, including deterministic final query ID generation, assembly of export-ready synthetic query rows from stage-1 and stage-2 outputs, and run-level metadata construction.

**Key changes**

- Add `core/querygen/assembly.py`:
  - `_build_query_ids()` for deterministic final query ID generation from `run_id`
  - `assemble_query_rows()` for:
    - constructing final `SyntheticQueryRow` objects
    - assigning stable final `query_id`s
  - `assemble_queries_meta()` for constructing `SyntheticQueriesMeta`

- Update `core/schemas/querygen_output.py`:
  - replace `SyntheticQueriesMeta.n_queries` with:
    - `n_requested_queries`
    - `n_returned_queries`

- Add unit tests for assembly:
  - deterministic query ID generation
  - row assembly from blueprint/realized-query joins via `candidate_id`
  - preservation of realized-query order in final assembled rows
  - empty realized-query handling
  - dataset-level metadata construction and `created_at` stamping
  - schema validation surface for invalid requested/returned query counts

- Update output contract tests:
  - align metadata schema tests with `n_requested_queries` / `n_returned_queries`
  - cover valid zero-valued `n_returned_queries`
  - remove obsolete `n_queries` expectations

**Status**

Ready for review.

Closes #111