### PR TITLE
feat: implement planning-summary updater executor

### DIFF
--- a/src/pragmata/core/querygen/planning.py
+++ b/src/pragmata/core/querygen/planning.py
@@ -13,7 +13,7 @@ class PlanningStageError(RuntimeError):
     """Raised when a planning-stage invocation fails."""
 
 
-def _format_weighted_values(values: list[WeightedValue] | None) -> str:
+def format_weighted_values(values: list[WeightedValue] | None) -> str:
     """Format weighted categorical values for prompt injection.
 
     Args:
@@ -28,7 +28,7 @@ def _format_weighted_values(values: list[WeightedValue] | None) -> str:
     return ", ".join(f"{item.value} (weight={item.weight:g})" for item in values)
 
 
-def _format_string_list(values: list[str] | None) -> str:
+def format_string_list(values: list[str] | None) -> str:
     """Format string lists for prompt injection.
 
     Args:
@@ -61,15 +61,15 @@ def _build_planning_prompt_vars(
 
     return {
         "candidate_ids": "\n    - " + "\n    - ".join(batch_candidate_ids),
-        "domains": _format_weighted_values(spec.domain_context.domains),
-        "roles": _format_weighted_values(spec.domain_context.roles),
-        "languages": _format_weighted_values(spec.domain_context.languages),
-        "topics": _format_weighted_values(spec.knowledge_scope.topics),
-        "intents": _format_weighted_values(spec.scenario.intents),
-        "tasks": _format_weighted_values(spec.scenario.tasks),
-        "difficulty": _format_weighted_values(spec.scenario.difficulty),
-        "formats": _format_weighted_values(spec.format_requests.formats),
-        "disallowed_topics": _format_string_list(spec.safety.disallowed_topics),
+        "domains": format_weighted_values(spec.domain_context.domains),
+        "roles": format_weighted_values(spec.domain_context.roles),
+        "languages": format_weighted_values(spec.domain_context.languages),
+        "topics": format_weighted_values(spec.knowledge_scope.topics),
+        "intents": format_weighted_values(spec.scenario.intents),
+        "tasks": format_weighted_values(spec.scenario.tasks),
+        "difficulty": format_weighted_values(spec.scenario.difficulty),
+        "formats": format_weighted_values(spec.format_requests.formats),
+        "disallowed_topics": format_string_list(spec.safety.disallowed_topics),
         "n_queries": len(batch_candidate_ids),
     }
 

--- a/src/pragmata/core/querygen/planning_memory.py
+++ b/src/pragmata/core/querygen/planning_memory.py
@@ -3,7 +3,21 @@
 import hashlib
 import json
 
+from pragmata.core.querygen.llm import LlmInitializationError, build_llm_runnable
+from pragmata.core.querygen.planning import format_string_list, format_weighted_values
+from pragmata.core.querygen.prompts import (
+    SYSTEM_PROMPT_PLANNING_SUMMARY,
+    USER_PROMPT_PLANNING_SUMMARY,
+)
+from pragmata.core.querygen.realization import format_blueprint
 from pragmata.core.schemas.querygen_input import QueryGenSpec
+from pragmata.core.schemas.querygen_plan import QueryBlueprint
+from pragmata.core.schemas.querygen_summary import PlanningSummaryState
+from pragmata.core.settings.querygen_settings import LlmSettings
+
+
+class PlanningSummaryStageError(RuntimeError):
+    """Raised when a planning-summary-stage invocation fails."""
 
 
 def _serialize_spec_content(
@@ -27,7 +41,9 @@ def _serialize_spec_content(
     )
 
 
-def fingerprint_querygen_spec(spec: QueryGenSpec) -> str:
+def fingerprint_querygen_spec(
+    spec: QueryGenSpec,
+) -> str:
     """Return a deterministic SHA-256 fingerprint for a querygen spec.
 
     Args:
@@ -38,3 +54,113 @@ def fingerprint_querygen_spec(spec: QueryGenSpec) -> str:
     """
     serialized = _serialize_spec_content(spec)
     return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def _format_prior_summary_state(
+    prior_summary_state: PlanningSummaryState,
+) -> str:
+    """Format a prior planning summary for prompt injection.
+
+    Args:
+        prior_summary_state: Prior summary state carried forward from earlier batches.
+
+    Returns:
+        A deterministic human-readable representation of the prior planning summary.
+    """
+    return (
+        "- redundancy_patterns:\n"
+        f"  {prior_summary_state.redundancy_patterns}\n"
+        "- diversification_targets:\n"
+        f"  {prior_summary_state.diversification_targets}\n"
+        "- coverage_notes:\n"
+        f"  {prior_summary_state.coverage_notes}"
+    )
+
+
+def _build_planning_summary_prompt_vars(
+    spec: QueryGenSpec,
+    candidates: list[QueryBlueprint],
+    prior_summary_state: PlanningSummaryState | None,
+) -> dict[str, object]:
+    """Build invoke-time prompt variables for one planning-summary.
+
+    Args:
+        spec: Resolved query-generation specification.
+        candidates: Stage-1 candidates for this single summary-updater invocation.
+        prior_summary_state: Optional prior planning summary state.
+
+    Returns:
+        Prompt variables aligned with the summary-updater prompt placeholders.
+    """
+    if not candidates:
+        raise ValueError("candidates must not be empty")
+
+    formatted_blueprints = "\n\n".join(format_blueprint(candidate) for candidate in candidates)
+
+    return {
+        "domains": format_weighted_values(spec.domain_context.domains),
+        "roles": format_weighted_values(spec.domain_context.roles),
+        "languages": format_weighted_values(spec.domain_context.languages),
+        "topics": format_weighted_values(spec.knowledge_scope.topics),
+        "intents": format_weighted_values(spec.scenario.intents),
+        "tasks": format_weighted_values(spec.scenario.tasks),
+        "difficulty": format_weighted_values(spec.scenario.difficulty),
+        "formats": format_weighted_values(spec.format_requests.formats),
+        "disallowed_topics": format_string_list(spec.safety.disallowed_topics),
+        "prior_planning_summary": (
+            _format_prior_summary_state(prior_summary_state)
+            if prior_summary_state is not None
+            else "No prior planning summary available yet."
+        ),
+        "query_blueprints": formatted_blueprints,
+    }
+
+
+def run_planning_summary(
+    spec: QueryGenSpec,
+    candidates: list[QueryBlueprint],
+    llm_settings: LlmSettings,
+    api_key: str,
+    prior_summary_state: PlanningSummaryState | None = None,
+) -> PlanningSummaryState:
+    """Run one summary-updater invocation.
+
+    Args:
+        spec: Resolved query-generation specification.
+        candidates: Stage-1 candidates for this single summary-updater invocation.
+        llm_settings: LLM settings for the query-generation workflow.
+        api_key: Provider API key for the configured planning model.
+        prior_summary_state: Optional prior planning summary state.
+
+    Returns:
+        The updated planning summary state.
+    """
+    prompt_vars = _build_planning_summary_prompt_vars(
+        spec=spec,
+        candidates=candidates,
+        prior_summary_state=prior_summary_state,
+    )
+
+    try:
+        llm_runnable = build_llm_runnable(
+            system_text=SYSTEM_PROMPT_PLANNING_SUMMARY,
+            user_text=USER_PROMPT_PLANNING_SUMMARY,
+            model_provider=llm_settings.model_provider,
+            model=llm_settings.planning_model,
+            api_key=api_key,
+            output_schema=PlanningSummaryState,
+            requests_per_second=llm_settings.requests_per_second,
+            check_every_n_seconds=llm_settings.check_every_n_seconds,
+            max_bucket_size=llm_settings.max_bucket_size,
+            base_url=llm_settings.base_url,
+            model_kwargs=llm_settings.model_kwargs,
+        )
+        llm_output = llm_runnable.invoke(prompt_vars)
+    except LlmInitializationError:
+        raise
+    except Exception as exc:
+        raise PlanningSummaryStageError(
+            "Planning stage invocation failed while updating the planning summary."
+        ) from exc
+
+    return llm_output

--- a/src/pragmata/core/querygen/planning_summary.py
+++ b/src/pragmata/core/querygen/planning_summary.py
@@ -56,6 +56,11 @@ def fingerprint_querygen_spec(
     return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
 
 
+def _normalize_multiline(value: str) -> str:
+    """Normalize multiline text to a single line for prompt safety."""
+    return " ".join(value.splitlines()).strip()
+
+
 def _format_prior_summary_state(
     prior_summary_state: PlanningSummaryState,
 ) -> str:
@@ -69,11 +74,11 @@ def _format_prior_summary_state(
     """
     return (
         "- redundancy_patterns:\n"
-        f"  {prior_summary_state.redundancy_patterns}\n"
+        f"  {_normalize_multiline(prior_summary_state.redundancy_patterns)}\n"
         "- diversification_targets:\n"
-        f"  {prior_summary_state.diversification_targets}\n"
+        f"  {_normalize_multiline(prior_summary_state.diversification_targets)}\n"
         "- coverage_notes:\n"
-        f"  {prior_summary_state.coverage_notes}"
+        f"  {_normalize_multiline(prior_summary_state.coverage_notes)}"
     )
 
 

--- a/src/pragmata/core/querygen/planning_summary.py
+++ b/src/pragmata/core/querygen/planning_summary.py
@@ -1,4 +1,4 @@
-"""Stage-1 planning memory helpers for synthetic query generation."""
+"""Stage-1 planning summary executor for synthetic query generation."""
 
 import hashlib
 import json

--- a/src/pragmata/core/querygen/realization.py
+++ b/src/pragmata/core/querygen/realization.py
@@ -11,7 +11,7 @@ class RealizationStageError(RuntimeError):
     """Raised when a realization-stage invocation fails."""
 
 
-def _format_blueprint(
+def format_blueprint(
     candidate: QueryBlueprint,
 ) -> str:
     """Format one query blueprint for prompt injection.
@@ -65,7 +65,7 @@ def _build_realization_prompt_vars(
     if not candidates:
         raise ValueError("candidates must not be empty")
 
-    formatted_blueprints = "\n\n".join(_format_blueprint(candidate) for candidate in candidates)
+    formatted_blueprints = "\n\n".join(format_blueprint(candidate) for candidate in candidates)
 
     return {
         "query_blueprints": formatted_blueprints,

--- a/tests/unit/core/querygen/test_planning_memory.py
+++ b/tests/unit/core/querygen/test_planning_memory.py
@@ -1,16 +1,29 @@
-"""Tests for the synthetic query-generation stage-1 planning memory helpers."""
+"""Tests for the synthetic query-generation stage-1 planning executor."""
 
 import hashlib
 import json
 from collections.abc import Callable
+from unittest.mock import Mock
 
 import pytest
 
+from pragmata.core.querygen.llm import LlmInitializationError
 from pragmata.core.querygen.planning_memory import (
+    PlanningSummaryStageError,
+    _build_planning_summary_prompt_vars,
+    _format_prior_summary_state,
     _serialize_spec_content,
     fingerprint_querygen_spec,
+    run_planning_summary,
+)
+from pragmata.core.querygen.prompts import (
+    SYSTEM_PROMPT_PLANNING_SUMMARY,
+    USER_PROMPT_PLANNING_SUMMARY,
 )
 from pragmata.core.schemas.querygen_input import QueryGenSpec
+from pragmata.core.schemas.querygen_plan import QueryBlueprint
+from pragmata.core.schemas.querygen_summary import PlanningSummaryState
+from pragmata.core.settings.querygen_settings import LlmSettings
 
 
 @pytest.fixture()
@@ -77,6 +90,45 @@ def expected_default_payload() -> dict[str, object]:
             "disallowed_topics": None,
         },
     }
+
+
+@pytest.fixture()
+def llm_settings() -> LlmSettings:
+    return LlmSettings(
+        model_provider="mistralai",
+        planning_model="magistral-medium-latest",
+        realization_model="mistral-medium-latest",
+        requests_per_second=2.5,
+        check_every_n_seconds=0.2,
+        max_bucket_size=3,
+        base_url="https://example.invalid/v1",
+        model_kwargs={"temperature": 0.2},
+    )
+
+
+@pytest.fixture()
+def prior_summary_state() -> PlanningSummaryState:
+    return PlanningSummaryState(
+        redundancy_patterns="Coverage-letter clarification scenarios recur.",
+        diversification_targets="Add more comparison and multilingual scenarios.",
+        coverage_notes="Basic benefits lookup appears well covered.",
+    )
+
+
+def _make_blueprint(candidate_id: str = "C001") -> QueryBlueprint:
+    return QueryBlueprint(
+        candidate_id=candidate_id,
+        domain="education policy",
+        role="policy analyst",
+        language="en",
+        topic="teacher shortages",
+        intent="find evidence",
+        task="literature search",
+        difficulty="medium",
+        format="bullet list",
+        user_scenario=f"Scenario for {candidate_id}",
+        information_need=f"Information need for {candidate_id}",
+    )
 
 
 def test_serialize_spec_content_returns_expected_canonical_json(
@@ -211,3 +263,321 @@ def test_fingerprint_querygen_spec_matches_sha256_of_serialized_content(
     expected_fingerprint = hashlib.sha256(serialized.encode("utf-8")).hexdigest()
 
     assert fingerprint_querygen_spec(spec) == expected_fingerprint
+
+
+def test_format_prior_summary_state_returns_deterministic_multiline_block(
+    prior_summary_state: PlanningSummaryState,
+) -> None:
+    assert _format_prior_summary_state(prior_summary_state) == (
+        "- redundancy_patterns:\n"
+        "  Coverage-letter clarification scenarios recur.\n"
+        "- diversification_targets:\n"
+        "  Add more comparison and multilingual scenarios.\n"
+        "- coverage_notes:\n"
+        "  Basic benefits lookup appears well covered."
+    )
+
+
+def test_build_planning_summary_prompt_vars_formats_spec_candidates_and_prior_summary(
+    make_spec: Callable[..., QueryGenSpec],
+    prior_summary_state: PlanningSummaryState,
+) -> None:
+    spec = make_spec(
+        domains=[
+            {"value": "education policy", "weight": 0.7},
+            {"value": "health policy", "weight": 0.3},
+        ],
+        roles="policy analyst",
+        languages=["en", "de"],
+        topics=[
+            {"value": "teacher shortages", "weight": 0.6},
+            {"value": "school funding", "weight": 0.4},
+        ],
+        intents=["find evidence", "compare options"],
+        tasks=[
+            {"value": "literature search", "weight": 0.25},
+            {"value": "summarization", "weight": 0.75},
+        ],
+        difficulty="medium",
+        formats=["bullet list", "table"],
+        disallowed_topics=["medical advice", "legal advice"],
+    )
+
+    result = _build_planning_summary_prompt_vars(
+        spec=spec,
+        candidates=[_make_blueprint("C001"), _make_blueprint("C002")],
+        prior_summary_state=prior_summary_state,
+    )
+
+    assert result == {
+        "domains": "education policy (weight=0.7), health policy (weight=0.3)",
+        "roles": "policy analyst (weight=1)",
+        "languages": "en (weight=0.5), de (weight=0.5)",
+        "topics": "teacher shortages (weight=0.6), school funding (weight=0.4)",
+        "intents": "find evidence (weight=0.5), compare options (weight=0.5)",
+        "tasks": "literature search (weight=0.25), summarization (weight=0.75)",
+        "difficulty": "medium (weight=1)",
+        "formats": "bullet list (weight=0.5), table (weight=0.5)",
+        "disallowed_topics": "medical advice, legal advice",
+        "prior_planning_summary": (
+            "- redundancy_patterns:\n"
+            "  Coverage-letter clarification scenarios recur.\n"
+            "- diversification_targets:\n"
+            "  Add more comparison and multilingual scenarios.\n"
+            "- coverage_notes:\n"
+            "  Basic benefits lookup appears well covered."
+        ),
+        "query_blueprints": (
+            "- candidate_id: C001\n"
+            "  domain: education policy\n"
+            "  role: policy analyst\n"
+            "  language: en\n"
+            "  topic: teacher shortages\n"
+            "  intent: find evidence\n"
+            "  task: literature search\n"
+            "  difficulty: medium\n"
+            "  format: bullet list\n"
+            "  user_scenario: Scenario for C001\n"
+            "  information_need: Information need for C001\n\n"
+            "- candidate_id: C002\n"
+            "  domain: education policy\n"
+            "  role: policy analyst\n"
+            "  language: en\n"
+            "  topic: teacher shortages\n"
+            "  intent: find evidence\n"
+            "  task: literature search\n"
+            "  difficulty: medium\n"
+            "  format: bullet list\n"
+            "  user_scenario: Scenario for C002\n"
+            "  information_need: Information need for C002"
+        ),
+    }
+
+
+def test_build_planning_summary_prompt_vars_uses_fallback_when_prior_summary_absent(
+    make_spec: Callable[..., QueryGenSpec],
+) -> None:
+    spec = make_spec(
+        difficulty=None,
+        formats=None,
+        disallowed_topics=None,
+    )
+
+    result = _build_planning_summary_prompt_vars(
+        spec=spec,
+        candidates=[_make_blueprint("C001")],
+        prior_summary_state=None,
+    )
+
+    assert result["difficulty"] == "Not specified"
+    assert result["formats"] == "Not specified"
+    assert result["disallowed_topics"] == "Not specified"
+    assert result["prior_planning_summary"] == "No prior planning summary available yet."
+
+
+def test_build_planning_summary_prompt_vars_rejects_empty_candidates(
+    make_spec: Callable[..., QueryGenSpec],
+) -> None:
+    spec = make_spec()
+
+    with pytest.raises(ValueError, match="candidates must not be empty"):
+        _build_planning_summary_prompt_vars(
+            spec=spec,
+            candidates=[],
+            prior_summary_state=None,
+        )
+
+
+def test_build_planning_summary_prompt_vars_returns_exact_placeholder_mapping(
+    make_spec: Callable[..., QueryGenSpec],
+) -> None:
+    spec = make_spec()
+
+    result = _build_planning_summary_prompt_vars(
+        spec=spec,
+        candidates=[_make_blueprint("C001")],
+        prior_summary_state=None,
+    )
+
+    assert set(result) == {
+        "domains",
+        "roles",
+        "languages",
+        "topics",
+        "intents",
+        "tasks",
+        "difficulty",
+        "formats",
+        "disallowed_topics",
+        "prior_planning_summary",
+        "query_blueprints",
+    }
+
+
+def test_run_planning_summary_wires_summary_prompt_assets_and_settings_into_llm_builder(
+    monkeypatch: pytest.MonkeyPatch,
+    make_spec: Callable[..., QueryGenSpec],
+    llm_settings: LlmSettings,
+    prior_summary_state: PlanningSummaryState,
+) -> None:
+    spec = make_spec()
+    candidates = [_make_blueprint("C001")]
+
+    expected_prompt_vars = _build_planning_summary_prompt_vars(
+        spec=spec,
+        candidates=candidates,
+        prior_summary_state=prior_summary_state,
+    )
+
+    expected_summary = PlanningSummaryState(
+        redundancy_patterns="Repeated evidence-seeking framing appears.",
+        diversification_targets="Increase variation in scenario framing.",
+        coverage_notes="Core teacher-shortage lookup is already covered.",
+    )
+
+    mock_runnable = Mock()
+    mock_runnable.invoke.return_value = expected_summary
+
+    build_llm_runnable_mock = Mock(return_value=mock_runnable)
+    monkeypatch.setattr(
+        "pragmata.core.querygen.planning_memory.build_llm_runnable",
+        build_llm_runnable_mock,
+    )
+
+    result = run_planning_summary(
+        spec=spec,
+        candidates=candidates,
+        llm_settings=llm_settings,
+        api_key="test-api-key",
+        prior_summary_state=prior_summary_state,
+    )
+
+    assert result == expected_summary
+
+    build_llm_runnable_mock.assert_called_once_with(
+        system_text=SYSTEM_PROMPT_PLANNING_SUMMARY,
+        user_text=USER_PROMPT_PLANNING_SUMMARY,
+        model_provider=llm_settings.model_provider,
+        model=llm_settings.planning_model,
+        api_key="test-api-key",
+        output_schema=PlanningSummaryState,
+        requests_per_second=llm_settings.requests_per_second,
+        check_every_n_seconds=llm_settings.check_every_n_seconds,
+        max_bucket_size=llm_settings.max_bucket_size,
+        base_url=llm_settings.base_url,
+        model_kwargs=llm_settings.model_kwargs,
+    )
+    mock_runnable.invoke.assert_called_once_with(expected_prompt_vars)
+
+
+def test_run_planning_summary_invokes_runnable_once_and_returns_summary_state(
+    monkeypatch: pytest.MonkeyPatch,
+    make_spec: Callable[..., QueryGenSpec],
+    llm_settings: LlmSettings,
+) -> None:
+    spec = make_spec()
+    candidates = [_make_blueprint("C001"), _make_blueprint("C002")]
+    expected_prompt_vars = _build_planning_summary_prompt_vars(
+        spec=spec,
+        candidates=candidates,
+        prior_summary_state=None,
+    )
+
+    expected_summary = PlanningSummaryState(
+        redundancy_patterns="Repeated baseline lookup patterns appear.",
+        diversification_targets="Use more decision-oriented information needs.",
+        coverage_notes="Basic factual retrieval seems adequately covered.",
+    )
+
+    class FakeRunnable:
+        def __init__(self) -> None:
+            self.seen_payload: dict[str, object] | None = None
+            self.invoke_calls = 0
+
+        def invoke(self, payload: dict[str, object]) -> PlanningSummaryState:
+            self.invoke_calls += 1
+            self.seen_payload = payload
+            return expected_summary
+
+    fake_runnable = FakeRunnable()
+
+    monkeypatch.setattr(
+        "pragmata.core.querygen.planning_memory.build_llm_runnable",
+        lambda **_: fake_runnable,
+    )
+
+    result = run_planning_summary(
+        spec=spec,
+        candidates=candidates,
+        llm_settings=llm_settings,
+        api_key="test-api-key",
+    )
+
+    assert result == expected_summary
+    assert isinstance(result, PlanningSummaryState)
+    assert fake_runnable.invoke_calls == 1
+    assert fake_runnable.seen_payload == expected_prompt_vars
+
+
+def test_run_planning_summary_propagates_llm_initialization_error(
+    monkeypatch: pytest.MonkeyPatch,
+    make_spec: Callable[..., QueryGenSpec],
+    llm_settings: LlmSettings,
+) -> None:
+    spec = make_spec()
+
+    monkeypatch.setattr(
+        "pragmata.core.querygen.planning_memory.build_llm_runnable",
+        Mock(side_effect=LlmInitializationError("bad config")),
+    )
+
+    with pytest.raises(LlmInitializationError, match="bad config"):
+        run_planning_summary(
+            spec=spec,
+            candidates=[_make_blueprint("C001")],
+            llm_settings=llm_settings,
+            api_key="test-api-key",
+        )
+
+
+def test_run_planning_summary_wraps_invoke_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    make_spec: Callable[..., QueryGenSpec],
+    llm_settings: LlmSettings,
+) -> None:
+    spec = make_spec()
+
+    class FakeRunnable:
+        def invoke(self, payload: dict[str, object]) -> PlanningSummaryState:
+            raise RuntimeError("provider failure")
+
+    monkeypatch.setattr(
+        "pragmata.core.querygen.planning_memory.build_llm_runnable",
+        lambda **_: FakeRunnable(),
+    )
+
+    with pytest.raises(
+        PlanningSummaryStageError,
+        match="Planning stage invocation failed while updating the planning summary.",
+    ):
+        run_planning_summary(
+            spec=spec,
+            candidates=[_make_blueprint("C001")],
+            llm_settings=llm_settings,
+            api_key="test-api-key",
+        )
+
+
+def test_run_planning_summary_propagates_empty_candidates_error(
+    make_spec: Callable[..., QueryGenSpec],
+    llm_settings: LlmSettings,
+) -> None:
+    spec = make_spec()
+
+    with pytest.raises(ValueError, match="candidates must not be empty"):
+        run_planning_summary(
+            spec=spec,
+            candidates=[],
+            llm_settings=llm_settings,
+            api_key="test-api-key",
+        )

--- a/tests/unit/core/querygen/test_planning_summary.py
+++ b/tests/unit/core/querygen/test_planning_summary.py
@@ -1,4 +1,4 @@
-"""Tests for the synthetic query-generation stage-1 planning executor."""
+"""Tests for the synthetic query-generation stage-1 planning summary executor."""
 
 import hashlib
 import json
@@ -8,7 +8,7 @@ from unittest.mock import Mock
 import pytest
 
 from pragmata.core.querygen.llm import LlmInitializationError
-from pragmata.core.querygen.planning_memory import (
+from pragmata.core.querygen.planning_summary import (
     PlanningSummaryStageError,
     _build_planning_summary_prompt_vars,
     _format_prior_summary_state,

--- a/tests/unit/core/querygen/test_planning_summary.py
+++ b/tests/unit/core/querygen/test_planning_summary.py
@@ -167,7 +167,6 @@ def test_fingerprint_querygen_spec_is_stable_across_repeated_calls(
     fingerprint = fingerprint_querygen_spec(spec)
 
     assert fingerprint == fingerprint_querygen_spec(spec)
-    assert fingerprint == fingerprint_querygen_spec(spec)
     assert len(fingerprint) == 64
     assert all(char in "0123456789abcdef" for char in fingerprint)
 
@@ -265,16 +264,20 @@ def test_fingerprint_querygen_spec_matches_sha256_of_serialized_content(
     assert fingerprint_querygen_spec(spec) == expected_fingerprint
 
 
-def test_format_prior_summary_state_returns_deterministic_multiline_block(
-    prior_summary_state: PlanningSummaryState,
-) -> None:
+def test_format_prior_summary_state_normalizes_embedded_newlines() -> None:
+    prior_summary_state = PlanningSummaryState(
+        redundancy_patterns="Coverage-letter clarification scenarios recur.\nRepeated follow-up framing appears.",
+        diversification_targets="Add more comparison scenarios.\nAdd multilingual requests.",
+        coverage_notes="Basic benefits lookup appears well covered.\nFAQ-style requests also recur.",
+    )
+
     assert _format_prior_summary_state(prior_summary_state) == (
         "- redundancy_patterns:\n"
-        "  Coverage-letter clarification scenarios recur.\n"
+        "  Coverage-letter clarification scenarios recur. Repeated follow-up framing appears.\n"
         "- diversification_targets:\n"
-        "  Add more comparison and multilingual scenarios.\n"
+        "  Add more comparison scenarios. Add multilingual requests.\n"
         "- coverage_notes:\n"
-        "  Basic benefits lookup appears well covered."
+        "  Basic benefits lookup appears well covered. FAQ-style requests also recur."
     )
 
 
@@ -412,6 +415,32 @@ def test_build_planning_summary_prompt_vars_returns_exact_placeholder_mapping(
         "prior_planning_summary",
         "query_blueprints",
     }
+
+
+def test_build_planning_summary_prompt_vars_normalizes_multiline_prior_summary(
+    make_spec: Callable[..., QueryGenSpec],
+) -> None:
+    spec = make_spec()
+    prior_summary_state = PlanningSummaryState(
+        redundancy_patterns="Pattern A\nPattern B",
+        diversification_targets="Target A\nTarget B",
+        coverage_notes="Note A\nNote B",
+    )
+
+    result = _build_planning_summary_prompt_vars(
+        spec=spec,
+        candidates=[_make_blueprint("C001")],
+        prior_summary_state=prior_summary_state,
+    )
+
+    assert result["prior_planning_summary"] == (
+        "- redundancy_patterns:\n"
+        "  Pattern A Pattern B\n"
+        "- diversification_targets:\n"
+        "  Target A Target B\n"
+        "- coverage_notes:\n"
+        "  Note A Note B"
+    )
 
 
 def test_run_planning_summary_wires_summary_prompt_assets_and_settings_into_llm_builder(

--- a/tests/unit/core/querygen/test_planning_summary.py
+++ b/tests/unit/core/querygen/test_planning_summary.py
@@ -440,7 +440,7 @@ def test_run_planning_summary_wires_summary_prompt_assets_and_settings_into_llm_
 
     build_llm_runnable_mock = Mock(return_value=mock_runnable)
     monkeypatch.setattr(
-        "pragmata.core.querygen.planning_memory.build_llm_runnable",
+        "pragmata.core.querygen.planning_summary.build_llm_runnable",
         build_llm_runnable_mock,
     )
 
@@ -502,7 +502,7 @@ def test_run_planning_summary_invokes_runnable_once_and_returns_summary_state(
     fake_runnable = FakeRunnable()
 
     monkeypatch.setattr(
-        "pragmata.core.querygen.planning_memory.build_llm_runnable",
+        "pragmata.core.querygen.planning_summary.build_llm_runnable",
         lambda **_: fake_runnable,
     )
 
@@ -527,7 +527,7 @@ def test_run_planning_summary_propagates_llm_initialization_error(
     spec = make_spec()
 
     monkeypatch.setattr(
-        "pragmata.core.querygen.planning_memory.build_llm_runnable",
+        "pragmata.core.querygen.planning_summary.build_llm_runnable",
         Mock(side_effect=LlmInitializationError("bad config")),
     )
 
@@ -552,7 +552,7 @@ def test_run_planning_summary_wraps_invoke_failures(
             raise RuntimeError("provider failure")
 
     monkeypatch.setattr(
-        "pragmata.core.querygen.planning_memory.build_llm_runnable",
+        "pragmata.core.querygen.planning_summary.build_llm_runnable",
         lambda **_: FakeRunnable(),
     )
 


### PR DESCRIPTION
**Summary**

Implement the planning-summary updater executor for synthetic query generation, including prompt payload construction, LLM invocation wiring, and structured output handling. Also promotes selected formatting helpers from planning and realization stages for cross-stage reuse.

**Key changes**

- Add planning-summary executor in `core/querygen/planning_memory.py`:
  - `_format_prior_summary_state()` for rendering `PlanningSummaryState` into human-readable prompt text
  - `_build_planning_summary_prompt_vars()` for constructing summary-updater prompt payloads from:
    - resolved `QueryGenSpec`
    - current batch of `QueryBlueprint`s
    - optional prior planning summary state
  - `run_planning_summary()` for:
    - composing the summary-updater runnable via `build_llm_runnable(...)`
    - enforcing `PlanningSummaryState` structured output
    - `.invoke(...)` execution
    - returning updated `PlanningSummaryState`
  - introduce `PlanningSummaryStageError` and wrap invocation failures with a clear, user-facing error while preserving `LlmInitializationError`

- Promote formatting helpers for cross-stage reuse:
  - update `core/querygen/planning.py`:
    - `_format_weighted_values()` → `format_weighted_values()`
    - `_format_string_list()` → `format_string_list()`
  - update `core/querygen/realization.py`:
    - `_format_blueprint()` → `format_blueprint()`
  - enables consistent prompt formatting across planning, realization, and planning-memory stages

- Prompt payload design:
  - aligns with summary-updater prompt placeholders:
    - spec dimensions (`domains`, `roles`, `languages`, `topics`, `intents`, `tasks`, `difficulty`, `formats`, `disallowed_topics`)
    - `prior_planning_summary`
    - `query_blueprints`
  - injects fallback text when no prior summary state is available

- Add unit tests in `tests/unit/core/querygen/test_planning_memory.py` covering:
  - canonical spec serialization and fingerprint stability
  - deterministic prior-summary formatting
  - prompt-payload construction from spec, candidates, and optional prior summary
  - fallback behavior when no prior summary is available
  - exact placeholder mapping
  - correct wiring of summary-updater prompt assets and `planning_model`
  - `output_schema=PlanningSummaryState`
  - one-shot invocation behavior and returned `PlanningSummaryState`
  - propagation of `LlmInitializationError`
  - wrapping of invocation failures in `PlanningSummaryStageError`
  - empty-candidate validation

**Status**

Ready for review.

Closes #126