### PR TITLE
feat: wire staged synthetic query generation into gen_queries()

### DIFF
--- a/src/pragmata/api/querygen.py
+++ b/src/pragmata/api/querygen.py
@@ -1,5 +1,6 @@
 """API orchestration for the synthetic query generation workflow."""
 
+from itertools import islice
 from pathlib import Path
 from typing import Any
 
@@ -7,16 +8,25 @@ from pydantic import BaseModel, ConfigDict, PositiveInt
 
 from pragmata.core.paths.paths import WorkspacePaths
 from pragmata.core.paths.querygen_paths import QueryGenRunPaths, resolve_querygen_paths
+from pragmata.core.querygen.assembly import assemble_queries_meta, assemble_query_rows
+from pragmata.core.querygen.batching import build_candidate_ids, chunk_blueprints, iter_batch_sizes
+from pragmata.core.querygen.deduplication import deduplicate_blueprints
+from pragmata.core.querygen.export import export_queries
+from pragmata.core.querygen.filtering import filter_aligned_candidate_ids
+from pragmata.core.querygen.planning import run_planning_stage
+from pragmata.core.querygen.realization import run_realization_stage
+from pragmata.core.schemas.querygen_plan import QueryBlueprint
+from pragmata.core.schemas.querygen_realize import RealizedQuery
 from pragmata.core.settings.querygen_settings import QueryGenRunSettings
 from pragmata.core.settings.settings_base import UNSET, Unset, load_config_file, resolve_provider_api_key
 
 
 class QueryGenRunResult(BaseModel):
-    """Prepared invocation state for a synthetic query generation run.
+    """Returned run descriptor for a synthetic query generation run.
 
     Attributes:
-        settings: Fully resolved run settings.
-        paths: Filesystem paths for run artifacts.
+        settings: Fully resolved run settings used for the run.
+        paths: Filesystem paths to the exported run artifacts.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -50,11 +60,11 @@ def gen_queries(
     model_kwargs: dict[str, Any] | Unset = UNSET,
     batch_size: PositiveInt | Unset = UNSET,
 ) -> QueryGenRunResult:
-    """Prepare a synthetic query generation run.
+    """Generate synthetic chatbot queries from a query-generation specification.
 
-    This function resolves the effective runtime configuration,
-    validates provider credentials, and prepares filesystem paths
-    for the run. It does not yet execute the query generation workflow.
+    This function resolves the effective runtime configuration, validates provider
+    credentials, prepares filesystem paths for the run, executes the staged query-generation
+    workflow, and exports the generated query artifacts to disk.
 
     Args:
         domains: Domain choices for the generated queries. The domain is the
