### PR TITLE
feat: add planning-memory schema contracts for summary state and persisted memory artifact

### DIFF
--- a/src/pragmata/core/schemas/querygen_output.py
+++ b/src/pragmata/core/schemas/querygen_output.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, NonNegativeInt, PositiveInt, model_validator
 
+from pragmata.core.schemas.querygen_summary import PlanningSummaryState
 from pragmata.core.types import NonEmptyStr
 
 
@@ -43,3 +44,14 @@ class SyntheticQueriesMeta(BaseModel):
         if self.n_returned_queries > self.n_requested_queries:
             raise ValueError("n_returned_queries must be less than or equal to n_requested_queries")
         return self
+
+class PlanningMemoryArtifact(BaseModel):
+    """Schema for persisted planning-memory metadata and state."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    spec_fingerprint: str
+    source_run_id: str
+    created_at: datetime
+    state: PlanningSummaryState
+

--- a/src/pragmata/core/schemas/querygen_output.py
+++ b/src/pragmata/core/schemas/querygen_output.py
@@ -51,7 +51,7 @@ class PlanningSummaryArtifact(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    spec_fingerprint: str
-    source_run_id: str
+    spec_fingerprint: NonEmptyStr
+    source_run_id: NonEmptyStr
     created_at: datetime
     state: PlanningSummaryState

--- a/src/pragmata/core/schemas/querygen_output.py
+++ b/src/pragmata/core/schemas/querygen_output.py
@@ -45,6 +45,7 @@ class SyntheticQueriesMeta(BaseModel):
             raise ValueError("n_returned_queries must be less than or equal to n_requested_queries")
         return self
 
+
 class PlanningMemoryArtifact(BaseModel):
     """Schema for persisted planning-memory metadata and state."""
 
@@ -54,4 +55,3 @@ class PlanningMemoryArtifact(BaseModel):
     source_run_id: str
     created_at: datetime
     state: PlanningSummaryState
-

--- a/src/pragmata/core/schemas/querygen_output.py
+++ b/src/pragmata/core/schemas/querygen_output.py
@@ -46,7 +46,7 @@ class SyntheticQueriesMeta(BaseModel):
         return self
 
 
-class PlanningMemoryArtifact(BaseModel):
+class PlanningSummaryArtifact(BaseModel):
     """Schema for persisted planning-memory metadata and state."""
 
     model_config = ConfigDict(extra="forbid")

--- a/src/pragmata/core/schemas/querygen_summary.py
+++ b/src/pragmata/core/schemas/querygen_summary.py
@@ -1,0 +1,38 @@
+"""Structured output contract for LLM stage 1 query planning memory."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class PlanningSummaryState(BaseModel):
+    """Compact advisory planning-memory state used across planning batches and runs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    redundancy_patterns: str = Field(
+        ...,
+        min_length=1,
+        max_length=300,
+        description=(
+            "Concise description of recurring candidate blueprint patterns, including repeated scenarios, information "
+            "needs, or semantic framings, that are already overrepresented and should be avoided in the next planning "
+            "batch."
+        ),
+    )
+    diversification_targets: str = Field(
+        ...,
+        min_length=1,
+        max_length=300,
+        description=(
+            "Concrete guidance on spec-compatible candidate blueprint patterns, including scenarios, information "
+            "needs, or semantic framings that would improve diversity in the next planning batch."
+        ),
+    )
+    coverage_notes: str = Field(
+        ...,
+        min_length=1,
+        max_length=300,
+        description=(
+            "Brief notes on candidate blueprint patterns, including scenarios and information needs, or semantic "
+            "framings, that have already appeared and should not be revisited too closely in the next planning batch."
+        ),
+    )

--- a/tests/unit/core/schemas/test_querygen_output.py
+++ b/tests/unit/core/schemas/test_querygen_output.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime, timezone
 import pytest
 from pydantic import ValidationError
 
-from pragmata.core.schemas.querygen_output import PlanningMemoryArtifact, SyntheticQueriesMeta, SyntheticQueryRow
+from pragmata.core.schemas.querygen_output import PlanningSummaryArtifact, SyntheticQueriesMeta, SyntheticQueryRow
 
 
 @pytest.fixture()
@@ -187,8 +187,8 @@ def test_synthetic_queries_meta_rejects_returned_queries_above_requested() -> No
 def test_planning_memory_artifact_accepts_valid_payload(
     valid_planning_memory_payload: dict[str, object],
 ) -> None:
-    """PlanningMemoryArtifact validates a complete nested payload."""
-    artifact = PlanningMemoryArtifact.model_validate(valid_planning_memory_payload)
+    """PlanningSummaryArtifact validates a complete nested payload."""
+    artifact = PlanningSummaryArtifact.model_validate(valid_planning_memory_payload)
 
     assert artifact.spec_fingerprint.startswith("9d8b6d94")
     assert artifact.source_run_id == "run_20260309_001"
@@ -201,24 +201,24 @@ def test_planning_memory_artifact_accepts_valid_payload(
 def test_planning_memory_artifact_rejects_extra_keys(
     valid_planning_memory_payload: dict[str, object],
 ) -> None:
-    """PlanningMemoryArtifact rejects unexpected top-level fields."""
+    """PlanningSummaryArtifact rejects unexpected top-level fields."""
     payload = dict(valid_planning_memory_payload)
     payload["unexpected"] = "boom"
 
     with pytest.raises(ValidationError):
-        PlanningMemoryArtifact.model_validate(payload)
+        PlanningSummaryArtifact.model_validate(payload)
 
 
 def test_planning_memory_artifact_rejects_extra_keys_in_nested_state(
     valid_planning_memory_payload: dict[str, object],
 ) -> None:
-    """PlanningMemoryArtifact rejects unexpected nested state fields."""
+    """PlanningSummaryArtifact rejects unexpected nested state fields."""
     payload = dict(valid_planning_memory_payload)
     payload["state"] = dict(payload["state"])
     payload["state"]["unexpected"] = "boom"
 
     with pytest.raises(ValidationError):
-        PlanningMemoryArtifact.model_validate(payload)
+        PlanningSummaryArtifact.model_validate(payload)
 
 
 @pytest.mark.parametrize(
@@ -235,7 +235,7 @@ def test_planning_memory_artifact_validates_nested_state_field_lengths(
     payload["state"][field_name] = ""
 
     with pytest.raises(ValidationError):
-        PlanningMemoryArtifact.model_validate(payload)
+        PlanningSummaryArtifact.model_validate(payload)
 
 
 def test_planning_memory_artifact_rejects_missing_nested_state_field(
@@ -247,4 +247,4 @@ def test_planning_memory_artifact_rejects_missing_nested_state_field(
     payload["state"].pop("coverage_notes")
 
     with pytest.raises(ValidationError):
-        PlanningMemoryArtifact.model_validate(payload)
+        PlanningSummaryArtifact.model_validate(payload)

--- a/tests/unit/core/schemas/test_querygen_output.py
+++ b/tests/unit/core/schemas/test_querygen_output.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime, timezone
 import pytest
 from pydantic import ValidationError
 
-from pragmata.core.schemas.querygen_output import SyntheticQueriesMeta, SyntheticQueryRow
+from pragmata.core.schemas.querygen_output import PlanningMemoryArtifact, SyntheticQueriesMeta, SyntheticQueryRow
 
 
 @pytest.fixture()
@@ -36,6 +36,30 @@ def valid_meta_payload() -> dict[str, object]:
         "model_provider": "openai",
         "planning_model": "gpt-4.1-mini",
         "realization_model": "gpt-4.1-mini",
+    }
+
+
+@pytest.fixture()
+def valid_planning_memory_payload() -> dict[str, object]:
+    """Return a valid planning-memory artifact payload."""
+    return {
+        "spec_fingerprint": "9d8b6d94d8f3a4b74e9e2cb7d5d4a3a2a6d4f7b5b2f8e3c1d6a9b7c4e2f1a0d3",
+        "source_run_id": "run_20260309_001",
+        "created_at": "2026-03-09T10:45:00Z",
+        "state": {
+            "redundancy_patterns": (
+                "Avoid repeating candidate blueprints centered on first-time housing-benefit "
+                "eligibility checks with near-identical applicant situations."
+            ),
+            "diversification_targets": (
+                "Favor candidate blueprints about document preparation, appeal procedures, "
+                "and deadline clarification with distinct scenarios and information needs."
+            ),
+            "coverage_notes": (
+                "Basic housing-support eligibility scenarios have already appeared and should "
+                "not be revisited too closely in the next planning batch."
+            ),
+        },
     }
 
 
@@ -158,3 +182,69 @@ def test_synthetic_queries_meta_rejects_returned_queries_above_requested() -> No
             planning_model="magistral-medium-latest",
             realization_model="mistral-medium-latest",
         )
+
+
+def test_planning_memory_artifact_accepts_valid_payload(
+    valid_planning_memory_payload: dict[str, object],
+) -> None:
+    """PlanningMemoryArtifact validates a complete nested payload."""
+    artifact = PlanningMemoryArtifact.model_validate(valid_planning_memory_payload)
+
+    assert artifact.spec_fingerprint.startswith("9d8b6d94")
+    assert artifact.source_run_id == "run_20260309_001"
+    assert artifact.created_at == datetime(2026, 3, 9, 10, 45, tzinfo=timezone.utc)
+    assert artifact.state.redundancy_patterns.startswith("Avoid repeating")
+    assert artifact.state.diversification_targets.startswith("Favor candidate blueprints")
+    assert artifact.state.coverage_notes.startswith("Basic housing-support")
+
+
+def test_planning_memory_artifact_rejects_extra_keys(
+    valid_planning_memory_payload: dict[str, object],
+) -> None:
+    """PlanningMemoryArtifact rejects unexpected top-level fields."""
+    payload = dict(valid_planning_memory_payload)
+    payload["unexpected"] = "boom"
+
+    with pytest.raises(ValidationError):
+        PlanningMemoryArtifact.model_validate(payload)
+
+
+def test_planning_memory_artifact_rejects_extra_keys_in_nested_state(
+    valid_planning_memory_payload: dict[str, object],
+) -> None:
+    """PlanningMemoryArtifact rejects unexpected nested state fields."""
+    payload = dict(valid_planning_memory_payload)
+    payload["state"] = dict(payload["state"])
+    payload["state"]["unexpected"] = "boom"
+
+    with pytest.raises(ValidationError):
+        PlanningMemoryArtifact.model_validate(payload)
+
+
+@pytest.mark.parametrize(
+    "field_name",
+    ["redundancy_patterns", "diversification_targets", "coverage_notes"],
+)
+def test_planning_memory_artifact_validates_nested_state_field_lengths(
+    valid_planning_memory_payload: dict[str, object],
+    field_name: str,
+) -> None:
+    """Nested PlanningSummaryState field constraints are enforced through the artifact."""
+    payload = dict(valid_planning_memory_payload)
+    payload["state"] = dict(payload["state"])
+    payload["state"][field_name] = ""
+
+    with pytest.raises(ValidationError):
+        PlanningMemoryArtifact.model_validate(payload)
+
+
+def test_planning_memory_artifact_rejects_missing_nested_state_field(
+    valid_planning_memory_payload: dict[str, object],
+) -> None:
+    """Nested PlanningSummaryState requires all summary fields."""
+    payload = dict(valid_planning_memory_payload)
+    payload["state"] = dict(payload["state"])
+    payload["state"].pop("coverage_notes")
+
+    with pytest.raises(ValidationError):
+        PlanningMemoryArtifact.model_validate(payload)

--- a/tests/unit/core/schemas/test_querygen_summary.py
+++ b/tests/unit/core/schemas/test_querygen_summary.py
@@ -1,0 +1,115 @@
+"""Tests for the output contracts for LLM stage 1 planning-memory summary."""
+
+import pytest
+from pydantic import ValidationError
+
+from pragmata.core.schemas.querygen_summary import PlanningSummaryState
+
+
+@pytest.fixture()
+def base_payload() -> dict[str, str]:
+    """Valid PlanningSummaryState payload for a planning-memory use case."""
+    return {
+        "redundancy_patterns": (
+            "Recurring candidate blueprints focus on first-time eligibility checks for housing "
+            "support with very similar applicant scenarios and information needs."
+        ),
+        "diversification_targets": (
+            "Favor spec-compatible candidate blueprints about appeals, document preparation, "
+            "deadline clarification, and follow-up procedures with distinct scenarios and information needs."
+        ),
+        "coverage_notes": (
+            "Basic housing-support eligibility scenarios have already appeared and should not be "
+            "revisited too closely in the next planning batch."
+        ),
+    }
+
+
+def test_planning_summary_state_accepts_valid_payload(base_payload: dict[str, str]) -> None:
+    """Schema accepts a valid planning summary payload."""
+    summary = PlanningSummaryState.model_validate(base_payload)
+
+    assert summary.redundancy_patterns.startswith("Recurring candidate blueprints")
+    assert summary.diversification_targets.startswith("Favor spec-compatible")
+    assert summary.coverage_notes.startswith("Basic housing-support")
+
+
+@pytest.mark.parametrize(
+    "field_name",
+    ["redundancy_patterns", "diversification_targets", "coverage_notes"],
+)
+def test_planning_summary_state_rejects_empty_summary_fields(
+    base_payload: dict[str, str],
+    field_name: str,
+) -> None:
+    """Schema rejects empty planning-summary fields."""
+    payload = {**base_payload, field_name: ""}
+
+    with pytest.raises(ValidationError) as exc_info:
+        PlanningSummaryState.model_validate(payload)
+
+    errors = exc_info.value.errors()
+    assert len(errors) == 1
+    assert errors[0]["loc"] == (field_name,)
+    assert errors[0]["type"] == "string_too_short"
+
+
+@pytest.mark.parametrize(
+    "field_name",
+    ["redundancy_patterns", "diversification_targets", "coverage_notes"],
+)
+def test_planning_summary_state_rejects_fields_longer_than_300_chars(
+    base_payload: dict[str, str],
+    field_name: str,
+) -> None:
+    """Schema rejects planning-summary fields longer than 300 characters."""
+    payload = {**base_payload, field_name: "x" * 301}
+
+    with pytest.raises(ValidationError) as exc_info:
+        PlanningSummaryState.model_validate(payload)
+
+    errors = exc_info.value.errors()
+    assert len(errors) == 1
+    assert errors[0]["loc"] == (field_name,)
+    assert errors[0]["type"] == "string_too_long"
+
+
+def test_planning_summary_state_rejects_extra_fields(base_payload: dict[str, str]) -> None:
+    """Schema rejects unexpected planning-summary fields."""
+    payload = {**base_payload, "unexpected": "value"}
+
+    with pytest.raises(ValidationError) as exc_info:
+        PlanningSummaryState.model_validate(payload)
+
+    errors = exc_info.value.errors()
+    assert len(errors) == 1
+    assert errors[0]["loc"] == ("unexpected",)
+    assert errors[0]["type"] == "extra_forbidden"
+
+
+@pytest.mark.parametrize(
+    "field_name",
+    ["redundancy_patterns", "diversification_targets", "coverage_notes"],
+)
+def test_planning_summary_state_rejects_missing_required_field(
+    base_payload: dict[str, str],
+    field_name: str,
+) -> None:
+    """Schema rejects payloads missing a required planning-summary field."""
+    payload = dict(base_payload)
+    payload.pop(field_name)
+
+    with pytest.raises(ValidationError) as exc_info:
+        PlanningSummaryState.model_validate(payload)
+
+    errors = exc_info.value.errors()
+    assert len(errors) == 1
+    assert errors[0]["loc"] == (field_name,)
+    assert errors[0]["type"] == "missing"
+
+
+def test_planning_summary_state_fields_define_descriptions() -> None:
+    """Planning summary fields expose descriptions for structured LLM output."""
+    for field in PlanningSummaryState.model_fields.values():
+        assert field.description
+        assert field.description.strip()


### PR DESCRIPTION
**Summary**

Add planning-memory schema contracts for synthetic query generation, including the reusable planning summary state and the persisted planning-memory artifact wrapper.

**Key changes**

- Add `core/schemas/querygen_summary.py`:
  - implement `PlanningSummaryState`

- Update `core/schemas/querygen_output.py`:
  - add `PlanningSummaryArtifact`

- Add unit tests for `PlanningSummaryState`:
  - valid payload acceptance
  - empty / overlong field rejection
  - missing-field rejection
  - extra-field rejection
  - field-description coverage

- Extend `test_querygen_output.py` for `PlanningSummaryArtifact`:
  - valid nested payload acceptance
  - top-level and nested extra-field rejection
  - nested validation of `state`
  - missing nested-field rejection

**Status**

Ready for review.

Closes #123