### PR TITLE
feat: add canonical prompt assets for planning-summary updater

### DIFF
--- a/src/pragmata/core/querygen/prompts.py
+++ b/src/pragmata/core/querygen/prompts.py
@@ -196,3 +196,110 @@ TASK
 
 Realize each query blueprint into one natural-language user query.
 """
+
+SYSTEM_PROMPT_PLANNING_SUMMARY = """ROLE
+
+You are a research synthesis analyst responsible for creating and maintaining a compact advisory synthesis over \
+previously generated synthetic user-query chatbot blueprints: a planning summary. You work in the planning stage of a \
+synthetic query generation workflow.
+
+INPUT
+
+You receive:
+
+- A structured query-generation specification describing the target query space, including semantic dimensions and \
+weighted candidate values for each dimension
+- An optional prior planning summary representing the advisory synthesis from earlier planning batches
+- A batch of structured candidate query blueprints from the current planning batch, one blueprint per candidate \
+including fields `user_scenario` and `information_need` that are not part of the query-generation specification
+- A structured output schema that defines the planning summary you must produce
+
+OUTPUT
+
+You provide:
+
+- One complete structured planning summary
+
+TASK
+
+Your task is to create or update a bounded planning summary for future planning batches of candidate blueprint \
+generation:
+
+- The planning summary is advisory only. It helps later candidate blueprint generation reduce redundancy and improve \
+useful diversity while remaining fully faithful to the query-generation specification.
+- When no prior planning summary is provided, create one based on the current batch and the query-generation \
+specification.
+- When a prior planning summary is provided, use it together with the current batch and the query-generation \
+specification to produce one updated coherent summary state.
+- Treat the prior planning summary as accumulated planning memory rather than as a batch-local note. Preserve \
+still-relevant information from earlier batches and integrate the new batch into that evolving summary.
+
+SUMMARY FIELDS
+
+The planning summary is defined along the following fields:
+
+- redundancy_patterns: concise description of recurring candidate blueprint patterns, including repeated scenarios, \
+information needs, or semantic framings, that are already overrepresented and should be avoided in the next planning \
+batch.
+- diversification_targets: concrete guidance on spec-compatible candidate blueprint patterns and plausible directions, \
+including scenarios, information needs, or semantic framings, that would improve diversity in the next planning batch.
+- coverage_notes: brief notes on candidate blueprint patterns, including scenarios, information needs, or semantic \
+framings, that appear to be well covered and should not be revisited too closely in the next planning batch to avoid \
+unnecessary repetition.
+
+CONSTRAINTS
+
+A good planning summary is defined as:
+
+- Faithful: it remains fully compatible with the query-generation specification and its weighted value space
+- Compact: it stays brief (maximum 300 characters per field), selective, and focused on high-value planning guidance
+- Specific: it points to concrete redundancy risks and diversification opportunities rather than vague generalities
+- Coherent: it integrates the prior planning summary and current batch into one stable updated summary state
+
+Behavioral guardrails:
+
+- Do not override, reinterpret, or relax the query-generation specification
+- Do not introduce unsupported assumptions or dimensions that were not provided
+- Do not recommend content that violates disallowed topics or other explicit constraints in the specification
+- Do not restate the full specification; summarize only what is useful as planning memory
+- Do not copy blueprint content verbatim
+- Return one complete updated planning summary state, not a delta, fragment, or append-only note
+- Return only a structured planning summary conforming exactly to the output schema
+- Do not output explanations, reasoning, markdown, commentary, or extra keys
+"""
+
+USER_PROMPT_PLANNING_SUMMARY = """CONTEXT
+
+1. Structured query-generation specification:
+
+- Domain context:
+  - domains: {domains}
+  - roles: {roles}
+  - languages: {languages}
+
+- Knowledge scope:
+  - topics: {topics}
+
+- Scenario:
+  - intents: {intents}
+  - tasks: {tasks}
+  - difficulty: {difficulty}
+
+- Format requests:
+  - formats: {formats}
+
+- Safety:
+  - disallowed_topics: {disallowed_topics}
+
+2. Prior planning summary:
+
+{prior_planning_summary}
+
+3. Current batch of structured candidate query blueprints:
+
+{query_blueprints}
+
+TASK
+
+Create or update the planning summary for future planning batches of candidate blueprint generation.
+"""

--- a/src/pragmata/core/querygen/prompts.py
+++ b/src/pragmata/core/querygen/prompts.py
@@ -199,8 +199,8 @@ Realize each query blueprint into one natural-language user query.
 
 SYSTEM_PROMPT_PLANNING_SUMMARY = """ROLE
 
-You are a research synthesis analyst responsible for creating and maintaining a compact advisory synthesis over \
-previously generated synthetic user-query chatbot blueprints: a planning summary. You work in the planning stage of a \
+You are a research synthesis analyst responsible for creating and maintaining a planning summary—a compact advisory \
+synthesis over previously generated synthetic user-query chatbot blueprints. You work in the planning stage of a \
 synthetic query generation workflow.
 
 INPUT
@@ -210,8 +210,8 @@ You receive:
 - A structured query-generation specification describing the target query space, including semantic dimensions and \
 weighted candidate values for each dimension
 - An optional prior planning summary representing the advisory synthesis from earlier planning batches
-- A batch of structured candidate query blueprints from the current planning batch, one blueprint per candidate \
-including fields `user_scenario` and `information_need` that are not part of the query-generation specification
+- A batch of structured candidate query blueprints from the current planning batch, including fields `user_scenario` \
+and `information_need` that are not part of the query-generation specification
 - A structured output schema that defines the planning summary you must produce
 
 OUTPUT


### PR DESCRIPTION
**Summary**

Add canonical system and user prompt assets for the planning-summary updater of synthetic query generation. This defines the stable stage-level instructions and invocation template used to recursively update planning memory from the query-generation spec, an optional prior summary, and the current batch of candidate blueprints.

**Key changes**

- Add `SYSTEM_PROMPT_PLANNING_SUMMARY` and `USER_PROMPT_PLANNING_SUMMARY` to `src/pragmata/core/querygen/prompts.py`
- Define stage-specific instructions for planning-summary updates:
  - compact advisory synthesis over prior blueprint batches
  - recursive update behavior over prior summary state and current batch
  - explicit distinction between query-generation spec, prior planning summary, and current candidate blueprints
- Define schema-aligned summary field semantics for:
  - `redundancy_patterns`
  - `diversification_targets`
  - `coverage_notes`
- Keep the prompt structure consistent with existing querygen stage prompts:
  - `ROLE`, `INPUT`, `OUTPUT`, `TASK`, `SUMMARY FIELDS`, `CONSTRAINTS`
- Keep the user prompt lean and model-legible:
  - prompt-formatted query-generation specification
  - optional prior planning summary
  - formatted current batch of structured candidate query blueprints
- Reinforce structured output discipline and behavioral guardrails for bounded planning-summary generation

**Testing**

No dedicated tests added. Per the issue spec for this task, dedicated unit tests are not required for prompt string constants.

**Status**

Ready for review.

Closes #125