@@ -101,8 +111,8 @@ def gen_queries(
             through to the underlying chat model.
 
     Returns:
-        QueryGenRunResult: Prepared run state containing resolved settings
-        and filesystem paths.
+        QueryGenRunResult: Run descriptor containing the resolved settings used
+        for the run and the filesystem paths to the exported artifacts.
     """
     settings = QueryGenRunSettings.resolve(
         config=load_config_file(config_path) if isinstance(config_path, (str, Path)) else None,
@@ -146,11 +156,80 @@ def gen_queries(
         },
     )
 
-    resolve_provider_api_key(settings.llm.model_provider)
+    api_key = resolve_provider_api_key(settings.llm.model_provider)
 
     paths = resolve_querygen_paths(
         workspace=WorkspacePaths.from_base_dir(settings.base_dir),
         run_id=settings.run_id,
     ).ensure_dirs()
+
+    # Stage 1: planning
+    candidate_ids = build_candidate_ids(settings.n_queries)
+    candidate_id_iter = iter(candidate_ids)
+    planning_outputs: list[QueryBlueprint] = []
+
+    for current_batch_size in iter_batch_sizes(
+        n_queries=settings.n_queries,
+        batch_size=settings.batch_size,
+    ):
+        batch_candidate_ids = list(islice(candidate_id_iter, current_batch_size))
+        planning_outputs.extend(
+            run_planning_stage(
+                spec=settings.spec,
+                llm_settings=settings.llm,
+                api_key=api_key,
+                batch_candidate_ids=batch_candidate_ids,
+            )
+        )
+
+    filtered_planning_outputs = filter_aligned_candidate_ids(
+        items=planning_outputs,
+        expected_candidate_ids=candidate_ids,
+    )
+
+    selected_blueprints = deduplicate_blueprints(filtered_planning_outputs)
+
+    # Stage 2: realization
+    realization_outputs: list[RealizedQuery] = []
+
+    for blueprint_batch in chunk_blueprints(
+        blueprints=selected_blueprints,
+        chunk_size=settings.batch_size,
+    ):
+        realization_outputs.extend(
+            run_realization_stage(
+                candidates=blueprint_batch,
+                llm_settings=settings.llm,
+                api_key=api_key,
+            )
+        )
+
+    filtered_realization_outputs = filter_aligned_candidate_ids(
+        items=realization_outputs,
+        expected_candidate_ids=[blueprint.candidate_id for blueprint in selected_blueprints],
+    )
+
+    # Assembly and export:
+    rows = assemble_query_rows(
+        blueprints=selected_blueprints,
+        realized_queries=filtered_realization_outputs,
+        run_id=settings.run_id,
+    )
+
+    meta = assemble_queries_meta(
+        run_id=settings.run_id,
+        n_requested_queries=settings.n_queries,
+        n_returned_queries=len(rows),
+        model_provider=settings.llm.model_provider,
+        planning_model=settings.llm.planning_model,
+        realization_model=settings.llm.realization_model,
+    )
+
+    export_queries(
+        rows=rows,
+        meta=meta,
+        queries_path=paths.synthetic_queries_csv,
+        meta_path=paths.synthetic_queries_meta_json,
+    )
 
     return QueryGenRunResult(settings=settings, paths=paths)

--- a/tests/integration/test_querygen.py
+++ b/tests/integration/test_querygen.py
@@ -1,88 +1,360 @@
 """Integration tests for the public synthetic query generation surface."""
 
+import json
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 from pragmata import querygen
+from pragmata.core.csv_io import read_csv
+from pragmata.core.schemas.querygen_output import SyntheticQueriesMeta, SyntheticQueryRow
+from pragmata.core.schemas.querygen_plan import QueryBlueprint, QueryBlueprintList
+from pragmata.core.schemas.querygen_realize import RealizedQuery, RealizedQueryList
+from pragmata.core.settings.settings_base import MissingSecretError
+import pragmata.core.querygen.deduplication as deduplication
+import pragmata.core.querygen.planning as planning
+import pragmata.core.querygen.realization as realization
 
 pytestmark = [pytest.mark.integration, pytest.mark.querygen]
 
 
-def test_gen_queries_prepares_run_via_public_surface(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    """Prepare a synthetic query generation run through the public surface."""
+@pytest.fixture(autouse=True)
+def mock_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure a provider API key is present unless a test removes it explicitly."""
     monkeypatch.setenv("MISTRAL_API_KEY", "test-mistral-api-key")
 
-    base_dir = tmp_path / "workspace"
-    run_id = "integration-run-001"
 
-    result = querygen.gen_queries(
-        domains="healthcare",
-        roles=["patient", "caregiver"],
-        languages="en",
-        topics="insurance coverage",
-        intents="understand benefits",
-        tasks="factual lookup",
-        difficulty="basic",
-        formats="bullet list",
-        disallowed_topics=["medical diagnosis"],
-        base_dir=base_dir,
-        run_id=run_id,
-        n_queries=3,
+def _required_querygen_kwargs(base_dir: Path) -> dict[str, object]:
+    """Return a minimal valid public-surface invocation."""
+    return {
+        "domains": "healthcare",
+        "roles": ["patient", "caregiver"],
+        "languages": "en",
+        "topics": "insurance coverage",
+        "intents": "understand benefits",
+        "tasks": "factual lookup",
+        "difficulty": "basic",
+        "formats": "bullet list",
+        "disallowed_topics": ["medical diagnosis"],
+        "base_dir": base_dir,
+        "model_provider": "mistralai",
+    }
+
+
+def _make_blueprint(
+    candidate_id: str,
+    *,
+    domain: str = "healthcare",
+    role: str = "patient",
+    language: str = "en",
+    topic: str = "insurance coverage",
+    intent: str = "understand benefits",
+    task: str = "factual lookup",
+    difficulty: str | None = "basic",
+    format: str | None = "bullet list",
+    user_scenario: str | None = None,
+    information_need: str | None = None,
+) -> QueryBlueprint:
+    """Build a valid planning-stage blueprint."""
+    return QueryBlueprint(
+        candidate_id=candidate_id,
+        domain=domain,
+        role=role,
+        language=language,
+        topic=topic,
+        intent=intent,
+        task=task,
+        difficulty=difficulty,
+        format=format,
+        user_scenario=user_scenario or f"Scenario for {candidate_id}",
+        information_need=information_need or f"Information need for {candidate_id}",
     )
 
-    expected_run_dir = base_dir.resolve() / "querygen" / "runs" / run_id
+
+def _parse_candidate_ids_block(block: str) -> list[str]:
+    """Parse the planning prompt variable containing candidate IDs."""
+    return [
+        line.strip().removeprefix("- ").strip()
+        for line in block.splitlines()
+        if line.strip()
+    ]
+
+
+def _parse_realization_candidate_ids(block: str) -> list[str]:
+    """Parse candidate IDs from the realization blueprint block."""
+    candidate_ids: list[str] = []
+
+    for line in block.splitlines():
+        stripped = line.strip()
+        prefix = "- candidate_id: "
+        if stripped.startswith(prefix):
+            candidate_ids.append(stripped.removeprefix(prefix).strip())
+
+    return candidate_ids
+
+
+class _SimilarityModelStub:
+    """Minimal similarity-only model stub for deterministic deduplication tests."""
+
+    def similarity(
+        self,
+        left: np.ndarray,
+        right: np.ndarray,
+    ) -> np.ndarray:
+        del right
+        return np.eye(len(left), dtype=np.float32)
+
+
+class _PlanningRunnableStub:
+    """Planning runnable stub keyed by candidate-id batches."""
+
+    def __init__(self, planning_calls: list[list[str]]) -> None:
+        self._planning_calls = planning_calls
+        self._duplicate_blueprint_kwargs = {
+            "topic": "coverage appeals",
+            "user_scenario": (
+                "My insurer denied a request and I need help understanding the appeal process."
+            ),
+            "information_need": (
+                "I need the concrete steps for appealing a denied coverage request."
+            ),
+        }
+
+    def invoke(self, prompt_vars: dict[str, object]) -> QueryBlueprintList:
+        """Return structured planning output for the requested batch."""
+        batch_candidate_ids = _parse_candidate_ids_block(str(prompt_vars["candidate_ids"]))
+        self._planning_calls.append(batch_candidate_ids)
+
+        if batch_candidate_ids == ["c001", "c002"]:
+            return QueryBlueprintList(
+                candidates=[
+                    _make_blueprint("c001"),
+                    _make_blueprint("c002"),
+                ]
+            )
+
+        if batch_candidate_ids == ["c003", "c004"]:
+            return QueryBlueprintList(
+                candidates=[
+                    _make_blueprint("c003", **self._duplicate_blueprint_kwargs),
+                    _make_blueprint("wrong-c004"),
+                ]
+            )
+
+        if batch_candidate_ids == ["c005"]:
+            return QueryBlueprintList(
+                candidates=[
+                    _make_blueprint("c005", **self._duplicate_blueprint_kwargs),
+                ]
+            )
+
+        pytest.fail(f"Unexpected planning batch: {batch_candidate_ids}")
+
+
+class _RealizationRunnableStub:
+    """Realization runnable stub keyed by blueprint batches."""
+
+    def __init__(self, realization_calls: list[list[str]]) -> None:
+        self._realization_calls = realization_calls
+
+    def invoke(self, prompt_vars: dict[str, object]) -> RealizedQueryList:
+        """Return structured realization output for the requested batch."""
+        batch_candidate_ids = _parse_realization_candidate_ids(str(prompt_vars["query_blueprints"]))
+        self._realization_calls.append(batch_candidate_ids)
+
+        if batch_candidate_ids == ["c001", "c002"]:
+            return RealizedQueryList(
+                queries=[
+                    RealizedQuery(
+                        candidate_id="c001",
+                        query="How can I check whether a treatment is covered by my insurance plan?",
+                    ),
+                    RealizedQuery(
+                        candidate_id="wrong-c002",
+                        query="This query should be removed by stage-2 filtering.",
+                    ),
+                ]
+            )
+
+        if batch_candidate_ids == ["c003"]:
+            return RealizedQueryList(
+                queries=[
+                    RealizedQuery(
+                        candidate_id="c003",
+                        query="What steps do I need to follow to appeal a denied coverage request?",
+                    )
+                ]
+            )
+
+        pytest.fail(f"Unexpected realization batch: {batch_candidate_ids}")
+
+
+class _TimeoutRunnableStub:
+    """Runnable stub that always fails at invocation time."""
+
+    def __init__(self, message: str) -> None:
+        self._message = message
+
+    def invoke(self, prompt_vars: dict[str, object]) -> QueryBlueprintList | RealizedQueryList:
+        """Raise a timeout-style failure."""
+        del prompt_vars
+        raise TimeoutError(self._message)
+
+
+@pytest.fixture
+def happy_path_workflow_stubs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> dict[str, list[list[str]]]:
+    """Install happy-path LLM and deduplication stubs for end-to-end API tests."""
+    planning_calls: list[list[str]] = []
+    realization_calls: list[list[str]] = []
+
+    def fake_planning_build_llm_runnable(**kwargs: object) -> _PlanningRunnableStub:
+        del kwargs
+        return _PlanningRunnableStub(planning_calls)
+
+    def fake_realization_build_llm_runnable(**kwargs: object) -> _RealizationRunnableStub:
+        del kwargs
+        return _RealizationRunnableStub(realization_calls)
+
+    monkeypatch.setattr(planning, "build_llm_runnable", fake_planning_build_llm_runnable)
+    monkeypatch.setattr(realization, "build_llm_runnable", fake_realization_build_llm_runnable)
+    monkeypatch.setattr(
+        deduplication,
+        "_embed_blueprints",
+        lambda candidates: np.eye(len(candidates), dtype=np.float32),
+    )
+    monkeypatch.setattr(
+        deduplication,
+        "_load_embedding_model",
+        lambda checkpoint="all-MiniLM-L6-v2": _SimilarityModelStub(),
+    )
+
+    return {
+        "planning_calls": planning_calls,
+        "realization_calls": realization_calls,
+    }
+
+
+def test_gen_queries_executes_staged_workflow_and_writes_expected_artifacts(
+    happy_path_workflow_stubs: dict[str, list[list[str]]],
+    tmp_path: Path,
+) -> None:
+    base_dir = tmp_path / "workspace"
+    run_id = "integration-run-staged-001"
+
+    result = querygen.gen_queries(
+        **_required_querygen_kwargs(base_dir),
+        run_id=run_id,
+        n_queries=5,
+        batch_size=2,
+    )
 
     assert isinstance(result, querygen.QueryGenRunResult)
 
-    assert result.settings.run_id == run_id
-    assert result.settings.n_queries == 3
-    assert result.settings.base_dir == base_dir
-    assert isinstance(result.settings.llm.model_provider, str)
-    assert result.settings.llm.model_provider
-    assert isinstance(result.settings.llm.planning_model, str)
-    assert result.settings.llm.planning_model
-    assert isinstance(result.settings.llm.realization_model, str)
-    assert result.settings.llm.realization_model
-
-    assert [item.value for item in result.settings.spec.domain_context.domains] == ["healthcare"]
-
+    expected_run_dir = base_dir.resolve() / "querygen" / "runs" / run_id
     assert result.paths.run_dir == expected_run_dir
     assert result.paths.synthetic_queries_csv == expected_run_dir / "synthetic_queries.csv"
     assert result.paths.synthetic_queries_meta_json == expected_run_dir / "synthetic_queries.meta.json"
 
+    assert happy_path_workflow_stubs["planning_calls"] == [
+        ["c001", "c002"],
+        ["c003", "c004"],
+        ["c005"],
+    ]
+    assert happy_path_workflow_stubs["realization_calls"] == [
+        ["c001", "c002"],
+        ["c003"],
+    ]
+
     assert result.paths.run_dir.exists()
-    assert result.paths.run_dir.is_dir()
-    assert not result.paths.synthetic_queries_csv.exists()
-    assert not result.paths.synthetic_queries_meta_json.exists()
+    assert result.paths.synthetic_queries_csv.exists()
+    assert result.paths.synthetic_queries_meta_json.exists()
+
+    rows = read_csv(result.paths.synthetic_queries_csv, SyntheticQueryRow)
+    assert rows == [
+        SyntheticQueryRow(
+            query_id=f"{run_id}_q1",
+            query="How can I check whether a treatment is covered by my insurance plan?",
+            domain="healthcare",
+            role="patient",
+            language="en",
+            topic="insurance coverage",
+            intent="understand benefits",
+            task="factual lookup",
+            difficulty="basic",
+            format="bullet list",
+        ),
+        SyntheticQueryRow(
+            query_id=f"{run_id}_q2",
+            query="What steps do I need to follow to appeal a denied coverage request?",
+            domain="healthcare",
+            role="patient",
+            language="en",
+            topic="coverage appeals",
+            intent="understand benefits",
+            task="factual lookup",
+            difficulty="basic",
+            format="bullet list",
+        ),
+    ]
+
+    meta = SyntheticQueriesMeta.model_validate(
+        json.loads(result.paths.synthetic_queries_meta_json.read_text(encoding="utf-8"))
+    )
+    assert meta.run_id == run_id
+    assert meta.n_requested_queries == 5
+    assert meta.n_returned_queries == 2
+    assert meta.model_provider == "mistralai"
+    assert meta.planning_model == "magistral-medium-latest"
+    assert meta.realization_model == "mistral-medium-latest"
+
 
 
 def test_gen_queries_raises_when_provider_api_key_missing(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Fail with the expected missing-secret error when the provider key is absent."""
+    """Fail before creating a run directory when the provider key is absent."""
     monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
 
     base_dir = tmp_path / "workspace"
     run_id = "integration-run-missing-secret"
     expected_run_dir = base_dir.resolve() / "querygen" / "runs" / run_id
 
-    with pytest.raises(Exception, match="MISTRAL_API_KEY"):
+    with pytest.raises(MissingSecretError, match="MISTRAL_API_KEY"):
         querygen.gen_queries(
-            domains="healthcare",
-            roles="patient",
-            languages="en",
-            topics="insurance coverage",
-            intents="understand benefits",
-            tasks="factual lookup",
-            base_dir=base_dir,
+            **_required_querygen_kwargs(base_dir),
             run_id=run_id,
             n_queries=2,
-            model_provider="mistralai",
         )
 
     assert not expected_run_dir.exists()
+
+def test_gen_queries_propagates_planning_timeout_and_writes_no_artifacts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A planning-stage provider timeout propagates and prevents export."""
+
+    def fake_planning_build_llm_runnable(**kwargs: object) -> _TimeoutRunnableStub:
+        del kwargs
+        return _TimeoutRunnableStub("provider timed out")
+
+    monkeypatch.setattr(planning, "build_llm_runnable", fake_planning_build_llm_runnable)
+
+    base_dir = tmp_path / "workspace"
+    run_id = "integration-run-planning-timeout"
+
+    with pytest.raises(planning.PlanningStageError, match="Planning stage invocation failed."):
+        querygen.gen_queries(
+            **_required_querygen_kwargs(base_dir),
+            run_id=run_id,
+            n_queries=2,
+        )
+
+    expected_run_dir = base_dir.resolve() / "querygen" / "runs" / run_id
+    assert expected_run_dir.exists()
+    assert not (expected_run_dir / "synthetic_queries.csv").exists()
+    assert not (expected_run_dir / "synthetic_queries.meta.json").exists()

--- a/tests/integration/test_querygen.py
+++ b/tests/integration/test_querygen.py
@@ -6,15 +6,15 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+import pragmata.core.querygen.deduplication as deduplication
+import pragmata.core.querygen.planning as planning
+import pragmata.core.querygen.realization as realization
 from pragmata import querygen
 from pragmata.core.csv_io import read_csv
 from pragmata.core.schemas.querygen_output import SyntheticQueriesMeta, SyntheticQueryRow
 from pragmata.core.schemas.querygen_plan import QueryBlueprint, QueryBlueprintList
 from pragmata.core.schemas.querygen_realize import RealizedQuery, RealizedQueryList
 from pragmata.core.settings.settings_base import MissingSecretError
-import pragmata.core.querygen.deduplication as deduplication
-import pragmata.core.querygen.planning as planning
-import pragmata.core.querygen.realization as realization
 
 pytestmark = [pytest.mark.integration, pytest.mark.querygen]
 
@@ -74,11 +74,7 @@ def _make_blueprint(
 
 def _parse_candidate_ids_block(block: str) -> list[str]:
     """Parse the planning prompt variable containing candidate IDs."""
-    return [
-        line.strip().removeprefix("- ").strip()
-        for line in block.splitlines()
-        if line.strip()
-    ]
+    return [line.strip().removeprefix("- ").strip() for line in block.splitlines() if line.strip()]
 
 
 def _parse_realization_candidate_ids(block: str) -> list[str]:
@@ -113,12 +109,8 @@ class _PlanningRunnableStub:
         self._planning_calls = planning_calls
         self._duplicate_blueprint_kwargs = {
             "topic": "coverage appeals",
-            "user_scenario": (
-                "My insurer denied a request and I need help understanding the appeal process."
-            ),
-            "information_need": (
-                "I need the concrete steps for appealing a denied coverage request."
-            ),
+            "user_scenario": ("My insurer denied a request and I need help understanding the appeal process."),
+            "information_need": ("I need the concrete steps for appealing a denied coverage request."),
         }
 
     def invoke(self, prompt_vars: dict[str, object]) -> QueryBlueprintList:
@@ -311,7 +303,6 @@ def test_gen_queries_executes_staged_workflow_and_writes_expected_artifacts(
     assert meta.realization_model == "mistral-medium-latest"
 
 
-
 def test_gen_queries_raises_when_provider_api_key_missing(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -331,6 +322,7 @@ def test_gen_queries_raises_when_provider_api_key_missing(
         )
 
     assert not expected_run_dir.exists()
+
 
 def test_gen_queries_propagates_planning_timeout_and_writes_no_artifacts(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/api/test_querygen.py
+++ b/tests/unit/api/test_querygen.py
@@ -1,16 +1,29 @@
 """Tests for the query generation API orchestration."""
 
+from datetime import UTC, datetime
 from pathlib import Path
+from textwrap import dedent
 
 import pytest
 
-from pragmata.api.querygen import QueryGenRunResult, gen_queries
+import pragmata.api.querygen as querygen_api
+from pragmata.core.schemas.querygen_output import SyntheticQueriesMeta, SyntheticQueryRow
+from pragmata.core.schemas.querygen_plan import QueryBlueprint
+from pragmata.core.schemas.querygen_realize import RealizedQuery
+
+pytestmark = pytest.mark.usefixtures("workflow_stubs")
 
 
 @pytest.fixture(autouse=True)
 def mock_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     """Ensure an API key is always present for orchestration tests."""
     monkeypatch.setenv("MISTRAL_API_KEY", "test-secret")
+
+
+@pytest.fixture
+def workflow_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Install default workflow stubs so tests stay unit-level and deterministic."""
+    _install_default_workflow_stubs(monkeypatch)
 
 
 def _required_querygen_kwargs(tmp_path: Path) -> dict[str, object]:
@@ -27,22 +40,216 @@ def _required_querygen_kwargs(tmp_path: Path) -> dict[str, object]:
     }
 
 
+def _make_blueprint(
+    candidate_id: str,
+    *,
+    domain: str = "public administration",
+    role: str = "policy analyst",
+    language: str = "en",
+    topic: str = "digital services",
+    intent: str = "learn",
+    task: str = "summarize",
+    difficulty: str | None = "basic",
+    format: str | None = "bullet list",
+) -> QueryBlueprint:
+    """Build a valid QueryBlueprint for tests."""
+    return QueryBlueprint(
+        candidate_id=candidate_id,
+        domain=domain,
+        role=role,
+        language=language,
+        topic=topic,
+        intent=intent,
+        task=task,
+        difficulty=difficulty,
+        format=format,
+        user_scenario=f"Scenario for {candidate_id}",
+        information_need=f"Information need for {candidate_id}",
+    )
+
+
+def _make_realized_query(
+    candidate_id: str,
+    *,
+    query: str | None = None,
+) -> RealizedQuery:
+    """Build a valid RealizedQuery for tests."""
+    return RealizedQuery(
+        candidate_id=candidate_id,
+        query=query or f"Realized query for {candidate_id}",
+    )
+
+
+def _make_row(
+    *,
+    query_id: str,
+    query: str = "How do I access this service?",
+    domain: str | None = "public administration",
+    role: str | None = "policy analyst",
+    language: str | None = "en",
+    topic: str | None = "digital services",
+    intent: str | None = "learn",
+    task: str | None = "summarize",
+    difficulty: str | None = "basic",
+    format: str | None = "bullet list",
+) -> SyntheticQueryRow:
+    """Build a valid SyntheticQueryRow for tests."""
+    return SyntheticQueryRow(
+        query_id=query_id,
+        query=query,
+        domain=domain,
+        role=role,
+        language=language,
+        topic=topic,
+        intent=intent,
+        task=task,
+        difficulty=difficulty,
+        format=format,
+    )
+
+
+def _make_meta(
+    *,
+    run_id: str,
+    n_requested_queries: int,
+    n_returned_queries: int,
+    model_provider: str = "mistralai",
+    planning_model: str = "magistral-medium-latest",
+    realization_model: str = "mistral-medium-latest",
+) -> SyntheticQueriesMeta:
+    """Build valid SyntheticQueriesMeta for tests."""
+    return SyntheticQueriesMeta(
+        run_id=run_id,
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        n_requested_queries=n_requested_queries,
+        n_returned_queries=n_returned_queries,
+        model_provider=model_provider,
+        planning_model=planning_model,
+        realization_model=realization_model,
+    )
+
+
+def _install_default_workflow_stubs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Install default passthrough stubs for the staged workflow."""
+
+    def build_candidate_ids(n_queries: int) -> list[str]:
+        digits = max(3, len(str(n_queries)))
+        return [f"c{index:0{digits}d}" for index in range(1, n_queries + 1)]
+
+    def iter_batch_sizes(n_queries: int, batch_size: int):  # noqa: ANN202
+        del batch_size
+        return iter([n_queries])
+
+    def run_planning_stage(
+        *,
+        spec,  # noqa: ANN001
+        llm_settings,  # noqa: ANN001
+        api_key: str,
+        batch_candidate_ids: list[str],
+    ) -> list[QueryBlueprint]:
+        del spec, llm_settings, api_key
+        return [_make_blueprint(candidate_id) for candidate_id in batch_candidate_ids]
+
+    def filter_aligned_candidate_ids(
+        items: list[object],
+        expected_candidate_ids: list[str],
+    ) -> list[object]:
+        del expected_candidate_ids
+        return items
+
+    def deduplicate_blueprints(candidates: list[QueryBlueprint]) -> list[QueryBlueprint]:
+        return candidates
+
+    def chunk_blueprints(
+        blueprints: list[QueryBlueprint],
+        chunk_size: int,
+    ):  # noqa: ANN202
+        del chunk_size
+        return iter([blueprints] if blueprints else [])
+
+    def run_realization_stage(
+        *,
+        candidates: list[QueryBlueprint],
+        llm_settings,  # noqa: ANN001
+        api_key: str,
+    ) -> list[RealizedQuery]:
+        del llm_settings, api_key
+        return [_make_realized_query(candidate.candidate_id) for candidate in candidates]
+
+    def assemble_query_rows(
+        *,
+        blueprints: list[QueryBlueprint],
+        realized_queries: list[RealizedQuery],
+        run_id: str,
+    ) -> list[SyntheticQueryRow]:
+        del blueprints
+        return [
+            _make_row(
+                query_id=f"{run_id}_q{index:03d}",
+                query=realized_query.query,
+            )
+            for index, realized_query in enumerate(realized_queries, start=1)
+        ]
+
+    def assemble_queries_meta(
+        *,
+        run_id: str,
+        n_requested_queries: int,
+        n_returned_queries: int,
+        model_provider: str,
+        planning_model: str,
+        realization_model: str,
+    ) -> SyntheticQueriesMeta:
+        return _make_meta(
+            run_id=run_id,
+            n_requested_queries=n_requested_queries,
+            n_returned_queries=n_returned_queries,
+            model_provider=model_provider,
+            planning_model=planning_model,
+            realization_model=realization_model,
+        )
+
+    def export_queries(
+        *,
+        rows: list[SyntheticQueryRow],
+        meta: SyntheticQueriesMeta,
+        queries_path: Path,
+        meta_path: Path,
+    ) -> None:
+        del rows, meta, queries_path, meta_path
+
+    monkeypatch.setattr(querygen_api, "build_candidate_ids", build_candidate_ids)
+    monkeypatch.setattr(querygen_api, "iter_batch_sizes", iter_batch_sizes)
+    monkeypatch.setattr(querygen_api, "run_planning_stage", run_planning_stage)
+    monkeypatch.setattr(querygen_api, "filter_aligned_candidate_ids", filter_aligned_candidate_ids)
+    monkeypatch.setattr(querygen_api, "deduplicate_blueprints", deduplicate_blueprints)
+    monkeypatch.setattr(querygen_api, "chunk_blueprints", chunk_blueprints)
+    monkeypatch.setattr(querygen_api, "run_realization_stage", run_realization_stage)
+    monkeypatch.setattr(querygen_api, "assemble_query_rows", assemble_query_rows)
+    monkeypatch.setattr(querygen_api, "assemble_queries_meta", assemble_queries_meta)
+    monkeypatch.setattr(querygen_api, "export_queries", export_queries)
+
+
 def test_gen_queries_combines_user_args_config_and_defaults(tmp_path: Path) -> None:
     """gen_queries combines user args, config values, and model defaults."""
     config_path = tmp_path / "querygen.yml"
     config_path.write_text(
-        (
-            "llm:\n"
-            "  model_provider: mistralai\n"
-            "  planning_model: custom-planner\n"
-            "n_queries: 10\n"
-            "batch_size: 12\n"
-            "run_id: original-id\n"
+        dedent(
+            """\
+            llm:
+              model_provider: mistralai
+              planning_model: custom-planner
+            n_queries: 10
+            batch_size: 12
+            run_id: original-id
+            """
         ),
         encoding="utf-8",
     )
 
-    result = gen_queries(
+    result = querygen_api.gen_queries(
         **_required_querygen_kwargs(tmp_path),
         config_path=config_path,
         run_id="overridden-id",
@@ -58,7 +265,7 @@ def test_gen_queries_combines_user_args_config_and_defaults(tmp_path: Path) -> N
 
 def test_gen_queries_orchestrates_run_paths(tmp_path: Path) -> None:
     """gen_queries resolves and creates the expected run path scaffold."""
-    result = gen_queries(
+    result = querygen_api.gen_queries(
         **_required_querygen_kwargs(tmp_path),
         run_id="run-123",
     )
@@ -72,40 +279,629 @@ def test_gen_queries_orchestrates_run_paths(tmp_path: Path) -> None:
 
 
 def test_gen_queries_returns_result_object(tmp_path: Path) -> None:
-    """gen_queries returns the structured prepared run result."""
-    result = gen_queries(
+    """gen_queries returns the structured run result."""
+    result = querygen_api.gen_queries(
         **_required_querygen_kwargs(tmp_path),
         run_id="result-check",
     )
 
-    assert isinstance(result, QueryGenRunResult)
+    assert isinstance(result, querygen_api.QueryGenRunResult)
     assert result.settings.run_id == "result-check"
     assert result.paths.run_dir.name == "result-check"
 
 
-def test_gen_queries_accepts_batch_size_override(tmp_path: Path) -> None:
-    result = gen_queries(
+@pytest.mark.parametrize("batch_size", [1, 7, 25])
+def test_gen_queries_accepts_batch_size_override(
+    tmp_path: Path,
+    batch_size: int,
+) -> None:
+    """gen_queries accepts explicit batch_size overrides."""
+    result = querygen_api.gen_queries(
         **_required_querygen_kwargs(tmp_path),
-        batch_size=7,
-        run_id="batch-size-check",
+        batch_size=batch_size,
+        run_id=f"batch-size-check-{batch_size}",
     )
 
-    assert result.settings.batch_size == 7
+    assert result.settings.batch_size == batch_size
 
 
-def test_gen_queries_batch_size_arg_overrides_config_value(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    ("config_batch_size", "arg_batch_size"),
+    [(12, 7), (25, 1), (3, 3)],
+)
+def test_gen_queries_batch_size_arg_overrides_config_value(
+    tmp_path: Path,
+    config_batch_size: int,
+    arg_batch_size: int,
+) -> None:
     """Explicit batch_size arg takes precedence over config batch_size."""
     config_path = tmp_path / "querygen.yml"
     config_path.write_text(
-        ("llm:\n  model_provider: mistralai\nbatch_size: 12\n"),
+        dedent(
+            f"""\
+            llm:
+              model_provider: mistralai
+            batch_size: {config_batch_size}
+            """
+        ),
         encoding="utf-8",
     )
 
-    result = gen_queries(
+    result = querygen_api.gen_queries(
         **_required_querygen_kwargs(tmp_path),
         config_path=config_path,
-        batch_size=7,
+        batch_size=arg_batch_size,
         run_id="batch-size-precedence-check",
     )
 
-    assert result.settings.batch_size == 7
+    assert result.settings.batch_size == arg_batch_size
+
+
+def test_gen_queries_repeats_planning_batches_and_applies_stage1_filter_to_aggregated_outputs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Planning batching repeats in order and stage-1 filtering sees aggregated outputs."""
+    candidate_ids = ["c001", "c002", "c003", "c004", "c005"]
+    planning_batch_calls: list[list[str]] = []
+    stage1_filter_seen: list[dict[str, list[str]]] = []
+
+    monkeypatch.setattr(querygen_api, "build_candidate_ids", lambda n_queries: candidate_ids)
+    monkeypatch.setattr(querygen_api, "iter_batch_sizes", lambda n_queries, batch_size: iter([2, 2, 1]))
+
+    def run_planning_stage(
+        *,
+        spec,  # noqa: ANN001
+        llm_settings,  # noqa: ANN001
+        api_key: str,
+        batch_candidate_ids: list[str],
+    ) -> list[QueryBlueprint]:
+        del spec, llm_settings, api_key
+        planning_batch_calls.append(list(batch_candidate_ids))
+        return [_make_blueprint(candidate_id) for candidate_id in batch_candidate_ids]
+
+    def filter_aligned_candidate_ids(
+        items: list[object],
+        expected_candidate_ids: list[str],
+    ) -> list[object]:
+        if items and isinstance(items[0], QueryBlueprint):
+            stage1_filter_seen.append(
+                {
+                    "item_ids": [item.candidate_id for item in items],
+                    "expected_ids": expected_candidate_ids,
+                }
+            )
+        return items
+
+    monkeypatch.setattr(querygen_api, "run_planning_stage", run_planning_stage)
+    monkeypatch.setattr(querygen_api, "filter_aligned_candidate_ids", filter_aligned_candidate_ids)
+
+    querygen_api.gen_queries(
+        **_required_querygen_kwargs(tmp_path),
+        n_queries=5,
+        batch_size=2,
+        run_id="planning-batch-order-check",
+    )
+
+    assert planning_batch_calls == [
+        ["c001", "c002"],
+        ["c003", "c004"],
+        ["c005"],
+    ]
+    assert stage1_filter_seen == [
+        {
+            "item_ids": ["c001", "c002", "c003", "c004", "c005"],
+            "expected_ids": ["c001", "c002", "c003", "c004", "c005"],
+        }
+    ]
+
+
+def test_gen_queries_applies_stage1_filtering_before_deduplication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stage-1 filtering is applied before deduplication."""
+    call_order: list[str] = []
+
+    def filter_aligned_candidate_ids(
+        items: list[object],
+        expected_candidate_ids: list[str],
+    ) -> list[object]:
+        del expected_candidate_ids
+        if items and isinstance(items[0], QueryBlueprint):
+            call_order.append("stage1_filter")
+            return [items[0], items[2]]
+        call_order.append("stage2_filter")
+        return items
+
+    def deduplicate_blueprints(candidates: list[QueryBlueprint]) -> list[QueryBlueprint]:
+        call_order.append("deduplicate")
+        assert [candidate.candidate_id for candidate in candidates] == ["c001", "c003"]
+        return candidates
+
+    monkeypatch.setattr(querygen_api, "filter_aligned_candidate_ids", filter_aligned_candidate_ids)
+    monkeypatch.setattr(querygen_api, "deduplicate_blueprints", deduplicate_blueprints)
+
+    querygen_api.gen_queries(
+        **_required_querygen_kwargs(tmp_path),
+        n_queries=3,
+        run_id="stage1-filter-before-dedup-check",
+    )
+
+    assert call_order.index("stage1_filter") < call_order.index("deduplicate")
+
+
+def test_gen_queries_drives_realization_batches_from_selected_blueprints(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Realization-stage batching is driven from the selected blueprints."""
+    selected_blueprints = [
+        _make_blueprint("c001"),
+        _make_blueprint("c003"),
+        _make_blueprint("c004"),
+    ]
+    realization_batch_calls: list[list[str]] = []
+
+    def deduplicate_blueprints(candidates: list[QueryBlueprint]) -> list[QueryBlueprint]:
+        del candidates
+        return selected_blueprints
+
+    def chunk_blueprints(
+        blueprints: list[QueryBlueprint],
+        chunk_size: int,
+    ):  # noqa: ANN202
+        assert blueprints == selected_blueprints
+        assert chunk_size == 2
+        return iter([blueprints[:2], blueprints[2:]])
+
+    def run_realization_stage(
+        *,
+        candidates: list[QueryBlueprint],
+        llm_settings,  # noqa: ANN001
+        api_key: str,
+    ) -> list[RealizedQuery]:
+        del llm_settings, api_key
+        realization_batch_calls.append([candidate.candidate_id for candidate in candidates])
+        return [_make_realized_query(candidate.candidate_id) for candidate in candidates]
+
+    monkeypatch.setattr(querygen_api, "deduplicate_blueprints", deduplicate_blueprints)
+    monkeypatch.setattr(querygen_api, "chunk_blueprints", chunk_blueprints)
+    monkeypatch.setattr(querygen_api, "run_realization_stage", run_realization_stage)
+
+    querygen_api.gen_queries(
+        **_required_querygen_kwargs(tmp_path),
+        n_queries=4,
+        batch_size=2,
+        run_id="realization-batch-source-check",
+    )
+
+    assert realization_batch_calls == [
+        ["c001", "c003"],
+        ["c004"],
+    ]
+
+
+def test_gen_queries_applies_stage2_filtering_before_assembly(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stage-2 filtering is applied before assembly using selected blueprint IDs."""
+    selected_blueprints = [
+        _make_blueprint("c002"),
+        _make_blueprint("c001"),
+        _make_blueprint("c003"),
+    ]
+    call_order: list[str] = []
+
+    def deduplicate_blueprints(candidates: list[QueryBlueprint]) -> list[QueryBlueprint]:
+        del candidates
+        return selected_blueprints
+
+    def filter_aligned_candidate_ids(
+        items: list[object],
+        expected_candidate_ids: list[str],
+    ) -> list[object]:
+        if items and isinstance(items[0], QueryBlueprint):
+            return items
+
+        call_order.append("stage2_filter")
+        assert expected_candidate_ids == ["c002", "c001", "c003"]
+        realized_items = items
+        assert [item.candidate_id for item in realized_items] == ["c002", "c001", "c003"]
+        return [realized_items[0], realized_items[2]]
+
+    def assemble_query_rows(
+        *,
+        blueprints: list[QueryBlueprint],
+        realized_queries: list[RealizedQuery],
+        run_id: str,
+    ) -> list[SyntheticQueryRow]:
+        del run_id
+        call_order.append("assemble")
+        assert [blueprint.candidate_id for blueprint in blueprints] == ["c002", "c001", "c003"]
+        assert [query.candidate_id for query in realized_queries] == ["c002", "c003"]
+        return [
+            _make_row(query_id="stage2-filter-check_q001", query="query 1"),
+            _make_row(query_id="stage2-filter-check_q002", query="query 2"),
+        ]
+
+    monkeypatch.setattr(querygen_api, "deduplicate_blueprints", deduplicate_blueprints)
+    monkeypatch.setattr(querygen_api, "filter_aligned_candidate_ids", filter_aligned_candidate_ids)
+    monkeypatch.setattr(querygen_api, "assemble_query_rows", assemble_query_rows)
+
+    querygen_api.gen_queries(
+        **_required_querygen_kwargs(tmp_path),
+        n_queries=3,
+        run_id="stage2-filter-check",
+    )
+
+    assert call_order == ["stage2_filter", "assemble"]
+
+
+def test_gen_queries_calls_assembly_and_export_with_final_post_filter_outputs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Assembly and export receive the final post-filter stage outputs."""
+    export_calls: list[dict[str, object]] = []
+    selected_blueprints = [
+        _make_blueprint("c001"),
+        _make_blueprint("c003"),
+    ]
+    filtered_realization_outputs = [
+        _make_realized_query("c001", query="Final realized query"),
+    ]
+    assembled_rows = [
+        _make_row(
+            query_id="assembly-export-check_q001",
+            query="Final realized query",
+        )
+    ]
+    assembled_meta = _make_meta(
+        run_id="assembly-export-check",
+        n_requested_queries=3,
+        n_returned_queries=1,
+    )
+    assemble_rows_calls: list[dict[str, object]] = []
+    assemble_meta_calls: list[dict[str, object]] = []
+
+    monkeypatch.setattr(querygen_api, "build_candidate_ids", lambda n_queries: ["c001", "c002", "c003"])
+    monkeypatch.setattr(querygen_api, "iter_batch_sizes", lambda n_queries, batch_size: iter([3]))
+
+    def run_planning_stage(
+        *,
+        spec,  # noqa: ANN001
+        llm_settings,  # noqa: ANN001
+        api_key: str,
+        batch_candidate_ids: list[str],
+    ) -> list[QueryBlueprint]:
+        del spec, llm_settings, api_key
+        return [_make_blueprint(candidate_id) for candidate_id in batch_candidate_ids]
+
+    def filter_aligned_candidate_ids(
+        items: list[object],
+        expected_candidate_ids: list[str],
+    ) -> list[object]:
+        del expected_candidate_ids
+        if items and isinstance(items[0], QueryBlueprint):
+            return items
+        return filtered_realization_outputs
+
+    def deduplicate_blueprints(candidates: list[QueryBlueprint]) -> list[QueryBlueprint]:
+        del candidates
+        return selected_blueprints
+
+    def chunk_blueprints(
+        blueprints: list[QueryBlueprint],
+        chunk_size: int,
+    ):  # noqa: ANN202
+        del chunk_size
+        assert blueprints == selected_blueprints
+        return iter([blueprints])
+
+    def run_realization_stage(
+        *,
+        candidates: list[QueryBlueprint],
+        llm_settings,  # noqa: ANN001
+        api_key: str,
+    ) -> list[RealizedQuery]:
+        del llm_settings, api_key
+        assert candidates == selected_blueprints
+        return [
+            _make_realized_query("c001", query="Final realized query"),
+            _make_realized_query("c003", query="Dropped by stage-2 filter"),
+        ]
+
+    def assemble_query_rows(
+        *,
+        blueprints: list[QueryBlueprint],
+        realized_queries: list[RealizedQuery],
+        run_id: str,
+    ) -> list[SyntheticQueryRow]:
+        assemble_rows_calls.append(
+            {
+                "blueprints": blueprints,
+                "realized_queries": realized_queries,
+                "run_id": run_id,
+            }
+        )
+        return assembled_rows
+
+    def assemble_queries_meta(
+        *,
+        run_id: str,
+        n_requested_queries: int,
+        n_returned_queries: int,
+        model_provider: str,
+        planning_model: str,
+        realization_model: str,
+    ) -> SyntheticQueriesMeta:
+        assemble_meta_calls.append(
+            {
+                "run_id": run_id,
+                "n_requested_queries": n_requested_queries,
+                "n_returned_queries": n_returned_queries,
+                "model_provider": model_provider,
+                "planning_model": planning_model,
+                "realization_model": realization_model,
+            }
+        )
+        return assembled_meta
+
+    def export_queries(
+        *,
+        rows: list[SyntheticQueryRow],
+        meta: SyntheticQueriesMeta,
+        queries_path: Path,
+        meta_path: Path,
+    ) -> None:
+        export_calls.append(
+            {
+                "rows": rows,
+                "meta": meta,
+                "queries_path": queries_path,
+                "meta_path": meta_path,
+            }
+        )
+
+    monkeypatch.setattr(querygen_api, "run_planning_stage", run_planning_stage)
+    monkeypatch.setattr(querygen_api, "filter_aligned_candidate_ids", filter_aligned_candidate_ids)
+    monkeypatch.setattr(querygen_api, "deduplicate_blueprints", deduplicate_blueprints)
+    monkeypatch.setattr(querygen_api, "chunk_blueprints", chunk_blueprints)
+    monkeypatch.setattr(querygen_api, "run_realization_stage", run_realization_stage)
+    monkeypatch.setattr(querygen_api, "assemble_query_rows", assemble_query_rows)
+    monkeypatch.setattr(querygen_api, "assemble_queries_meta", assemble_queries_meta)
+    monkeypatch.setattr(querygen_api, "export_queries", export_queries)
+
+    result = querygen_api.gen_queries(
+        **_required_querygen_kwargs(tmp_path),
+        n_queries=3,
+        run_id="assembly-export-check",
+    )
+
+    assert assemble_rows_calls == [
+        {
+            "blueprints": selected_blueprints,
+            "realized_queries": filtered_realization_outputs,
+            "run_id": "assembly-export-check",
+        }
+    ]
+    assert assemble_meta_calls == [
+        {
+            "run_id": "assembly-export-check",
+            "n_requested_queries": 3,
+            "n_returned_queries": 1,
+            "model_provider": "mistralai",
+            "planning_model": "magistral-medium-latest",
+            "realization_model": "mistral-medium-latest",
+        }
+    ]
+    assert export_calls == [
+        {
+            "rows": assembled_rows,
+            "meta": assembled_meta,
+            "queries_path": result.paths.synthetic_queries_csv,
+            "meta_path": result.paths.synthetic_queries_meta_json,
+        }
+    ]
+
+
+def test_gen_queries_raises_when_provider_secret_resolution_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Provider-secret resolution failures stop the workflow before stage execution."""
+    monkeypatch.setattr(
+        querygen_api,
+        "resolve_provider_api_key",
+        lambda provider: (_ for _ in ()).throw(RuntimeError("missing secret")),
+    )
+    monkeypatch.setattr(
+        querygen_api,
+        "build_candidate_ids",
+        lambda n_queries: pytest.fail("build_candidate_ids must not run when secret resolution fails"),
+    )
+
+    with pytest.raises(RuntimeError, match="missing secret"):
+        querygen_api.gen_queries(
+            **_required_querygen_kwargs(tmp_path),
+            run_id="missing-secret-check",
+        )
+
+
+def test_gen_queries_propagates_planning_failure_and_stops_downstream_work(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Planning failures propagate and prevent realization, assembly, and export."""
+    monkeypatch.setattr(
+        querygen_api,
+        "run_planning_stage",
+        lambda **kwargs: (_ for _ in ()).throw(RuntimeError("planning failed")),
+    )
+    monkeypatch.setattr(
+        querygen_api,
+        "run_realization_stage",
+        lambda **kwargs: pytest.fail("run_realization_stage must not run after planning failure"),
+    )
+    monkeypatch.setattr(
+        querygen_api,
+        "assemble_query_rows",
+        lambda **kwargs: pytest.fail("assemble_query_rows must not run after planning failure"),
+    )
+    monkeypatch.setattr(
+        querygen_api,
+        "export_queries",
+        lambda **kwargs: pytest.fail("export_queries must not run after planning failure"),
+    )
+
+    with pytest.raises(RuntimeError, match="planning failed"):
+        querygen_api.gen_queries(
+            **_required_querygen_kwargs(tmp_path),
+            run_id="planning-failure-check",
+        )
+
+
+def test_gen_queries_propagates_realization_failure_and_stops_downstream_work(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Realization failures propagate and prevent assembly and export."""
+    monkeypatch.setattr(
+        querygen_api,
+        "run_realization_stage",
+        lambda **kwargs: (_ for _ in ()).throw(RuntimeError("realization failed")),
+    )
+    monkeypatch.setattr(
+        querygen_api,
+        "assemble_query_rows",
+        lambda **kwargs: pytest.fail("assemble_query_rows must not run after realization failure"),
+    )
+    monkeypatch.setattr(
+        querygen_api,
+        "export_queries",
+        lambda **kwargs: pytest.fail("export_queries must not run after realization failure"),
+    )
+
+    with pytest.raises(RuntimeError, match="realization failed"):
+        querygen_api.gen_queries(
+            **_required_querygen_kwargs(tmp_path),
+            run_id="realization-failure-check",
+        )
+
+
+def test_gen_queries_handles_empty_selected_blueprints_after_stage1(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When nothing survives stage 1, realization is skipped and empty outputs are assembled/exported."""
+    assemble_rows_calls: list[dict[str, object]] = []
+    assemble_meta_calls: list[dict[str, object]] = []
+    export_calls: list[dict[str, object]] = []
+
+    monkeypatch.setattr(querygen_api, "deduplicate_blueprints", lambda candidates: [])
+    monkeypatch.setattr(
+        querygen_api,
+        "run_realization_stage",
+        lambda **kwargs: pytest.fail("run_realization_stage must not run when no blueprints remain"),
+    )
+
+    def assemble_query_rows(
+        *,
+        blueprints: list[QueryBlueprint],
+        realized_queries: list[RealizedQuery],
+        run_id: str,
+    ) -> list[SyntheticQueryRow]:
+        assemble_rows_calls.append(
+            {
+                "blueprints": blueprints,
+                "realized_queries": realized_queries,
+                "run_id": run_id,
+            }
+        )
+        return []
+
+    def assemble_queries_meta(
+        *,
+        run_id: str,
+        n_requested_queries: int,
+        n_returned_queries: int,
+        model_provider: str,
+        planning_model: str,
+        realization_model: str,
+    ) -> SyntheticQueriesMeta:
+        assemble_meta_calls.append(
+            {
+                "run_id": run_id,
+                "n_requested_queries": n_requested_queries,
+                "n_returned_queries": n_returned_queries,
+                "model_provider": model_provider,
+                "planning_model": planning_model,
+                "realization_model": realization_model,
+            }
+        )
+        return _make_meta(
+            run_id=run_id,
+            n_requested_queries=n_requested_queries,
+            n_returned_queries=n_returned_queries,
+            model_provider=model_provider,
+            planning_model=planning_model,
+            realization_model=realization_model,
+        )
+
+    def export_queries(
+        *,
+        rows: list[SyntheticQueryRow],
+        meta: SyntheticQueriesMeta,
+        queries_path: Path,
+        meta_path: Path,
+    ) -> None:
+        export_calls.append(
+            {
+                "rows": rows,
+                "meta": meta,
+                "queries_path": queries_path,
+                "meta_path": meta_path,
+            }
+        )
+
+    monkeypatch.setattr(querygen_api, "assemble_query_rows", assemble_query_rows)
+    monkeypatch.setattr(querygen_api, "assemble_queries_meta", assemble_queries_meta)
+    monkeypatch.setattr(querygen_api, "export_queries", export_queries)
+
+    result = querygen_api.gen_queries(
+        **_required_querygen_kwargs(tmp_path),
+        n_queries=3,
+        run_id="empty-selected-blueprints-check",
+    )
+
+    assert assemble_rows_calls == [
+        {
+            "blueprints": [],
+            "realized_queries": [],
+            "run_id": "empty-selected-blueprints-check",
+        }
+    ]
+    assert assemble_meta_calls == [
+        {
+            "run_id": "empty-selected-blueprints-check",
+            "n_requested_queries": 3,
+            "n_returned_queries": 0,
+            "model_provider": "mistralai",
+            "planning_model": "magistral-medium-latest",
+            "realization_model": "mistral-medium-latest",
+        }
+    ]
+    assert export_calls == [
+        {
+            "rows": [],
+            "meta": _make_meta(
+                run_id="empty-selected-blueprints-check",
+                n_requested_queries=3,
+                n_returned_queries=0,
+            ),
+            "queries_path": result.paths.synthetic_queries_csv,
+            "meta_path": result.paths.synthetic_queries_meta_json,
+        }
+    ]


### PR DESCRIPTION
**Summary**

Wire the full staged synthetic query generation workflow into `gen_queries()`, so the public API now executes planning, stage-level filtering, deduplication, realization, assembly, and export end to end.

**Key changes**

- Update `api/querygen.py`:
  - orchestrate stage-1 planning via `build_candidate_ids()`, `iter_batch_sizes()`, and repeated `run_planning_stage()` calls
  - aggregate planning outputs, apply positional candidate-ID filtering, and deduplicate selected blueprints
  - orchestrate stage-2 realization via `chunk_blueprints()` and repeated `run_realization_stage()` calls
  - apply stage-2 positional candidate-ID filtering before assembly
  - assemble final rows and metadata, export CSV/JSON artifacts, and return a structured `QueryGenRunResult`

- Add orchestration-focused unit tests for `gen_queries()`:
  - settings/config/default resolution and run-path scaffolding
  - repeated planning batching and aggregated stage-1 filtering
  - stage-1 filtering before deduplication
  - realization batching driven from selected blueprints
  - stage-2 filtering before assembly
  - final assembly/export inputs, failure propagation, and empty post-stage-1 handling

- Add integration tests for the public querygen surface:
  - end-to-end staged execution across planning, filtering, deduplication, realization, assembly, and export
  - artifact creation and contract checks for exported CSV and metadata JSON
  - missing-secret and planning-timeout failure behavior

**Status**

Ready for review.

Closes #113