### PR TITLE
feat(annotation): replace workspace_prefix with dataset_id suffix

### DIFF
--- a/src/pragmata/api/annotation_export.py
+++ b/src/pragmata/api/annotation_export.py
@@ -23,7 +23,7 @@ def export_annotations(
     export_id: str | Unset = UNSET,
     base_dir: str | Path | Unset = UNSET,
     tasks: list[Task] | None = None,
-    workspace_prefix: str | Unset = UNSET,
+    dataset_id: str | Unset = UNSET,
     config_path: str | Path | Unset = UNSET,
 ) -> ExportResult:
     """Fetch submitted annotations from Argilla and write flat CSVs per task.
@@ -39,10 +39,10 @@ def export_annotations(
         api_url: Argilla server URL.
         api_key: Argilla API key.
         export_id: Unique identifier for this export run. Auto-generated from
-            prefix + ISO timestamp if not supplied.
+            dataset_id + ISO timestamp if not supplied.
         base_dir: Workspace base directory for run artifacts. Defaults to cwd.
         tasks: Tasks to export. Defaults to all three tasks.
-        workspace_prefix: Prefix used when the environment was created.
+        dataset_id: Suffix identifying which datasets to export from.
         config_path: Path to YAML config file for settings resolution.
 
     Returns:
@@ -53,7 +53,7 @@ def export_annotations(
         env={"argilla": {"api_url": os.environ.get("ARGILLA_API_URL")}} if os.environ.get("ARGILLA_API_URL") else None,
         overrides={
             "argilla": {"api_url": api_url},
-            "workspace_prefix": workspace_prefix,
+            "dataset_id": dataset_id,
             "base_dir": base_dir,
         },
     )

--- a/src/pragmata/api/annotation_iaa.py
+++ b/src/pragmata/api/annotation_iaa.py
@@ -21,7 +21,6 @@ def compute_iaa(
     *,
     base_dir: str | Path | Unset = UNSET,
     tasks: list[Task] | None = None,
-    workspace_prefix: str | Unset = UNSET,
     n_resamples: int = 1000,
     ci: float = 0.95,
     seed: int | None = None,
@@ -40,7 +39,6 @@ def compute_iaa(
         export_id: Identifier of a previous export run whose CSVs to analyse.
         base_dir: Workspace base directory. Defaults to cwd.
         tasks: Tasks to analyse. Defaults to all three tasks.
-        workspace_prefix: Prefix used when the environment was created.
         n_resamples: Number of bootstrap iterations for CIs.
         ci: Confidence level (e.g. 0.95 for 95% CI).
         seed: Optional RNG seed for reproducible bootstrap.
@@ -54,7 +52,7 @@ def compute_iaa(
     """
     settings = AnnotationSettings.resolve(
         config=load_config_file(config_path) if isinstance(config_path, (str, Path)) else None,
-        overrides={"workspace_prefix": workspace_prefix, "base_dir": base_dir},
+        overrides={"base_dir": base_dir},
     )
     workspace = WorkspacePaths.from_base_dir(settings.base_dir)
     export_paths = resolve_export_paths(workspace=workspace, export_id=export_id)

--- a/src/pragmata/api/annotation_import.py
+++ b/src/pragmata/api/annotation_import.py
@@ -42,7 +42,7 @@ def import_records(
     api_url: str | Unset = UNSET,
     api_key: str | Unset = UNSET,
     format: str = "auto",
-    workspace_prefix: str | Unset = UNSET,
+    dataset_id: str | Unset = UNSET,
     base_dir: str | Path | Unset = UNSET,
     config_path: str | Path | Unset = UNSET,
 ) -> ImportResult:
@@ -58,8 +58,9 @@ def import_records(
     failures are collected in ImportResult.errors — invalid records are
     skipped, not raised.
 
-    Record IDs are derived from content hashes for idempotent upsert.
-    Datasets must already exist (call setup() first).
+    Datasets are auto-created if they don't exist. Workspaces must already
+    exist (call setup() first). Record IDs are derived from content hashes
+    for idempotent upsert.
 
     Credential resolution:
     - ``api_url``: kwarg > ``ARGILLA_API_URL`` env > config (``argilla.api_url``)
@@ -72,7 +73,7 @@ def import_records(
         api_key: Argilla API key.
         format: File format override — 'auto' (default), 'json', 'jsonl',
             or 'csv'. Only used for str/Path inputs.
-        workspace_prefix: Prefix used when the environment was created.
+        dataset_id: Suffix appended to dataset names for run scoping.
         base_dir: Workspace base directory. Defaults to cwd.
         config_path: Path to YAML config file for settings resolution.
 
@@ -85,7 +86,7 @@ def import_records(
         env={"argilla": {"api_url": os.environ.get("ARGILLA_API_URL")}} if os.environ.get("ARGILLA_API_URL") else None,
         overrides={
             "argilla": {"api_url": api_url},
-            "workspace_prefix": workspace_prefix,
+            "dataset_id": dataset_id,
             "base_dir": base_dir,
         },
     )

--- a/src/pragmata/api/annotation_setup.py
+++ b/src/pragmata/api/annotation_setup.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from pragmata.api._error_log import error_log
 from pragmata.core.annotation.client import resolve_argilla_client
-from pragmata.core.annotation.setup import SetupResult, provision_users, setup_datasets, teardown_resources
+from pragmata.core.annotation.setup import SetupResult, provision_users, setup_workspaces, teardown_resources
 from pragmata.core.paths.annotation_paths import resolve_annotation_paths
 from pragmata.core.paths.paths import WorkspacePaths
 from pragmata.core.settings.annotation_settings import AnnotationSettings, UserSpec
@@ -20,16 +20,18 @@ def setup(
     *,
     api_url: str | Unset = UNSET,
     api_key: str | Unset = UNSET,
-    workspace_prefix: str | Unset = UNSET,
     min_submitted: int | Unset = UNSET,
     base_dir: str | Path | Unset = UNSET,
     config_path: str | Path | Unset = UNSET,
 ) -> SetupResult:
-    """Create the full Argilla annotation environment idempotently.
+    """Create the Argilla annotation environment idempotently.
 
-    Creates workspaces and datasets for all three annotation tasks (retrieval,
-    grounding, generation). Optionally provisions user accounts and assigns
-    them to workspaces. Existing resources are skipped.
+    Creates workspaces for all three annotation tasks (retrieval, grounding,
+    generation). Optionally provisions user accounts and assigns them to
+    workspaces. Existing resources are skipped.
+
+    Datasets are not created here — they are auto-created on import,
+    scoped by dataset_id.
 
     Settings are resolved from config file and/or keyword overrides. Omitted
     values fall through to config-file defaults, then built-in defaults.
@@ -42,20 +44,18 @@ def setup(
         users: User accounts to provision. Pass None to skip user setup.
         api_url: Argilla server URL.
         api_key: Argilla API key.
-        workspace_prefix: Prefix prepended to workspace and dataset names.
         min_submitted: Minimum annotations required per record.
         base_dir: Workspace base directory. Defaults to cwd.
         config_path: Path to YAML config file for settings resolution.
 
     Returns:
-        SetupResult tracking created/skipped workspaces, datasets, and users.
+        SetupResult tracking created/skipped workspaces and users.
     """
     settings = AnnotationSettings.resolve(
         config=load_config_file(config_path) if isinstance(config_path, (str, Path)) else None,
         env={"argilla": {"api_url": os.environ.get("ARGILLA_API_URL")}} if os.environ.get("ARGILLA_API_URL") else None,
         overrides={
             "argilla": {"api_url": api_url},
-            "workspace_prefix": workspace_prefix,
             "min_submitted": min_submitted,
             "base_dir": base_dir,
         },
@@ -65,13 +65,12 @@ def setup(
     workspace = WorkspacePaths.from_base_dir(settings.base_dir)
     paths = resolve_annotation_paths(workspace=workspace).ensure_dirs()
     with error_log(paths.tool_root):
-        ds_result = setup_datasets(client, settings)
+        ws_result = setup_workspaces(client, settings)
         user_result = provision_users(client, users or [], settings)
-    merged = ds_result.merge(user_result)
+    merged = ws_result.merge(user_result)
     logger.info(
-        "Setup complete: %d workspaces, %d datasets, %d users created",
+        "Setup complete: %d workspaces, %d users created",
         len(merged.created_workspaces),
-        len(merged.created_datasets),
         len(merged.created_users),
     )
     return merged
@@ -81,11 +80,15 @@ def teardown(
     *,
     api_url: str | Unset = UNSET,
     api_key: str | Unset = UNSET,
-    workspace_prefix: str | Unset = UNSET,
+    dataset_id: str | Unset = UNSET,
     base_dir: str | Path | Unset = UNSET,
     config_path: str | Path | Unset = UNSET,
 ) -> None:
     """Remove the Argilla annotation environment.
+
+    When dataset_id is set, only datasets matching that suffix are deleted
+    and workspaces are left intact. When dataset_id is empty, all default
+    datasets and workspaces are deleted.
 
     Deletes datasets first (Argilla requires empty workspaces), then
     workspaces. Missing resources are silently skipped. User accounts
@@ -98,7 +101,7 @@ def teardown(
     Args:
         api_url: Argilla server URL.
         api_key: Argilla API key.
-        workspace_prefix: Prefix used when the environment was created.
+        dataset_id: Suffix identifying which datasets to delete.
         base_dir: Workspace base directory. Defaults to cwd.
         config_path: Path to YAML config file for settings resolution.
     """
@@ -107,7 +110,7 @@ def teardown(
         env={"argilla": {"api_url": os.environ.get("ARGILLA_API_URL")}} if os.environ.get("ARGILLA_API_URL") else None,
         overrides={
             "argilla": {"api_url": api_url},
-            "workspace_prefix": workspace_prefix,
+            "dataset_id": dataset_id,
             "base_dir": base_dir,
         },
     )
@@ -115,7 +118,7 @@ def teardown(
     client = resolve_argilla_client(settings.argilla.api_url, api_key)
     workspace = WorkspacePaths.from_base_dir(settings.base_dir)
     paths = resolve_annotation_paths(workspace=workspace).ensure_dirs()
-    logger.info("Starting teardown (prefix=%r)", settings.workspace_prefix)
+    logger.info("Starting teardown (dataset_id=%r)", settings.dataset_id)
     with error_log(paths.tool_root):
         teardown_resources(client, settings)
     logger.info("Teardown complete")

--- a/src/pragmata/api/annotation_setup.py
+++ b/src/pragmata/api/annotation_setup.py
@@ -86,13 +86,8 @@ def teardown(
 ) -> None:
     """Remove the Argilla annotation environment.
 
-    When dataset_id is set, only datasets matching that suffix are deleted
-    and workspaces are left intact. When dataset_id is empty, all default
-    datasets and workspaces are deleted.
-
-    Deletes datasets first (Argilla requires empty workspaces), then
-    workspaces. Missing resources are silently skipped. User accounts
-    are not touched.
+    See :func:`pragmata.core.annotation.setup.teardown_resources` for deletion
+    semantics (dataset_id scoping, ordering, idempotency).
 
     Credential resolution:
     - ``api_url``: kwarg > ``ARGILLA_API_URL`` env > config (``argilla.api_url``)
@@ -101,7 +96,8 @@ def teardown(
     Args:
         api_url: Argilla server URL.
         api_key: Argilla API key.
-        dataset_id: Suffix identifying which datasets to delete.
+        dataset_id: Suffix identifying which datasets to delete. Empty tears
+            down workspaces too.
         base_dir: Workspace base directory. Defaults to cwd.
         config_path: Path to YAML config file for settings resolution.
     """

--- a/src/pragmata/cli/commands/annotation.py
+++ b/src/pragmata/cli/commands/annotation.py
@@ -9,8 +9,8 @@ annotation_app = typer.Typer(help="Annotation pipeline commands.")
 
 _api_url_opt = typer.Option(None, "--api-url", help="Argilla server URL. Falls back to ARGILLA_API_URL env var.")
 _api_key_opt = typer.Option(None, "--api-key", help="Argilla API key. Falls back to ARGILLA_API_KEY env var.")
-_prefix_opt = typer.Option(
-    None, "--prefix", help="Prefix prepended to workspace and dataset names. Defaults to config file value or ''."
+_dataset_id_opt = typer.Option(
+    None, "--dataset-id", help="Suffix appended to dataset names for run scoping (e.g. 'run1')."
 )
 _base_dir_opt = typer.Option(
     None, "--base-dir", help="Workspace base directory for run artifacts. Defaults to current working directory."
@@ -22,7 +22,6 @@ _config_opt = typer.Option(None, "--config", help="Path to YAML config file for 
 def setup_command(
     api_url: str | None = _api_url_opt,
     api_key: str | None = _api_key_opt,
-    prefix: str | None = _prefix_opt,
     base_dir: str | None = _base_dir_opt,
     config: str | None = _config_opt,
     min_submitted: int | None = typer.Option(
@@ -35,20 +34,21 @@ def setup_command(
         " 'workspaces' and 'password' are optional.",
     ),
 ) -> None:
-    """Create Argilla workspaces, datasets, and (optionally) user accounts."""
+    """Create Argilla workspaces and (optionally) user accounts.
+
+    Datasets are created automatically on import, not here.
+    """
     from pragmata import annotation
 
     result = annotation.setup(
         parse_user_specs(users_json),
         api_url=UNSET if api_url is None else api_url,
         api_key=UNSET if api_key is None else api_key,
-        workspace_prefix=UNSET if prefix is None else prefix,
         min_submitted=UNSET if min_submitted is None else min_submitted,
         base_dir=UNSET if base_dir is None else base_dir,
         config_path=UNSET if config is None else config,
     )
     typer.echo(f"Workspaces created: {len(result.created_workspaces)}, skipped: {len(result.skipped_workspaces)}")
-    typer.echo(f"Datasets created: {len(result.created_datasets)}, skipped: {len(result.skipped_datasets)}")
     typer.echo(f"Users created: {len(result.created_users)}, skipped: {len(result.skipped_users)}")
 
 
@@ -56,17 +56,21 @@ def setup_command(
 def teardown_command(
     api_url: str | None = _api_url_opt,
     api_key: str | None = _api_key_opt,
-    prefix: str | None = _prefix_opt,
+    dataset_id: str | None = _dataset_id_opt,
     base_dir: str | None = _base_dir_opt,
     config: str | None = _config_opt,
 ) -> None:
-    """Remove Argilla workspaces and datasets."""
+    """Remove Argilla datasets and (optionally) workspaces.
+
+    With --dataset-id, only datasets matching that suffix are deleted.
+    Without it, all default datasets and workspaces are removed.
+    """
     from pragmata import annotation
 
     annotation.teardown(
         api_url=UNSET if api_url is None else api_url,
         api_key=UNSET if api_key is None else api_key,
-        workspace_prefix=UNSET if prefix is None else prefix,
+        dataset_id=UNSET if dataset_id is None else dataset_id,
         base_dir=UNSET if base_dir is None else base_dir,
         config_path=UNSET if config is None else config,
     )
@@ -78,14 +82,17 @@ def import_command(
     records: str = typer.Argument(..., help="Path to records file (JSON, JSONL, or CSV)."),
     api_url: str | None = _api_url_opt,
     api_key: str | None = _api_key_opt,
-    prefix: str | None = _prefix_opt,
+    dataset_id: str | None = _dataset_id_opt,
     base_dir: str | None = _base_dir_opt,
     config: str | None = _config_opt,
     format: str | None = typer.Option(
         None, "--format", help="File format override (json, jsonl, csv). Auto-detected by default."
     ),
 ) -> None:
-    """Validate and import records into annotation datasets."""
+    """Validate and import records into annotation datasets.
+
+    Datasets are auto-created if they don't exist.
+    """
     from pragmata import annotation
 
     result = annotation.import_records(
@@ -93,7 +100,7 @@ def import_command(
         api_url=UNSET if api_url is None else api_url,
         api_key=UNSET if api_key is None else api_key,
         format=format or "auto",
-        workspace_prefix=UNSET if prefix is None else prefix,
+        dataset_id=UNSET if dataset_id is None else dataset_id,
         base_dir=UNSET if base_dir is None else base_dir,
         config_path=UNSET if config is None else config,
     )
@@ -109,7 +116,7 @@ def import_command(
 def export_command(
     api_url: str | None = _api_url_opt,
     api_key: str | None = _api_key_opt,
-    prefix: str | None = _prefix_opt,
+    dataset_id: str | None = _dataset_id_opt,
     base_dir: str | None = _base_dir_opt,
     config: str | None = _config_opt,
     export_id: str | None = typer.Option(None, "--export-id", help="Export run identifier. Auto-generated if omitted."),
@@ -126,7 +133,7 @@ def export_command(
         export_id=UNSET if export_id is None else export_id,
         base_dir=UNSET if base_dir is None else base_dir,
         tasks=parse_tasks(tasks),
-        workspace_prefix=UNSET if prefix is None else prefix,
+        dataset_id=UNSET if dataset_id is None else dataset_id,
         config_path=UNSET if config is None else config,
     )
     for task_name, count in result.row_counts.items():
@@ -140,7 +147,6 @@ def iaa_command(
     export_id: str = typer.Argument(..., help="Export run identifier whose CSVs to analyse."),
     base_dir: str | None = _base_dir_opt,
     config: str | None = _config_opt,
-    prefix: str | None = _prefix_opt,
     tasks: str | None = typer.Option(
         None, "--tasks", help="Comma-separated tasks to analyse (retrieval,grounding,generation)."
     ),
@@ -155,7 +161,6 @@ def iaa_command(
         export_id,
         base_dir=UNSET if base_dir is None else base_dir,
         tasks=parse_tasks(tasks),
-        workspace_prefix=UNSET if prefix is None else prefix,
         n_resamples=n_resamples,
         ci=ci,
         seed=seed,

--- a/src/pragmata/core/annotation/argilla_ops.py
+++ b/src/pragmata/core/annotation/argilla_ops.py
@@ -13,9 +13,9 @@ logger = logging.getLogger(__name__)
 _PASSWORD_CHARS = string.ascii_letters + string.digits + "!@#$%"
 
 
-def apply_prefix(prefix: str, name: str) -> str:
-    """Prepend prefix with underscore separator; return name unchanged if prefix is empty."""
-    return f"{prefix}_{name}" if prefix else name
+def apply_suffix(name: str, suffix: str) -> str:
+    """Append suffix with underscore separator; return name unchanged if suffix is empty."""
+    return f"{name}_{suffix}" if suffix else name
 
 
 def generate_password(length: int = 16) -> str:

--- a/src/pragmata/core/annotation/argilla_task_definitions.py
+++ b/src/pragmata/core/annotation/argilla_task_definitions.py
@@ -19,9 +19,9 @@ import argilla as rg
 from pragmata.core.schemas.annotation_task import Task
 
 DATASET_NAMES: dict[Task, str] = {
-    Task.RETRIEVAL: "task_retrieval",
-    Task.GROUNDING: "task_grounding",
-    Task.GENERATION: "task_generation",
+    Task.RETRIEVAL: "retrieval",
+    Task.GROUNDING: "grounding",
+    Task.GENERATION: "generation",
 }
 
 

--- a/src/pragmata/core/annotation/export_fetcher.py
+++ b/src/pragmata/core/annotation/export_fetcher.py
@@ -10,7 +10,7 @@ from uuid import UUID
 
 import argilla as rg
 
-from pragmata.core.annotation.argilla_ops import apply_prefix
+from pragmata.core.annotation.argilla_ops import apply_suffix
 from pragmata.core.annotation.argilla_task_definitions import DATASET_NAMES
 from pragmata.core.annotation.constraints import CONSTRAINT_CHECKERS
 from pragmata.core.schemas.annotation_export import (
@@ -95,12 +95,12 @@ def fetch_task(
     user_lookup: dict[UUID, str],
 ) -> list[tuple[AnnotationModel, list[str]]]:
     """Fetch submitted records for a task, build typed rows with constraint violations."""
-    dataset_name = apply_prefix(settings.workspace_prefix, DATASET_NAMES[task])
+    dataset_name = apply_suffix(DATASET_NAMES[task], settings.dataset_id)
 
     workspace_name: str | None = None
     for ws_base, tasks in settings.workspace_dataset_map.items():
         if task in tasks:
-            workspace_name = apply_prefix(settings.workspace_prefix, ws_base)
+            workspace_name = ws_base
             break
 
     dataset = client.datasets(dataset_name, workspace=workspace_name)

--- a/src/pragmata/core/annotation/export_runner.py
+++ b/src/pragmata/core/annotation/export_runner.py
@@ -151,9 +151,9 @@ def run_export(
 
 
 def resolve_export_id(settings: "AnnotationSettings", export_id: str | None) -> str:
-    """Derive a run identifier from an explicit value or generate one from prefix + timestamp."""
+    """Derive a run identifier from an explicit value or generate one from dataset_id + timestamp."""
     if export_id is not None:
         return export_id
     ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%S")
-    prefix = settings.workspace_prefix
-    return f"{prefix}_{ts}" if prefix else ts
+    dataset_id = settings.dataset_id
+    return f"{dataset_id}_{ts}" if dataset_id else ts

--- a/src/pragmata/core/annotation/record_builder.py
+++ b/src/pragmata/core/annotation/record_builder.py
@@ -13,8 +13,8 @@ from typing import Any
 import argilla as rg
 from argilla.records._dataset_records import RecordErrorHandling  # no public re-export in argilla v2; pinned to ==2.6.0
 
-from pragmata.core.annotation.argilla_ops import apply_prefix
-from pragmata.core.annotation.argilla_task_definitions import DATASET_NAMES
+from pragmata.core.annotation.argilla_ops import apply_suffix, create_dataset
+from pragmata.core.annotation.argilla_task_definitions import DATASET_NAMES, build_task_settings
 from pragmata.core.schemas.annotation_import import QueryResponsePair
 from pragmata.core.schemas.annotation_task import Task
 from pragmata.core.settings.annotation_settings import AnnotationSettings
@@ -162,11 +162,14 @@ def fan_out_records(
 ) -> dict[str, int]:
     """Build and log Argilla records to all three datasets.
 
+    Datasets are created on-the-fly if they don't exist (idempotent).
+    Workspaces must already exist (call setup() first).
+
     Returns counts of records submitted per dataset (not confirmed — individual
     record failures are logged as warnings by Argilla but not reflected in counts).
     """
-    prefix = settings.workspace_prefix
     task_to_ws = _invert_workspace_map(settings.workspace_dataset_map)
+    task_settings_map = build_task_settings()
     batches = _build_batches(records)
 
     dataset_counts: dict[str, int] = {}
@@ -179,12 +182,23 @@ def fan_out_records(
             logger.warning("Task %r not in workspace_dataset_map — skipping", task)
             continue
 
-        ws_name = apply_prefix(prefix, ws_base)
-        ds_name = apply_prefix(prefix, DATASET_NAMES[task])
+        ds_name = apply_suffix(DATASET_NAMES[task], settings.dataset_id)
 
-        dataset = client.datasets(ds_name, workspace=ws_name)
-        if dataset is None:
-            raise RuntimeError(f"Dataset {ds_name!r} in workspace {ws_name!r} not found. Run setup() first.")
+        workspace = client.workspaces(ws_base)
+        if workspace is None:
+            raise RuntimeError(f"Workspace {ws_base!r} not found. Run setup() first.")
+
+        base_settings = task_settings_map[task]
+        task_cfg = rg.Settings(
+            fields=base_settings.fields,
+            questions=base_settings.questions,
+            metadata=base_settings.metadata,
+            guidelines=base_settings.guidelines,
+            distribution=rg.TaskDistribution(min_submitted=settings.min_submitted),
+        )
+        dataset, ds_created = create_dataset(client, ds_name, ws_base, task_cfg)
+        if ds_created:
+            logger.info("Auto-created dataset %r in workspace %r", ds_name, ws_base)
 
         dataset.records.log(rg_records, on_error=RecordErrorHandling.WARN)
         dataset_counts[ds_name] = len(rg_records)

--- a/src/pragmata/core/annotation/setup.py
+++ b/src/pragmata/core/annotation/setup.py
@@ -110,5 +110,7 @@ def teardown_resources(
                 logger.info("Deleted dataset %r from workspace %r", ds_name, ws_base)
 
         if not settings.dataset_id:
+            for user in list(workspace.users):
+                workspace.remove_user(user)
             workspace.delete()
             logger.info("Deleted workspace %r", ws_base)

--- a/src/pragmata/core/annotation/setup.py
+++ b/src/pragmata/core/annotation/setup.py
@@ -1,4 +1,4 @@
-"""Annotation setup implementation — workspace, dataset, and user provisioning.
+"""Annotation setup implementation — workspace and user provisioning.
 
 All Argilla SDK interaction for setup/teardown lives here. The api/ layer
 resolves settings and delegates to these functions.
@@ -9,8 +9,8 @@ from dataclasses import dataclass, field
 
 import argilla as rg
 
-from pragmata.core.annotation.argilla_ops import apply_prefix, create_dataset, create_user, create_workspace
-from pragmata.core.annotation.argilla_task_definitions import DATASET_NAMES, build_task_settings
+from pragmata.core.annotation.argilla_ops import apply_suffix, create_user, create_workspace
+from pragmata.core.annotation.argilla_task_definitions import DATASET_NAMES
 from pragmata.core.settings.annotation_settings import AnnotationSettings, UserSpec
 
 logger = logging.getLogger(__name__)
@@ -23,8 +23,6 @@ class SetupResult:
     Attributes:
         created_workspaces: Names of newly created workspaces.
         skipped_workspaces: Names of workspaces that already existed.
-        created_datasets: Names of newly created datasets.
-        skipped_datasets: Names of datasets that already existed.
         created_users: Usernames of newly created accounts.
         skipped_users: Usernames of accounts that already existed.
         generated_passwords: Mapping of username to auto-generated password
@@ -34,54 +32,30 @@ class SetupResult:
 
     created_workspaces: list[str] = field(default_factory=list)
     skipped_workspaces: list[str] = field(default_factory=list)
-    created_datasets: list[str] = field(default_factory=list)
-    skipped_datasets: list[str] = field(default_factory=list)
     created_users: list[str] = field(default_factory=list)
     skipped_users: list[str] = field(default_factory=list)
     generated_passwords: dict[str, str] = field(default_factory=dict)
 
     def merge(self, other: "SetupResult") -> "SetupResult":
-        """Combine two results (e.g. dataset setup + user provisioning)."""
+        """Combine two results (e.g. workspace setup + user provisioning)."""
         return SetupResult(
             created_workspaces=self.created_workspaces + other.created_workspaces,
             skipped_workspaces=self.skipped_workspaces + other.skipped_workspaces,
-            created_datasets=self.created_datasets + other.created_datasets,
-            skipped_datasets=self.skipped_datasets + other.skipped_datasets,
             created_users=self.created_users + other.created_users,
             skipped_users=self.skipped_users + other.skipped_users,
             generated_passwords={**self.generated_passwords, **other.generated_passwords},
         )
 
 
-def setup_datasets(
+def setup_workspaces(
     client: rg.Argilla,
     settings: AnnotationSettings,
 ) -> SetupResult:
-    """Create all workspaces and datasets idempotently per settings topology."""
+    """Create all workspaces idempotently per settings topology."""
     result = SetupResult()
-    task_settings_map = build_task_settings()
-
-    for ws_base, tasks in settings.workspace_dataset_map.items():
-        ws_name = apply_prefix(settings.workspace_prefix, ws_base)
-        workspace, created = create_workspace(client, ws_name)
-        (result.created_workspaces if created else result.skipped_workspaces).append(ws_name)
-
-        for task in tasks:
-            ds_base = DATASET_NAMES[task]
-            ds_name = apply_prefix(settings.workspace_prefix, ds_base)
-            base_settings = task_settings_map[task]
-
-            # Never mutate the cached constant — construct fresh Settings
-            task_settings = rg.Settings(
-                fields=base_settings.fields,
-                questions=base_settings.questions,
-                metadata=base_settings.metadata,
-                guidelines=base_settings.guidelines,
-                distribution=rg.TaskDistribution(min_submitted=settings.min_submitted),
-            )
-            _, ds_created = create_dataset(client, ds_name, ws_name, task_settings)
-            (result.created_datasets if ds_created else result.skipped_datasets).append(ds_name)
-
+    for ws_base in settings.workspace_dataset_map:
+        workspace, created = create_workspace(client, ws_base)
+        (result.created_workspaces if created else result.skipped_workspaces).append(ws_base)
     return result
 
 
@@ -100,10 +74,9 @@ def provision_users(
             result.generated_passwords[spec.username] = generated_pw
 
         for ws_base in spec.workspaces:
-            ws_name = apply_prefix(settings.workspace_prefix, ws_base)
-            workspace = client.workspaces(ws_name)
+            workspace = client.workspaces(ws_base)
             if workspace is None:
-                logger.warning("Workspace %r not found when assigning user %r", ws_name, spec.username)
+                logger.warning("Workspace %r not found when assigning user %r", ws_base, spec.username)
             elif user not in workspace.users:
                 workspace.add_user(user)
 
@@ -114,25 +87,28 @@ def teardown_resources(
     client: rg.Argilla,
     settings: AnnotationSettings,
 ) -> None:
-    """Delete datasets and workspaces for the annotation environment.
+    """Delete datasets and (optionally) workspaces for the annotation environment.
+
+    When dataset_id is set, only datasets matching that suffix are deleted and
+    workspaces are left intact. When dataset_id is empty, all default datasets
+    and workspaces are deleted.
 
     Ordering: datasets first (Argilla requires workspace to be empty before deletion).
     Missing resources are silently skipped. User accounts are not touched.
     """
     for ws_base, tasks in settings.workspace_dataset_map.items():
-        ws_name = apply_prefix(settings.workspace_prefix, ws_base)
-        workspace = client.workspaces(ws_name)
+        workspace = client.workspaces(ws_base)
         if workspace is None:
-            logger.info("Workspace %r not found — skipping", ws_name)
+            logger.info("Workspace %r not found — skipping", ws_base)
             continue
 
         for task in tasks:
-            ds_base = DATASET_NAMES[task]
-            ds_name = apply_prefix(settings.workspace_prefix, ds_base)
-            dataset = client.datasets(ds_name, workspace=ws_name)
+            ds_name = apply_suffix(DATASET_NAMES[task], settings.dataset_id)
+            dataset = client.datasets(ds_name, workspace=ws_base)
             if dataset is not None:
                 dataset.delete()
-                logger.info("Deleted dataset %r from workspace %r", ds_name, ws_name)
+                logger.info("Deleted dataset %r from workspace %r", ds_name, ws_base)
 
-        workspace.delete()
-        logger.info("Deleted workspace %r", ws_name)
+        if not settings.dataset_id:
+            workspace.delete()
+            logger.info("Deleted workspace %r", ws_base)

--- a/src/pragmata/core/settings/annotation_settings.py
+++ b/src/pragmata/core/settings/annotation_settings.py
@@ -28,7 +28,7 @@ class AnnotationSettings(ResolveSettings):
 
     argilla: ArgillaSettings = Field(default_factory=ArgillaSettings)
     base_dir: Path = Field(default_factory=Path.cwd)
-    workspace_prefix: str = ""
+    dataset_id: str = ""
     workspace_dataset_map: dict[str, list[Task]] = Field(
         default_factory=lambda: {
             "retrieval": [Task.RETRIEVAL],

--- a/tests/integration/test_annotation_import.py
+++ b/tests/integration/test_annotation_import.py
@@ -9,17 +9,17 @@ import pytest
 
 from pragmata.api.annotation_import import ImportResult, import_records
 from pragmata.api.annotation_setup import teardown
-from pragmata.core.annotation.setup import setup_datasets
+from pragmata.core.annotation.setup import setup_workspaces
 from pragmata.core.settings.annotation_settings import AnnotationSettings
 
 pytestmark = [pytest.mark.integration, pytest.mark.annotation]
 
 _API_URL = "http://localhost:6900"
 _API_KEY = "argilla.apikey"
-_PREFIX = "testimport"
+_DATASET_ID = "testimport"
 _CREDS: dict[str, str] = {"api_url": _API_URL, "api_key": _API_KEY}
 
-_SETTINGS = AnnotationSettings(workspace_prefix=_PREFIX)
+_SETTINGS = AnnotationSettings(dataset_id=_DATASET_ID)
 
 
 def _make_raw(n_chunks: int = 2, *, language: str | None = "de") -> dict:
@@ -43,10 +43,10 @@ def client() -> rg.Argilla:
 @pytest.fixture(autouse=True, scope="module")
 def clean_environment(client: rg.Argilla):
     """Tear down and re-setup prefixed environment before/after all tests."""
-    teardown(workspace_prefix=_PREFIX, **_CREDS)
-    setup_datasets(client, _SETTINGS)
+    teardown(dataset_id=_DATASET_ID, **_CREDS)
+    setup_workspaces(client, _SETTINGS)
     yield
-    teardown(workspace_prefix=_PREFIX, **_CREDS)
+    teardown(dataset_id=_DATASET_ID, **_CREDS)
 
 
 @pytest.fixture()
@@ -61,7 +61,7 @@ def sample_records() -> list[dict]:
 
 
 def test_import_result_type(client: rg.Argilla, sample_records: list[dict]) -> None:
-    result = import_records(sample_records, workspace_prefix=_PREFIX, **_CREDS)
+    result = import_records(sample_records, dataset_id=_DATASET_ID, **_CREDS)
     assert isinstance(result, ImportResult)
 
 
@@ -70,14 +70,14 @@ def test_record_counts_per_dataset(client: rg.Argilla, sample_records: list[dict
     n_records = len(sample_records)
     n_retrieval = sum(len(r["chunks"]) for r in sample_records)  # 3 + 2 = 5
 
-    result = import_records(sample_records, workspace_prefix=_PREFIX, **_CREDS)
+    result = import_records(sample_records, dataset_id=_DATASET_ID, **_CREDS)
 
     assert result.total_records == n_records
     assert result.errors == []
 
-    ret_ds_name = f"{_PREFIX}_task_retrieval"
-    gnd_ds_name = f"{_PREFIX}_task_grounding"
-    gen_ds_name = f"{_PREFIX}_task_generation"
+    ret_ds_name = f"{_DATASET_ID}_task_retrieval"
+    gnd_ds_name = f"{_DATASET_ID}_task_grounding"
+    gen_ds_name = f"{_DATASET_ID}_task_generation"
 
     assert result.dataset_counts[ret_ds_name] == n_retrieval
     assert result.dataset_counts[gnd_ds_name] == n_records
@@ -86,11 +86,11 @@ def test_record_counts_per_dataset(client: rg.Argilla, sample_records: list[dict
 
 def test_records_exist_in_argilla(client: rg.Argilla, sample_records: list[dict]) -> None:
     """After import, all three datasets contain records."""
-    import_records(sample_records, workspace_prefix=_PREFIX, **_CREDS)
+    import_records(sample_records, dataset_id=_DATASET_ID, **_CREDS)
 
-    ret_ds = client.datasets(f"{_PREFIX}_task_retrieval", workspace=f"{_PREFIX}_retrieval")
-    gnd_ds = client.datasets(f"{_PREFIX}_task_grounding", workspace=f"{_PREFIX}_grounding")
-    gen_ds = client.datasets(f"{_PREFIX}_task_generation", workspace=f"{_PREFIX}_generation")
+    ret_ds = client.datasets(f"{_DATASET_ID}_task_retrieval", workspace=f"{_DATASET_ID}_retrieval")
+    gnd_ds = client.datasets(f"{_DATASET_ID}_task_grounding", workspace=f"{_DATASET_ID}_grounding")
+    gen_ds = client.datasets(f"{_DATASET_ID}_task_generation", workspace=f"{_DATASET_ID}_generation")
 
     assert ret_ds is not None
     assert gnd_ds is not None
@@ -104,15 +104,15 @@ def test_records_exist_in_argilla(client: rg.Argilla, sample_records: list[dict]
 
 def test_record_uuid_linkage(client: rg.Argilla, sample_records: list[dict]) -> None:
     """record_uuid metadata appears in all three datasets and intersects."""
-    import_records(sample_records, workspace_prefix=_PREFIX, **_CREDS)
+    import_records(sample_records, dataset_id=_DATASET_ID, **_CREDS)
 
     def _uuids(ds_name: str, ws_name: str) -> set[str]:
         ds = client.datasets(ds_name, workspace=ws_name)
         return {r.metadata["record_uuid"] for r in ds.records if r.metadata.get("record_uuid")}
 
-    ret_uuids = _uuids(f"{_PREFIX}_task_retrieval", f"{_PREFIX}_retrieval")
-    gnd_uuids = _uuids(f"{_PREFIX}_task_grounding", f"{_PREFIX}_grounding")
-    gen_uuids = _uuids(f"{_PREFIX}_task_generation", f"{_PREFIX}_generation")
+    ret_uuids = _uuids(f"{_DATASET_ID}_task_retrieval", f"{_DATASET_ID}_retrieval")
+    gnd_uuids = _uuids(f"{_DATASET_ID}_task_grounding", f"{_DATASET_ID}_grounding")
+    gen_uuids = _uuids(f"{_DATASET_ID}_task_generation", f"{_DATASET_ID}_generation")
 
     # All three datasets share the same UUIDs
     assert ret_uuids == gnd_uuids == gen_uuids
@@ -126,12 +126,12 @@ def test_idempotent_reimport(client: rg.Argilla, sample_records: list[dict]) -> 
     (derive_record_uuid). Argilla upserts on Record.id, so identical IDs on the second
     import overwrite existing records rather than creating duplicates.
     """
-    import_records(sample_records, workspace_prefix=_PREFIX, **_CREDS)
-    import_records(sample_records, workspace_prefix=_PREFIX, **_CREDS)
+    import_records(sample_records, dataset_id=_DATASET_ID, **_CREDS)
+    import_records(sample_records, dataset_id=_DATASET_ID, **_CREDS)
 
-    ret_ds = client.datasets(f"{_PREFIX}_task_retrieval", workspace=f"{_PREFIX}_retrieval")
-    gnd_ds = client.datasets(f"{_PREFIX}_task_grounding", workspace=f"{_PREFIX}_grounding")
-    gen_ds = client.datasets(f"{_PREFIX}_task_generation", workspace=f"{_PREFIX}_generation")
+    ret_ds = client.datasets(f"{_DATASET_ID}_task_retrieval", workspace=f"{_DATASET_ID}_retrieval")
+    gnd_ds = client.datasets(f"{_DATASET_ID}_task_grounding", workspace=f"{_DATASET_ID}_grounding")
+    gen_ds = client.datasets(f"{_DATASET_ID}_task_generation", workspace=f"{_DATASET_ID}_generation")
 
     n_retrieval = sum(len(r["chunks"]) for r in sample_records)
     n_records = len(sample_records)
@@ -145,7 +145,7 @@ def test_invalid_records_skipped_with_errors(client: rg.Argilla) -> None:
     """Invalid dicts are reported as errors, not sent to Argilla."""
     raw = [{"query": "no answer or chunks"}, _make_raw(1)]
 
-    result = import_records(raw, workspace_prefix=_PREFIX, **_CREDS)
+    result = import_records(raw, dataset_id=_DATASET_ID, **_CREDS)
 
     assert result.total_records == 2
     assert len(result.errors) == 1

--- a/tests/integration/test_annotation_import.py
+++ b/tests/integration/test_annotation_import.py
@@ -8,8 +8,7 @@ import argilla as rg
 import pytest
 
 from pragmata.api.annotation_import import ImportResult, import_records
-from pragmata.api.annotation_setup import teardown
-from pragmata.core.annotation.setup import setup_workspaces
+from pragmata.core.annotation.setup import setup_workspaces, teardown_resources
 from pragmata.core.settings.annotation_settings import AnnotationSettings
 
 pytestmark = [pytest.mark.integration, pytest.mark.annotation]
@@ -42,11 +41,13 @@ def client() -> rg.Argilla:
 
 @pytest.fixture(autouse=True, scope="module")
 def clean_environment(client: rg.Argilla):
-    """Tear down and re-setup prefixed environment before/after all tests."""
-    teardown(dataset_id=_DATASET_ID, **_CREDS)
+    """Tear down and re-setup environment before/after all tests."""
+    teardown_resources(client, _SETTINGS)
+    teardown_resources(client, AnnotationSettings())
     setup_workspaces(client, _SETTINGS)
     yield
-    teardown(dataset_id=_DATASET_ID, **_CREDS)
+    teardown_resources(client, _SETTINGS)
+    teardown_resources(client, AnnotationSettings())
 
 
 @pytest.fixture()
@@ -75,9 +76,9 @@ def test_record_counts_per_dataset(client: rg.Argilla, sample_records: list[dict
     assert result.total_records == n_records
     assert result.errors == []
 
-    ret_ds_name = f"{_DATASET_ID}_task_retrieval"
-    gnd_ds_name = f"{_DATASET_ID}_task_grounding"
-    gen_ds_name = f"{_DATASET_ID}_task_generation"
+    ret_ds_name = f"retrieval_{_DATASET_ID}"
+    gnd_ds_name = f"grounding_{_DATASET_ID}"
+    gen_ds_name = f"generation_{_DATASET_ID}"
 
     assert result.dataset_counts[ret_ds_name] == n_retrieval
     assert result.dataset_counts[gnd_ds_name] == n_records
@@ -88,9 +89,9 @@ def test_records_exist_in_argilla(client: rg.Argilla, sample_records: list[dict]
     """After import, all three datasets contain records."""
     import_records(sample_records, dataset_id=_DATASET_ID, **_CREDS)
 
-    ret_ds = client.datasets(f"{_DATASET_ID}_task_retrieval", workspace=f"{_DATASET_ID}_retrieval")
-    gnd_ds = client.datasets(f"{_DATASET_ID}_task_grounding", workspace=f"{_DATASET_ID}_grounding")
-    gen_ds = client.datasets(f"{_DATASET_ID}_task_generation", workspace=f"{_DATASET_ID}_generation")
+    ret_ds = client.datasets(f"retrieval_{_DATASET_ID}", workspace="retrieval")
+    gnd_ds = client.datasets(f"grounding_{_DATASET_ID}", workspace="grounding")
+    gen_ds = client.datasets(f"generation_{_DATASET_ID}", workspace="generation")
 
     assert ret_ds is not None
     assert gnd_ds is not None
@@ -110,9 +111,9 @@ def test_record_uuid_linkage(client: rg.Argilla, sample_records: list[dict]) -> 
         ds = client.datasets(ds_name, workspace=ws_name)
         return {r.metadata["record_uuid"] for r in ds.records if r.metadata.get("record_uuid")}
 
-    ret_uuids = _uuids(f"{_DATASET_ID}_task_retrieval", f"{_DATASET_ID}_retrieval")
-    gnd_uuids = _uuids(f"{_DATASET_ID}_task_grounding", f"{_DATASET_ID}_grounding")
-    gen_uuids = _uuids(f"{_DATASET_ID}_task_generation", f"{_DATASET_ID}_generation")
+    ret_uuids = _uuids(f"retrieval_{_DATASET_ID}", "retrieval")
+    gnd_uuids = _uuids(f"grounding_{_DATASET_ID}", "grounding")
+    gen_uuids = _uuids(f"generation_{_DATASET_ID}", "generation")
 
     # All three datasets share the same UUIDs
     assert ret_uuids == gnd_uuids == gen_uuids
@@ -129,9 +130,9 @@ def test_idempotent_reimport(client: rg.Argilla, sample_records: list[dict]) -> 
     import_records(sample_records, dataset_id=_DATASET_ID, **_CREDS)
     import_records(sample_records, dataset_id=_DATASET_ID, **_CREDS)
 
-    ret_ds = client.datasets(f"{_DATASET_ID}_task_retrieval", workspace=f"{_DATASET_ID}_retrieval")
-    gnd_ds = client.datasets(f"{_DATASET_ID}_task_grounding", workspace=f"{_DATASET_ID}_grounding")
-    gen_ds = client.datasets(f"{_DATASET_ID}_task_generation", workspace=f"{_DATASET_ID}_generation")
+    ret_ds = client.datasets(f"retrieval_{_DATASET_ID}", workspace="retrieval")
+    gnd_ds = client.datasets(f"grounding_{_DATASET_ID}", workspace="grounding")
+    gen_ds = client.datasets(f"generation_{_DATASET_ID}", workspace="generation")
 
     n_retrieval = sum(len(r["chunks"]) for r in sample_records)
     n_records = len(sample_records)
@@ -152,3 +153,26 @@ def test_invalid_records_skipped_with_errors(client: rg.Argilla) -> None:
     assert result.errors[0].index == 0
     # The one valid record was still imported
     assert sum(result.dataset_counts.values()) > 0
+
+
+def test_dataset_auto_creation(client: rg.Argilla) -> None:
+    """Import auto-creates datasets when they don't exist."""
+    auto_id = "autotest"
+    auto_settings = AnnotationSettings(dataset_id=auto_id)
+
+    # Clean up any prior run
+    teardown_resources(client, auto_settings)
+
+    # Import without prior setup_datasets — datasets should be auto-created
+    result = import_records([_make_raw(1)], dataset_id=auto_id, **_CREDS)
+
+    assert result.total_records == 1
+    assert result.errors == []
+
+    # Datasets exist
+    assert client.datasets(f"retrieval_{auto_id}", workspace="retrieval") is not None
+    assert client.datasets(f"grounding_{auto_id}", workspace="grounding") is not None
+    assert client.datasets(f"generation_{auto_id}", workspace="generation") is not None
+
+    # Clean up
+    teardown_resources(client, auto_settings)

--- a/tests/integration/test_annotation_setup.py
+++ b/tests/integration/test_annotation_setup.py
@@ -10,7 +10,7 @@ import pytest
 from pragmata.core.annotation.setup import (
     SetupResult,
     provision_users,
-    setup_datasets,
+    setup_workspaces,
     teardown_resources,
 )
 from pragmata.core.settings.annotation_settings import AnnotationSettings, UserSpec
@@ -42,10 +42,10 @@ def clean_slate(client: rg.Argilla):
 # ---------------------------------------------------------------------------
 
 
-def test_full_setup_creates_workspaces_and_datasets(client: rg.Argilla) -> None:
+def test_setup_creates_workspaces(client: rg.Argilla) -> None:
     teardown_resources(client, _DEFAULT_SETTINGS)
 
-    result = setup_datasets(client, _DEFAULT_SETTINGS)
+    result = setup_workspaces(client, _DEFAULT_SETTINGS)
 
     assert isinstance(result, SetupResult)
 
@@ -54,61 +54,17 @@ def test_full_setup_creates_workspaces_and_datasets(client: rg.Argilla) -> None:
     assert client.workspaces("grounding") is not None
     assert client.workspaces("generation") is not None
 
-    # 3 datasets
-    assert client.datasets("task_retrieval", workspace="retrieval") is not None
-    assert client.datasets("task_grounding", workspace="grounding") is not None
-    assert client.datasets("task_generation", workspace="generation") is not None
-
     # Result accounting
     assert set(result.created_workspaces) == {"retrieval", "grounding", "generation"}
     assert result.skipped_workspaces == []
-    assert set(result.created_datasets) == {
-        "task_retrieval",
-        "task_grounding",
-        "task_generation",
-    }
-    assert result.skipped_datasets == []
-
-
-def test_dataset_field_and_question_counts(client: rg.Argilla) -> None:
-    """Verify datasets have the expected schema shape from annotation-interface.md."""
-    # Retrieval: 3 fields (query, chunk, generated_answer), 4 questions (3 label + 1 text)
-    ds1 = client.datasets("task_retrieval", workspace="retrieval")
-    assert ds1 is not None
-    assert len(ds1.settings.fields) == 3
-    assert len(ds1.settings.questions) == 4
-
-    # Grounding: 3 fields (answer, context_set, query), 6 questions (5 label + 1 text)
-    ds2 = client.datasets("task_grounding", workspace="grounding")
-    assert ds2 is not None
-    assert len(ds2.settings.fields) == 3
-    assert len(ds2.settings.questions) == 6
-
-    # Generation: 3 fields (query, answer, context_set), 6 questions (5 label + 1 text)
-    ds3 = client.datasets("task_generation", workspace="generation")
-    assert ds3 is not None
-    assert len(ds3.settings.fields) == 3
-    assert len(ds3.settings.questions) == 6
-
-
-def test_dataset_min_submitted(client: rg.Argilla) -> None:
-    ds1 = client.datasets("task_retrieval", workspace="retrieval")
-    assert ds1 is not None
-    assert ds1.settings.distribution.min_submitted == 1
 
 
 def test_idempotent_rerun(client: rg.Argilla) -> None:
-    # Datasets already exist from prior test — re-run should skip all
-    result = setup_datasets(client, _DEFAULT_SETTINGS)
+    # Workspaces already exist from prior test — re-run should skip all
+    result = setup_workspaces(client, _DEFAULT_SETTINGS)
 
     assert result.created_workspaces == []
-    assert result.created_datasets == []
     assert set(result.skipped_workspaces) == {"retrieval", "grounding", "generation"}
-    assert set(result.skipped_datasets) == {
-        "task_retrieval",
-        "task_grounding",
-        "task_generation",
-    }
 
 
 def test_user_provisioning(client: rg.Argilla) -> None:
@@ -156,48 +112,32 @@ def test_teardown_retains_user_accounts(client: rg.Argilla) -> None:
 
     teardown_resources(client, _DEFAULT_SETTINGS)
 
-    # Workspaces and datasets gone
+    # Workspaces gone
     assert client.workspaces("retrieval") is None
     assert client.workspaces("grounding") is None
     assert client.workspaces("generation") is None
-    assert client.datasets("task_retrieval", workspace="retrieval") is None
 
     # User still exists
     assert client.users(_TEST_USER) is not None
 
 
 def test_rerun_after_teardown(client: rg.Argilla) -> None:
-    result = setup_datasets(client, _DEFAULT_SETTINGS)
+    result = setup_workspaces(client, _DEFAULT_SETTINGS)
 
     assert set(result.created_workspaces) == {"retrieval", "grounding", "generation"}
-    assert set(result.created_datasets) == {
-        "task_retrieval",
-        "task_grounding",
-        "task_generation",
-    }
     assert result.skipped_workspaces == []
-    assert result.skipped_datasets == []
 
 
-def test_prefix_support(client: rg.Argilla) -> None:
-    prefixed_settings = AnnotationSettings(workspace_prefix="test")
-    teardown_resources(client, prefixed_settings)
+def test_scoped_teardown_preserves_workspaces(client: rg.Argilla) -> None:
+    """Teardown with dataset_id only deletes matching datasets, not workspaces."""
+    teardown_resources(client, _DEFAULT_SETTINGS)
+    setup_workspaces(client, _DEFAULT_SETTINGS)
 
-    result = setup_datasets(client, prefixed_settings)
+    # Scoped teardown with a dataset_id should not delete workspaces
+    scoped_settings = AnnotationSettings(dataset_id="run1")
+    teardown_resources(client, scoped_settings)
 
-    assert client.workspaces("test_retrieval") is not None
-    assert client.workspaces("test_grounding") is not None
-    assert client.workspaces("test_generation") is not None
-    assert client.datasets("test_task_retrieval", workspace="test_retrieval") is not None
-    assert client.datasets("test_task_grounding", workspace="test_grounding") is not None
-    assert client.datasets("test_task_generation", workspace="test_generation") is not None
-
-    assert set(result.created_workspaces) == {"test_retrieval", "test_grounding", "test_generation"}
-    assert set(result.created_datasets) == {
-        "test_task_retrieval",
-        "test_task_grounding",
-        "test_task_generation",
-    }
-
-    # Cleanup prefixed resources
-    teardown_resources(client, prefixed_settings)
+    # Workspaces still exist
+    assert client.workspaces("retrieval") is not None
+    assert client.workspaces("grounding") is not None
+    assert client.workspaces("generation") is not None

--- a/tests/unit/api/test_annotation.py
+++ b/tests/unit/api/test_annotation.py
@@ -59,7 +59,7 @@ def _make_raw() -> dict:
 
 class TestSetup:
     @patch("pragmata.api.annotation_setup.provision_users")
-    @patch("pragmata.api.annotation_setup.setup_datasets")
+    @patch("pragmata.api.annotation_setup.setup_workspaces")
     def test_delegates_to_core(
         self,
         mock_ds: MagicMock,
@@ -69,64 +69,52 @@ class TestSetup:
         mock_ds.return_value = SetupResult(created_workspaces=["ws1"])
         mock_users.return_value = SetupResult(created_users=["alice"])
 
-        setup(workspace_prefix="test")
+        setup()
 
         mock_ds.assert_called_once()
         mock_users.assert_called_once()
         assert mock_client is mock_ds.call_args[0][0]
 
     @patch("pragmata.api.annotation_setup.provision_users")
-    @patch("pragmata.api.annotation_setup.setup_datasets")
-    def test_merges_dataset_and_user_results(self, mock_ds: MagicMock, mock_users: MagicMock) -> None:
-        mock_ds.return_value = SetupResult(created_workspaces=["ws1"], created_datasets=["ds1"])
+    @patch("pragmata.api.annotation_setup.setup_workspaces")
+    def test_merges_workspace_and_user_results(self, mock_ds: MagicMock, mock_users: MagicMock) -> None:
+        mock_ds.return_value = SetupResult(created_workspaces=["ws1"])
         mock_users.return_value = SetupResult(created_users=["alice"])
 
-        result = setup(workspace_prefix="test")
+        result = setup()
 
         assert result.created_workspaces == ["ws1"]
-        assert result.created_datasets == ["ds1"]
         assert result.created_users == ["alice"]
 
     @patch("pragmata.api.annotation_setup.provision_users")
-    @patch("pragmata.api.annotation_setup.setup_datasets")
-    def test_resolves_workspace_prefix(self, mock_ds: MagicMock, mock_users: MagicMock) -> None:
-        mock_ds.return_value = SetupResult()
-        mock_users.return_value = SetupResult()
-
-        setup(workspace_prefix="myprefix")
-
-        settings: AnnotationSettings = mock_ds.call_args[0][1]
-        assert settings.workspace_prefix == "myprefix"
-
-    @patch("pragmata.api.annotation_setup.provision_users")
-    @patch("pragmata.api.annotation_setup.setup_datasets")
+    @patch("pragmata.api.annotation_setup.setup_workspaces")
     def test_resolves_min_submitted(self, mock_ds: MagicMock, mock_users: MagicMock) -> None:
         mock_ds.return_value = SetupResult()
         mock_users.return_value = SetupResult()
 
-        setup(workspace_prefix="test", min_submitted=3)
+        setup(min_submitted=3)
 
         settings: AnnotationSettings = mock_ds.call_args[0][1]
         assert settings.min_submitted == 3
 
     @patch("pragmata.api.annotation_setup.provision_users")
-    @patch("pragmata.api.annotation_setup.setup_datasets")
+    @patch("pragmata.api.annotation_setup.setup_workspaces")
     def test_passes_users_to_provision(self, mock_ds: MagicMock, mock_users: MagicMock) -> None:
         mock_ds.return_value = SetupResult()
         mock_users.return_value = SetupResult()
         users = [UserSpec(username="alice", role="annotator")]
 
-        setup(users, workspace_prefix="test")
+        setup(users)
 
         assert mock_users.call_args[0][1] == users
 
     @patch("pragmata.api.annotation_setup.provision_users")
-    @patch("pragmata.api.annotation_setup.setup_datasets")
+    @patch("pragmata.api.annotation_setup.setup_workspaces")
     def test_none_users_passes_empty_list(self, mock_ds: MagicMock, mock_users: MagicMock) -> None:
         mock_ds.return_value = SetupResult()
         mock_users.return_value = SetupResult()
 
-        setup(workspace_prefix="test")
+        setup()
 
         assert mock_users.call_args[0][1] == []
 
@@ -139,15 +127,15 @@ class TestSetup:
 class TestTeardown:
     @patch("pragmata.api.annotation_setup.teardown_resources")
     def test_delegates_to_core(self, mock_teardown: MagicMock, mock_client: MagicMock) -> None:
-        teardown(workspace_prefix="test")
+        teardown(dataset_id="test")
         mock_teardown.assert_called_once()
         assert mock_client is mock_teardown.call_args[0][0]
 
     @patch("pragmata.api.annotation_setup.teardown_resources")
-    def test_resolves_workspace_prefix(self, mock_teardown: MagicMock) -> None:
-        teardown(workspace_prefix="myprefix")
+    def test_resolves_dataset_id(self, mock_teardown: MagicMock) -> None:
+        teardown(dataset_id="myprefix")
         settings: AnnotationSettings = mock_teardown.call_args[0][1]
-        assert settings.workspace_prefix == "myprefix"
+        assert settings.dataset_id == "myprefix"
 
 
 # ---------------------------------------------------------------------------
@@ -161,27 +149,27 @@ class TestImportRecords:
         mock_fan_out.return_value = {"ds1": 2}
         raw = [_make_raw()]
 
-        import_records(raw, workspace_prefix="test")
+        import_records(raw, dataset_id="test")
 
         mock_fan_out.assert_called_once()
         assert mock_client is mock_fan_out.call_args[0][0]
         assert len(mock_fan_out.call_args[0][1]) == 1
 
     @patch("pragmata.api.annotation_import.fan_out_records")
-    def test_resolves_workspace_prefix(self, mock_fan_out: MagicMock) -> None:
+    def test_resolves_dataset_id(self, mock_fan_out: MagicMock) -> None:
         mock_fan_out.return_value = {}
 
-        import_records([], workspace_prefix="myprefix")
+        import_records([], dataset_id="myprefix")
 
         settings: AnnotationSettings = mock_fan_out.call_args[0][2]
-        assert settings.workspace_prefix == "myprefix"
+        assert settings.dataset_id == "myprefix"
 
     @patch("pragmata.api.annotation_import.fan_out_records")
     def test_returns_import_result(self, mock_fan_out: MagicMock) -> None:
         mock_fan_out.return_value = {"ds1": 3, "ds2": 1}
         raw = [_make_raw(), _make_raw()]
 
-        result = import_records(raw, workspace_prefix="test")
+        result = import_records(raw, dataset_id="test")
 
         assert isinstance(result, ImportResult)
         assert result.total_records == 2
@@ -192,7 +180,7 @@ class TestImportRecords:
     def test_empty_records_returns_zero_totals(self, mock_fan_out: MagicMock) -> None:
         mock_fan_out.return_value = {}
 
-        result = import_records([], workspace_prefix="test")
+        result = import_records([], dataset_id="test")
 
         assert result.total_records == 0
         assert result.dataset_counts == {}
@@ -203,7 +191,7 @@ class TestImportRecords:
         mock_fan_out.return_value = {"ds1": 1}
         raw = [_make_raw(), {"query": "missing required fields"}]
 
-        result = import_records(raw, workspace_prefix="test")
+        result = import_records(raw, dataset_id="test")
 
         assert result.total_records == 2
         assert len(result.errors) == 1
@@ -216,7 +204,7 @@ class TestImportRecords:
         mock_fan_out.return_value = {}
         raw = [{"bad": "data"}, {"also": "bad"}]
 
-        result = import_records(raw, workspace_prefix="test")
+        result = import_records(raw, dataset_id="test")
 
         assert result.total_records == 2
         assert len(result.errors) == 2
@@ -229,7 +217,7 @@ class TestImportRecords:
         f = tmp_path / "data.json"
         f.write_text(json.dumps([_make_raw()]))
 
-        result = import_records(str(f), workspace_prefix="test")
+        result = import_records(str(f), dataset_id="test")
 
         assert result.total_records == 1
         mock_fan_out.assert_called_once()
@@ -240,7 +228,7 @@ class TestImportRecords:
         f = tmp_path / "data.json"
         f.write_text(json.dumps([_make_raw()]))
 
-        result = import_records(f, workspace_prefix="test")
+        result = import_records(f, dataset_id="test")
 
         assert result.total_records == 1
 
@@ -250,7 +238,7 @@ class TestImportRecords:
         f = tmp_path / "data.jsonl"
         f.write_text(json.dumps(_make_raw()) + "\n")
 
-        result = import_records(str(f), workspace_prefix="test")
+        result = import_records(str(f), dataset_id="test")
 
         assert result.total_records == 1
 
@@ -260,19 +248,19 @@ class TestImportRecords:
         f = tmp_path / "data.txt"
         f.write_text(json.dumps([_make_raw()]))
 
-        result = import_records(str(f), format="json", workspace_prefix="test")
+        result = import_records(str(f), format="json", dataset_id="test")
 
         assert result.total_records == 1
 
     def test_file_not_found_raises(self) -> None:
         with pytest.raises(FileNotFoundError):
-            import_records("/nonexistent/data.json", workspace_prefix="test")
+            import_records("/nonexistent/data.json", dataset_id="test")
 
     def test_unsupported_extension_raises(self, tmp_path: Path) -> None:
         f = tmp_path / "data.parquet"
         f.write_text("")
         with pytest.raises(ValueError, match="Unsupported file extension"):
-            import_records(str(f), workspace_prefix="test")
+            import_records(str(f), dataset_id="test")
 
     @patch("pragmata.api.annotation_import.fan_out_records")
     def test_accepts_hf_dataset(self, mock_fan_out: MagicMock) -> None:
@@ -284,7 +272,7 @@ class TestImportRecords:
         fake_mod.Dataset = FakeDataset  # type: ignore[attr-defined]
 
         with patch.dict("sys.modules", {"datasets": fake_mod}):
-            result = import_records(fake_ds, workspace_prefix="test")
+            result = import_records(fake_ds, dataset_id="test")
 
         assert result.total_records == 1
 
@@ -298,6 +286,6 @@ class TestImportRecords:
         fake_mod.DataFrame = FakeDataFrame  # type: ignore[attr-defined]
 
         with patch.dict("sys.modules", {"pandas": fake_mod}):
-            result = import_records(fake_df, workspace_prefix="test")
+            result = import_records(fake_df, dataset_id="test")
 
         assert result.total_records == 1

--- a/tests/unit/api/test_export_api.py
+++ b/tests/unit/api/test_export_api.py
@@ -221,7 +221,7 @@ class TestExportAnnotations:
     def test_export_id_auto_generated_with_prefix(self, tmp_path: Path, mock_client: MagicMock) -> None:
         from pragmata.api.annotation_export import export_annotations
 
-        result = export_annotations(base_dir=tmp_path, workspace_prefix="myproject")
+        result = export_annotations(base_dir=tmp_path, dataset_id="myproject")
         export_id = result.paths.export_dir.name
         assert export_id.startswith("myproject_")
 

--- a/tests/unit/api/test_export_api.py
+++ b/tests/unit/api/test_export_api.py
@@ -294,4 +294,4 @@ class TestExportAnnotations:
 
         assert set(result.files.keys()) == {Task.RETRIEVAL, Task.GROUNDING, Task.GENERATION}
         called_names = {call.args[0] for call in mock_client.datasets.call_args_list}
-        assert called_names == {"task_retrieval", "task_grounding", "task_generation"}
+        assert called_names == {"retrieval", "grounding", "generation"}

--- a/tests/unit/core/annotation/test_argilla_task_definitions.py
+++ b/tests/unit/core/annotation/test_argilla_task_definitions.py
@@ -203,6 +203,6 @@ class TestDatasetNames:
         assert set(DATASET_NAMES.keys()) == {Task.RETRIEVAL, Task.GROUNDING, Task.GENERATION}
 
     def test_dataset_name_values(self):
-        assert DATASET_NAMES[Task.RETRIEVAL] == "task_retrieval"
-        assert DATASET_NAMES[Task.GROUNDING] == "task_grounding"
-        assert DATASET_NAMES[Task.GENERATION] == "task_generation"
+        assert DATASET_NAMES[Task.RETRIEVAL] == "retrieval"
+        assert DATASET_NAMES[Task.GROUNDING] == "grounding"
+        assert DATASET_NAMES[Task.GENERATION] == "generation"

--- a/tests/unit/core/annotation/test_setup.py
+++ b/tests/unit/core/annotation/test_setup.py
@@ -11,13 +11,13 @@ from pragmata.core.annotation.setup import SetupResult
 
 class TestApplySuffix:
     def test_empty_suffix_returns_name(self) -> None:
-        assert apply_suffix("task_retrieval", "") == "task_retrieval"
+        assert apply_suffix("retrieval", "") == "retrieval"
 
     def test_non_empty_suffix_appends(self) -> None:
-        assert apply_suffix("task_retrieval", "run1") == "task_retrieval_run1"
+        assert apply_suffix("retrieval", "run1") == "retrieval_run1"
 
     def test_non_empty_suffix_any_name(self) -> None:
-        assert apply_suffix("task_generation", "batch2") == "task_generation_batch2"
+        assert apply_suffix("generation", "batch2") == "generation_batch2"
 
 
 class TestGeneratePassword:

--- a/tests/unit/core/annotation/test_setup.py
+++ b/tests/unit/core/annotation/test_setup.py
@@ -5,19 +5,19 @@ No Argilla server required; these tests exercise pure Python logic only.
 
 from dataclasses import fields
 
-from pragmata.core.annotation.argilla_ops import apply_prefix, generate_password
+from pragmata.core.annotation.argilla_ops import apply_suffix, generate_password
 from pragmata.core.annotation.setup import SetupResult
 
 
-class TestApplyPrefix:
-    def test_empty_prefix_returns_name(self) -> None:
-        assert apply_prefix("", "retrieval") == "retrieval"
+class TestApplySuffix:
+    def test_empty_suffix_returns_name(self) -> None:
+        assert apply_suffix("task_retrieval", "") == "task_retrieval"
 
-    def test_non_empty_prefix_prepends(self) -> None:
-        assert apply_prefix("pb", "retrieval") == "pb_retrieval"
+    def test_non_empty_suffix_appends(self) -> None:
+        assert apply_suffix("task_retrieval", "run1") == "task_retrieval_run1"
 
-    def test_non_empty_prefix_any_name(self) -> None:
-        assert apply_prefix("test", "generation") == "test_generation"
+    def test_non_empty_suffix_any_name(self) -> None:
+        assert apply_suffix("task_generation", "batch2") == "task_generation_batch2"
 
 
 class TestGeneratePassword:
@@ -42,8 +42,6 @@ class TestSetupResult:
         result = SetupResult()
         assert result.created_workspaces == []
         assert result.skipped_workspaces == []
-        assert result.created_datasets == []
-        assert result.skipped_datasets == []
         assert result.created_users == []
         assert result.skipped_users == []
 
@@ -56,8 +54,6 @@ class TestSetupResult:
         assert field_names == {
             "created_workspaces",
             "skipped_workspaces",
-            "created_datasets",
-            "skipped_datasets",
             "created_users",
             "skipped_users",
             "generated_passwords",

--- a/tests/unit/core/settings/test_annotation_settings.py
+++ b/tests/unit/core/settings/test_annotation_settings.py
@@ -16,9 +16,9 @@ class TestAnnotationSettingsDefaults:
             "generation": [Task.GENERATION],
         }
 
-    def test_workspace_prefix_default(self):
+    def test_dataset_id_default(self):
         s = AnnotationSettings()
-        assert s.workspace_prefix == ""
+        assert s.dataset_id == ""
 
     def test_min_submitted_default(self):
         s = AnnotationSettings()
@@ -33,15 +33,15 @@ class TestAnnotationSettingsResolve:
     def test_resolve_with_no_args_returns_defaults(self):
         s = AnnotationSettings.resolve()
         assert s.min_submitted == 1
-        assert s.workspace_prefix == ""
+        assert s.dataset_id == ""
 
     def test_resolve_overrides_min_submitted(self):
         s = AnnotationSettings.resolve(overrides={"min_submitted": 3})
         assert s.min_submitted == 3
 
-    def test_resolve_overrides_prefix(self):
-        s = AnnotationSettings.resolve(overrides={"workspace_prefix": "pb"})
-        assert s.workspace_prefix == "pb"
+    def test_resolve_overrides_dataset_id(self):
+        s = AnnotationSettings.resolve(overrides={"dataset_id": "run1"})
+        assert s.dataset_id == "run1"
 
     def test_resolve_config_layer(self):
         s = AnnotationSettings.resolve(config={"min_submitted": 2})


### PR DESCRIPTION
## Goal

Decouple workspace and dataset naming so that workspaces are permanent (users assigned once) and datasets are scoped per-run via a `dataset_id` suffix. Environment isolation moves to the infrastructure level (Docker Compose project names).

## Scope

- Drop `workspace_prefix` entirely from settings, API, CLI
- Add `dataset_id: str` setting — optional suffix appended to dataset names
- Drop redundant `task_` prefix from dataset names (workspaces already provide task scoping)
- Split setup: `setup` creates workspaces + users only; `import` auto-creates datasets
- Scoped teardown: `teardown --dataset-id X` deletes only matching datasets

## Implementation

**Naming change:**
| dataset_id | Workspace | Dataset |
|-----------|-----------|---------|
| `""` | `retrieval` | `retrieval` |
| `run1` | `retrieval` | `retrieval_run1` |
| `run2` | `retrieval` | `retrieval_run2` |

**Core (`core/`):**
- `annotation_settings.py` — `workspace_prefix` → `dataset_id`
- `argilla_ops.py` — remove `apply_prefix`, add `apply_suffix`
- `argilla_task_definitions.py` — `task_retrieval/grounding/generation` → `retrieval/grounding/generation`
- `setup.py` — `setup_datasets()` → `setup_workspaces()` (workspaces only); scoped teardown
- `record_builder.py` — dataset auto-creation on import via idempotent `create_dataset`
- `export_fetcher.py`, `export_runner.py` — bare workspace names + dataset_id suffix

**API (`api/`):**
- All 4 annotation API modules: `workspace_prefix` → `dataset_id` (or removed where not needed)

**CLI (`cli/`):**
- `--prefix` replaced with `--dataset-id` on import/export/teardown
- `setup` no longer takes `--prefix` (workspaces are permanent)
- `iaa` no longer takes `--prefix` (reads export CSVs only)

**Deploy:**
- Add `.env.uat.example` with separate port/credentials
- Document `-p` project name pattern for environment isolation

## Testing

- 419 unit tests pass
- Integration tests updated (require Argilla instance)
- New tests: `test_dataset_auto_creation`, `test_scoped_teardown_preserves_workspaces`
- UAT validated locally (PR #122)

## References

- `annotation_uat/issues.md` — raised from UAT (PR #122)
- `docs/design/annotation-import-pipeline.md`
- `docs/design/annotation-user-management.md`