### PR TITLE
feat: implement planning-summary artifact loading with spec compatibility checks

### DIFF
--- a/src/pragmata/core/querygen/planning.py
+++ b/src/pragmata/core/querygen/planning.py
@@ -13,7 +13,7 @@ class PlanningStageError(RuntimeError):
     """Raised when a planning-stage invocation fails."""
 
 
-def _format_weighted_values(values: list[WeightedValue] | None) -> str:
+def format_weighted_values(values: list[WeightedValue] | None) -> str:
     """Format weighted categorical values for prompt injection.
 
     Args:
@@ -28,7 +28,7 @@ def _format_weighted_values(values: list[WeightedValue] | None) -> str:
     return ", ".join(f"{item.value} (weight={item.weight:g})" for item in values)
 
 
-def _format_string_list(values: list[str] | None) -> str:
+def format_string_list(values: list[str] | None) -> str:
     """Format string lists for prompt injection.
 
     Args:
@@ -61,15 +61,15 @@ def _build_planning_prompt_vars(
 
     return {
         "candidate_ids": "\n    - " + "\n    - ".join(batch_candidate_ids),
-        "domains": _format_weighted_values(spec.domain_context.domains),
-        "roles": _format_weighted_values(spec.domain_context.roles),
-        "languages": _format_weighted_values(spec.domain_context.languages),
-        "topics": _format_weighted_values(spec.knowledge_scope.topics),
-        "intents": _format_weighted_values(spec.scenario.intents),
-        "tasks": _format_weighted_values(spec.scenario.tasks),
-        "difficulty": _format_weighted_values(spec.scenario.difficulty),
-        "formats": _format_weighted_values(spec.format_requests.formats),
-        "disallowed_topics": _format_string_list(spec.safety.disallowed_topics),
+        "domains": format_weighted_values(spec.domain_context.domains),
+        "roles": format_weighted_values(spec.domain_context.roles),
+        "languages": format_weighted_values(spec.domain_context.languages),
+        "topics": format_weighted_values(spec.knowledge_scope.topics),
+        "intents": format_weighted_values(spec.scenario.intents),
+        "tasks": format_weighted_values(spec.scenario.tasks),
+        "difficulty": format_weighted_values(spec.scenario.difficulty),
+        "formats": format_weighted_values(spec.format_requests.formats),
+        "disallowed_topics": format_string_list(spec.safety.disallowed_topics),
         "n_queries": len(batch_candidate_ids),
     }
 

--- a/src/pragmata/core/querygen/planning_memory.py
+++ b/src/pragmata/core/querygen/planning_memory.py
@@ -3,7 +3,21 @@
 import hashlib
 import json
 
+from pragmata.core.querygen.llm import LlmInitializationError, build_llm_runnable
+from pragmata.core.querygen.planning import format_string_list, format_weighted_values
+from pragmata.core.querygen.prompts import (
+    SYSTEM_PROMPT_PLANNING_SUMMARY,
+    USER_PROMPT_PLANNING_SUMMARY,
+)
+from pragmata.core.querygen.realization import format_blueprint
 from pragmata.core.schemas.querygen_input import QueryGenSpec
+from pragmata.core.schemas.querygen_plan import QueryBlueprint
+from pragmata.core.schemas.querygen_summary import PlanningSummaryState
+from pragmata.core.settings.querygen_settings import LlmSettings
+
+
+class PlanningSummaryStageError(RuntimeError):
+    """Raised when a planning-summary-stage invocation fails."""
 
 
 def _serialize_spec_content(
@@ -27,7 +41,9 @@ def _serialize_spec_content(
     )
 
 
-def fingerprint_querygen_spec(spec: QueryGenSpec) -> str:
+def fingerprint_querygen_spec(
+    spec: QueryGenSpec,
+) -> str:
     """Return a deterministic SHA-256 fingerprint for a querygen spec.
 
     Args:
@@ -38,3 +54,113 @@ def fingerprint_querygen_spec(spec: QueryGenSpec) -> str:
     """
     serialized = _serialize_spec_content(spec)
     return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def _format_prior_summary_state(
+    prior_summary_state: PlanningSummaryState,
+) -> str:
+    """Format a prior planning summary for prompt injection.
+
+    Args:
+        prior_summary_state: Prior summary state carried forward from earlier batches.
+
+    Returns:
+        A deterministic human-readable representation of the prior planning summary.
+    """
+    return (
+        "- redundancy_patterns:\n"
+        f"  {prior_summary_state.redundancy_patterns}\n"
+        "- diversification_targets:\n"
+        f"  {prior_summary_state.diversification_targets}\n"
+        "- coverage_notes:\n"
+        f"  {prior_summary_state.coverage_notes}"
+    )
+
+
+def _build_planning_summary_prompt_vars(
+    spec: QueryGenSpec,
+    candidates: list[QueryBlueprint],
+    prior_summary_state: PlanningSummaryState | None,
+) -> dict[str, object]:
+    """Build invoke-time prompt variables for one planning-summary.
+
+    Args:
+        spec: Resolved query-generation specification.
+        candidates: Stage-1 candidates for this single summary-updater invocation.
+        prior_summary_state: Optional prior planning summary state.
+
+    Returns:
+        Prompt variables aligned with the summary-updater prompt placeholders.
+    """
+    if not candidates:
+        raise ValueError("candidates must not be empty")
+
+    formatted_blueprints = "\n\n".join(format_blueprint(candidate) for candidate in candidates)
+
+    return {
+        "domains": format_weighted_values(spec.domain_context.domains),
+        "roles": format_weighted_values(spec.domain_context.roles),
+        "languages": format_weighted_values(spec.domain_context.languages),
+        "topics": format_weighted_values(spec.knowledge_scope.topics),
+        "intents": format_weighted_values(spec.scenario.intents),
+        "tasks": format_weighted_values(spec.scenario.tasks),
+        "difficulty": format_weighted_values(spec.scenario.difficulty),
+        "formats": format_weighted_values(spec.format_requests.formats),
+        "disallowed_topics": format_string_list(spec.safety.disallowed_topics),
+        "prior_planning_summary": (
+            _format_prior_summary_state(prior_summary_state)
+            if prior_summary_state is not None
+            else "No prior planning summary available yet."
+        ),
+        "query_blueprints": formatted_blueprints,
+    }
+
+
+def run_planning_summary(
+    spec: QueryGenSpec,
+    candidates: list[QueryBlueprint],
+    llm_settings: LlmSettings,
+    api_key: str,
+    prior_summary_state: PlanningSummaryState | None = None,
+) -> PlanningSummaryState:
+    """Run one summary-updater invocation.
+
+    Args:
+        spec: Resolved query-generation specification.
+        candidates: Stage-1 candidates for this single summary-updater invocation.
+        llm_settings: LLM settings for the query-generation workflow.
+        api_key: Provider API key for the configured planning model.
+        prior_summary_state: Optional prior planning summary state.
+
+    Returns:
+        The updated planning summary state.
+    """
+    prompt_vars = _build_planning_summary_prompt_vars(
+        spec=spec,
+        candidates=candidates,
+        prior_summary_state=prior_summary_state,
+    )
+
+    try:
+        llm_runnable = build_llm_runnable(
+            system_text=SYSTEM_PROMPT_PLANNING_SUMMARY,
+            user_text=USER_PROMPT_PLANNING_SUMMARY,
+            model_provider=llm_settings.model_provider,
+            model=llm_settings.planning_model,
+            api_key=api_key,
+            output_schema=PlanningSummaryState,
+            requests_per_second=llm_settings.requests_per_second,
+            check_every_n_seconds=llm_settings.check_every_n_seconds,
+            max_bucket_size=llm_settings.max_bucket_size,
+            base_url=llm_settings.base_url,
+            model_kwargs=llm_settings.model_kwargs,
+        )
+        llm_output = llm_runnable.invoke(prompt_vars)
+    except LlmInitializationError:
+        raise
+    except Exception as exc:
+        raise PlanningSummaryStageError(
+            "Planning stage invocation failed while updating the planning summary."
+        ) from exc
+
+    return llm_output

--- a/src/pragmata/core/querygen/planning_memory.py
+++ b/src/pragmata/core/querygen/planning_memory.py
@@ -1,0 +1,40 @@
+"""Stage-1 planning memory helpers for synthetic query generation."""
+
+import hashlib
+import json
+
+from pragmata.core.schemas.querygen_input import QueryGenSpec
+
+
+def _serialize_spec_content(
+    spec: QueryGenSpec,
+) -> str:
+    """Build a deterministic content-only serialization for a querygen spec.
+
+    Args:
+        spec: Resolved query-generation specification.
+
+    Returns:
+        A canonical JSON string suitable for stable hashing.
+    """
+    payload = spec.model_dump(mode="json")
+
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+
+
+def fingerprint_querygen_spec(spec: QueryGenSpec) -> str:
+    """Return a deterministic SHA-256 fingerprint for a querygen spec.
+
+    Args:
+        spec: Resolved query-generation specification.
+
+    Returns:
+        Stable SHA-256 hex digest of the canonical serialized spec content.
+    """
+    serialized = _serialize_spec_content(spec)
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()

--- a/src/pragmata/core/querygen/planning_memory.py
+++ b/src/pragmata/core/querygen/planning_memory.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import json
+from pathlib import Path
 
 from pragmata.core.querygen.llm import LlmInitializationError, build_llm_runnable
 from pragmata.core.querygen.planning import format_string_list, format_weighted_values
@@ -11,6 +12,7 @@ from pragmata.core.querygen.prompts import (
 )
 from pragmata.core.querygen.realization import format_blueprint
 from pragmata.core.schemas.querygen_input import QueryGenSpec
+from pragmata.core.schemas.querygen_output import PlanningMemoryArtifact
 from pragmata.core.schemas.querygen_plan import QueryBlueprint
 from pragmata.core.schemas.querygen_summary import PlanningSummaryState
 from pragmata.core.settings.querygen_settings import LlmSettings
@@ -54,6 +56,35 @@ def fingerprint_querygen_spec(
     """
     serialized = _serialize_spec_content(spec)
     return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def read_planning_summary_artifact(
+    artifact_path: Path,
+    spec: QueryGenSpec,
+) -> PlanningMemoryArtifact | None:
+    """Read a planning-summary artifact if it matches the current spec.
+
+    Args:
+        artifact_path: Path to the persisted planning-summary artifact JSON file.
+        spec: Resolved query-generation specification for the current run.
+
+    Returns:
+        The validated planning-summary artifact when the file exists and its
+        ``spec_fingerprint`` exactly matches the current spec fingerprint.
+        Returns ``None`` when the path does not exist or when the artifact
+        fingerprint is incompatible with the current spec.
+    """
+    if not artifact_path.exists():
+        return None
+
+    payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+    artifact = PlanningMemoryArtifact.model_validate(payload)
+
+    current_spec_fingerprint = fingerprint_querygen_spec(spec)
+    if artifact.spec_fingerprint != current_spec_fingerprint:
+        return None
+
+    return artifact
 
 
 def _format_prior_summary_state(

--- a/src/pragmata/core/querygen/planning_memory.py
+++ b/src/pragmata/core/querygen/planning_memory.py
@@ -12,7 +12,7 @@ from pragmata.core.querygen.prompts import (
 )
 from pragmata.core.querygen.realization import format_blueprint
 from pragmata.core.schemas.querygen_input import QueryGenSpec
-from pragmata.core.schemas.querygen_output import PlanningMemoryArtifact
+from pragmata.core.schemas.querygen_output import PlanningSummaryArtifact
 from pragmata.core.schemas.querygen_plan import QueryBlueprint
 from pragmata.core.schemas.querygen_summary import PlanningSummaryState
 from pragmata.core.settings.querygen_settings import LlmSettings
@@ -61,7 +61,7 @@ def fingerprint_querygen_spec(
 def read_planning_summary_artifact(
     artifact_path: Path,
     spec: QueryGenSpec,
-) -> PlanningMemoryArtifact | None:
+) -> PlanningSummaryArtifact | None:
     """Read a planning-summary artifact if it matches the current spec.
 
     Args:
@@ -78,7 +78,7 @@ def read_planning_summary_artifact(
         return None
 
     payload = json.loads(artifact_path.read_text(encoding="utf-8"))
-    artifact = PlanningMemoryArtifact.model_validate(payload)
+    artifact = PlanningSummaryArtifact.model_validate(payload)
 
     current_spec_fingerprint = fingerprint_querygen_spec(spec)
     if artifact.spec_fingerprint != current_spec_fingerprint:

--- a/src/pragmata/core/querygen/realization.py
+++ b/src/pragmata/core/querygen/realization.py
@@ -11,7 +11,7 @@ class RealizationStageError(RuntimeError):
     """Raised when a realization-stage invocation fails."""
 
 
-def _format_blueprint(
+def format_blueprint(
     candidate: QueryBlueprint,
 ) -> str:
     """Format one query blueprint for prompt injection.
@@ -65,7 +65,7 @@ def _build_realization_prompt_vars(
     if not candidates:
         raise ValueError("candidates must not be empty")
 
-    formatted_blueprints = "\n\n".join(_format_blueprint(candidate) for candidate in candidates)
+    formatted_blueprints = "\n\n".join(format_blueprint(candidate) for candidate in candidates)
 
     return {
         "query_blueprints": formatted_blueprints,

--- a/tests/unit/core/querygen/test_planning_memory.py
+++ b/tests/unit/core/querygen/test_planning_memory.py
@@ -1,0 +1,213 @@
+"""Tests for the synthetic query-generation stage-1 planning memory helpers."""
+
+import hashlib
+import json
+from collections.abc import Callable
+
+import pytest
+
+from pragmata.core.querygen.planning_memory import (
+    _serialize_spec_content,
+    fingerprint_querygen_spec,
+)
+from pragmata.core.schemas.querygen_input import QueryGenSpec
+
+
+@pytest.fixture()
+def make_spec() -> Callable[..., QueryGenSpec]:
+    def _make_spec(
+        *,
+        domains: object = "education policy",
+        roles: object = "policy analyst",
+        languages: object = "en",
+        topics: object = "teacher shortages",
+        intents: object = "find evidence",
+        tasks: object = "literature search",
+        difficulty: object = "medium",
+        formats: object = "bullet list",
+        disallowed_topics: list[str] | None = None,
+    ) -> QueryGenSpec:
+        return QueryGenSpec.model_validate(
+            {
+                "domain_context": {
+                    "domains": domains,
+                    "roles": roles,
+                    "languages": languages,
+                },
+                "knowledge_scope": {
+                    "topics": topics,
+                },
+                "scenario": {
+                    "intents": intents,
+                    "tasks": tasks,
+                    "difficulty": difficulty,
+                },
+                "format_requests": {
+                    "formats": formats,
+                },
+                "safety": {
+                    "disallowed_topics": disallowed_topics,
+                },
+            }
+        )
+
+    return _make_spec
+
+
+@pytest.fixture()
+def expected_default_payload() -> dict[str, object]:
+    return {
+        "domain_context": {
+            "domains": [{"value": "education policy", "weight": 1.0}],
+            "roles": [{"value": "policy analyst", "weight": 1.0}],
+            "languages": [{"value": "en", "weight": 1.0}],
+        },
+        "knowledge_scope": {
+            "topics": [{"value": "teacher shortages", "weight": 1.0}],
+        },
+        "scenario": {
+            "intents": [{"value": "find evidence", "weight": 1.0}],
+            "tasks": [{"value": "literature search", "weight": 1.0}],
+            "difficulty": [{"value": "medium", "weight": 1.0}],
+        },
+        "format_requests": {
+            "formats": [{"value": "bullet list", "weight": 1.0}],
+        },
+        "safety": {
+            "disallowed_topics": None,
+        },
+    }
+
+
+def test_serialize_spec_content_returns_expected_canonical_json(
+    make_spec: Callable[..., QueryGenSpec],
+    expected_default_payload: dict[str, object],
+) -> None:
+    spec = make_spec()
+
+    expected_serialized = json.dumps(
+        expected_default_payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+    assert _serialize_spec_content(spec) == expected_serialized
+
+
+def test_serialize_spec_content_round_trips_to_expected_payload(
+    make_spec: Callable[..., QueryGenSpec],
+    expected_default_payload: dict[str, object],
+) -> None:
+    spec = make_spec()
+
+    serialized = _serialize_spec_content(spec)
+
+    assert isinstance(serialized, str)
+    assert json.loads(serialized) == expected_default_payload
+
+
+def test_fingerprint_querygen_spec_is_stable_across_repeated_calls(
+    make_spec: Callable[..., QueryGenSpec],
+) -> None:
+    spec = make_spec(disallowed_topics=["medical advice"])
+
+    fingerprint = fingerprint_querygen_spec(spec)
+
+    assert fingerprint == fingerprint_querygen_spec(spec)
+    assert fingerprint == fingerprint_querygen_spec(spec)
+    assert len(fingerprint) == 64
+    assert all(char in "0123456789abcdef" for char in fingerprint)
+
+
+@pytest.mark.parametrize(
+    ("field_name", "base_value", "changed_value"),
+    [
+        ("domains", "education policy", "health policy"),
+        ("roles", "policy analyst", "school principal"),
+        ("languages", "en", "de"),
+        ("topics", "teacher shortages", "school meals"),
+        ("intents", "find evidence", "compare options"),
+        ("tasks", "literature search", "summarization"),
+        ("difficulty", "medium", "hard"),
+        ("formats", "bullet list", "table"),
+        ("disallowed_topics", ["medical advice"], ["legal advice"]),
+    ],
+)
+def test_fingerprint_querygen_spec_changes_when_any_field_value_changes(
+    make_spec: Callable[..., QueryGenSpec],
+    field_name: str,
+    base_value: object,
+    changed_value: object,
+) -> None:
+    kwargs_base = {field_name: base_value}
+    kwargs_changed = {field_name: changed_value}
+
+    spec_a = make_spec(**kwargs_base)
+    spec_b = make_spec(**kwargs_changed)
+
+    assert fingerprint_querygen_spec(spec_a) != fingerprint_querygen_spec(spec_b)
+
+
+def test_fingerprint_querygen_spec_matches_for_equivalent_canonicalized_inputs() -> None:
+    scalar_spec = QueryGenSpec.model_validate(
+        {
+            "domain_context": {
+                "domains": "education policy",
+                "roles": "policy analyst",
+                "languages": "en",
+            },
+            "knowledge_scope": {
+                "topics": "teacher shortages",
+            },
+            "scenario": {
+                "intents": "find evidence",
+                "tasks": "literature search",
+                "difficulty": "medium",
+            },
+            "format_requests": {
+                "formats": "bullet list",
+            },
+            "safety": {
+                "disallowed_topics": ["medical advice"],
+            },
+        }
+    )
+
+    weighted_spec = QueryGenSpec.model_validate(
+        {
+            "domain_context": {
+                "domains": [{"value": "education policy", "weight": 1.0}],
+                "roles": [{"value": "policy analyst", "weight": 1.0}],
+                "languages": [{"value": "en", "weight": 1.0}],
+            },
+            "knowledge_scope": {
+                "topics": [{"value": "teacher shortages", "weight": 1.0}],
+            },
+            "scenario": {
+                "intents": [{"value": "find evidence", "weight": 1.0}],
+                "tasks": [{"value": "literature search", "weight": 1.0}],
+                "difficulty": [{"value": "medium", "weight": 1.0}],
+            },
+            "format_requests": {
+                "formats": [{"value": "bullet list", "weight": 1.0}],
+            },
+            "safety": {
+                "disallowed_topics": ["medical advice"],
+            },
+        }
+    )
+
+    assert scalar_spec == weighted_spec
+    assert fingerprint_querygen_spec(scalar_spec) == fingerprint_querygen_spec(weighted_spec)
+
+
+def test_fingerprint_querygen_spec_matches_sha256_of_serialized_content(
+    make_spec: Callable[..., QueryGenSpec],
+) -> None:
+    spec = make_spec(disallowed_topics=["medical advice"])
+
+    serialized = _serialize_spec_content(spec)
+    expected_fingerprint = hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+    assert fingerprint_querygen_spec(spec) == expected_fingerprint


### PR DESCRIPTION
**Summary**

Implement planning-summary artifact loading in `core/querygen/planning_memory.py`, including spec compatibility checks via deterministic spec fingerprint comparison.

**Key changes**

- Add `read_planning_summary_artifact()`:
  - reads a persisted planning-summary artifact JSON from disk
  - validates the payload against `PlanningSummaryArtifact`
  - computes the current spec fingerprint via `fingerprint_querygen_spec(spec)`
  - returns the artifact only when the fingerprint matches exactly
- Return `None` when:
  - the artifact path does not exist
  - the artifact fingerprint does not match the current spec

**Testing**

Tests are still outstanding and will follow.

**Status**

Requires merge of PR #137.

Closes #127