### PR TITLE
refactor(annotation): introduce export-row schemas for on-disk CSV format

### DIFF
--- a/src/pragmata/core/annotation/export_runner.py
+++ b/src/pragmata/core/annotation/export_runner.py
@@ -33,6 +33,14 @@ TASK_CSV_ATTR = {
     Task.GENERATION: "generation_annotation_csv",
 }
 
+TASK_ANNOTATION_SCHEMA: dict[
+    Task, type[RetrievalAnnotation] | type[GroundingAnnotation] | type[GenerationAnnotation]
+] = {
+    Task.RETRIEVAL: RetrievalAnnotation,
+    Task.GROUNDING: GroundingAnnotation,
+    Task.GENERATION: GenerationAnnotation,
+}
+
 TASK_EXPORT_ROW: dict[Task, type[RetrievalExportRow] | type[GroundingExportRow] | type[GenerationExportRow]] = {
     Task.RETRIEVAL: RetrievalExportRow,
     Task.GROUNDING: GroundingExportRow,

--- a/src/pragmata/core/annotation/export_runner.py
+++ b/src/pragmata/core/annotation/export_runner.py
@@ -15,8 +15,11 @@ from pragmata.core.paths.annotation_paths import AnnotationExportPaths
 from pragmata.core.schemas.annotation_export import (
     AnnotationBase,
     GenerationAnnotation,
+    GenerationExportRow,
     GroundingAnnotation,
+    GroundingExportRow,
     RetrievalAnnotation,
+    RetrievalExportRow,
 )
 from pragmata.core.schemas.annotation_task import Task
 
@@ -25,16 +28,22 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from pragmata.core.settings.annotation_settings import AnnotationSettings
 
-_TASK_CSV_ATTR = {
+TASK_CSV_ATTR = {
     Task.RETRIEVAL: "retrieval_annotation_csv",
     Task.GROUNDING: "grounding_annotation_csv",
     Task.GENERATION: "generation_annotation_csv",
 }
 
-_TASK_SCHEMA: dict[Task, type[AnnotationBase]] = {
+TASK_ANNOTATION_SCHEMA: dict[Task, type[AnnotationBase]] = {
     Task.RETRIEVAL: RetrievalAnnotation,
     Task.GROUNDING: GroundingAnnotation,
     Task.GENERATION: GenerationAnnotation,
+}
+
+TASK_EXPORT_ROW: dict[Task, type[AnnotationBase]] = {
+    Task.RETRIEVAL: RetrievalExportRow,
+    Task.GROUNDING: GroundingExportRow,
+    Task.GENERATION: GenerationExportRow,
 }
 
 
@@ -60,29 +69,33 @@ def write_export_csv(
     path: Path,
     task: Task,
 ) -> None:
-    """Write annotation rows to a CSV file with constraint columns appended.
+    """Write annotation rows to a CSV using the task's export-row schema.
 
-    Writes atomically via a .tmp file; cleans up on failure. Always writes
-    the header row even when rows is empty.
+    The schema (``TASK_EXPORT_ROW[task]``) models the full on-disk format,
+    including ``constraint_violated`` and ``constraint_details``. Writes
+    atomically via a .tmp file; cleans up on failure. Always writes the
+    header row even when rows is empty.
 
     Args:
         rows: List of (annotation, violations) tuples.
         path: Final output path.
-        task: Task type — determines schema for header derivation.
+        task: Task type — determines the export-row schema.
     """
-    schema_cls = _TASK_SCHEMA[task]
-    headers = list(schema_cls.model_fields.keys()) + ["constraint_violated", "constraint_details"]
+    row_cls = TASK_EXPORT_ROW[task]
+    headers = list(row_cls.model_fields.keys())
     tmp = path.with_suffix(".tmp")
     try:
         with tmp.open("w", newline="", encoding="utf-8") as f:
             writer = csv.DictWriter(f, fieldnames=headers)
             writer.writeheader()
             for annotation, violations in rows:
-                raw = annotation.model_dump(mode="json")
-                row = {k: _to_csv_value(raw[k]) for k in schema_cls.model_fields}
-                row["constraint_violated"] = "true" if violations else "false"
-                row["constraint_details"] = ";".join(violations)
-                writer.writerow(row)
+                export_row = row_cls(
+                    **annotation.model_dump(),
+                    constraint_violated=bool(violations),
+                    constraint_details=";".join(violations),
+                )
+                raw = export_row.model_dump(mode="json")
+                writer.writerow({k: _to_csv_value(raw[k]) for k in headers})
         tmp.rename(path)
         logger.info("Wrote %d rows to %s", len(rows), path)
     except Exception:
@@ -107,7 +120,7 @@ def run_export(
     for task in tasks:
         task_rows[task] = fetch_task(client, settings, task, user_lookup)
 
-    task_paths = {task: getattr(paths, _TASK_CSV_ATTR[task]) for task in tasks}
+    task_paths = {task: getattr(paths, TASK_CSV_ATTR[task]) for task in tasks}
 
     written: list[Path] = []
     try:

--- a/src/pragmata/core/annotation/export_runner.py
+++ b/src/pragmata/core/annotation/export_runner.py
@@ -13,7 +13,6 @@ from pragmata.core.annotation.export_fetcher import AnnotationModel, build_user_
 from pragmata.core.csv_io import _to_csv_value
 from pragmata.core.paths.annotation_paths import AnnotationExportPaths
 from pragmata.core.schemas.annotation_export import (
-    AnnotationBase,
     GenerationAnnotation,
     GenerationExportRow,
     GroundingAnnotation,
@@ -34,13 +33,15 @@ TASK_CSV_ATTR = {
     Task.GENERATION: "generation_annotation_csv",
 }
 
-TASK_ANNOTATION_SCHEMA: dict[Task, type[AnnotationBase]] = {
+TASK_ANNOTATION_SCHEMA: dict[
+    Task, type[RetrievalAnnotation] | type[GroundingAnnotation] | type[GenerationAnnotation]
+] = {
     Task.RETRIEVAL: RetrievalAnnotation,
     Task.GROUNDING: GroundingAnnotation,
     Task.GENERATION: GenerationAnnotation,
 }
 
-TASK_EXPORT_ROW: dict[Task, type[AnnotationBase]] = {
+TASK_EXPORT_ROW: dict[Task, type[RetrievalExportRow] | type[GroundingExportRow] | type[GenerationExportRow]] = {
     Task.RETRIEVAL: RetrievalExportRow,
     Task.GROUNDING: GroundingExportRow,
     Task.GENERATION: GenerationExportRow,

--- a/src/pragmata/core/annotation/export_runner.py
+++ b/src/pragmata/core/annotation/export_runner.py
@@ -33,14 +33,6 @@ TASK_CSV_ATTR = {
     Task.GENERATION: "generation_annotation_csv",
 }
 
-TASK_ANNOTATION_SCHEMA: dict[
-    Task, type[RetrievalAnnotation] | type[GroundingAnnotation] | type[GenerationAnnotation]
-] = {
-    Task.RETRIEVAL: RetrievalAnnotation,
-    Task.GROUNDING: GroundingAnnotation,
-    Task.GENERATION: GenerationAnnotation,
-}
-
 TASK_EXPORT_ROW: dict[Task, type[RetrievalExportRow] | type[GroundingExportRow] | type[GenerationExportRow]] = {
     Task.RETRIEVAL: RetrievalExportRow,
     Task.GROUNDING: GroundingExportRow,

--- a/src/pragmata/core/schemas/annotation_export.py
+++ b/src/pragmata/core/schemas/annotation_export.py
@@ -66,21 +66,21 @@ class GenerationAnnotation(AnnotationBase):
 
 
 class RetrievalExportRow(RetrievalAnnotation):
-    """On-disk CSV row for retrieval: annotation plus constraint metadata."""
+    """Full on-disk CSV row for retrieval: extends RetrievalAnnotation with constraint metadata."""
 
     constraint_violated: bool
     constraint_details: str = ""
 
 
 class GroundingExportRow(GroundingAnnotation):
-    """On-disk CSV row for grounding: annotation plus constraint metadata."""
+    """Full on-disk CSV row for grounding: extends GroundingAnnotation with constraint metadata."""
 
     constraint_violated: bool
     constraint_details: str = ""
 
 
 class GenerationExportRow(GenerationAnnotation):
-    """On-disk CSV row for generation: annotation plus constraint metadata."""
+    """Full on-disk CSV row for generation: extends GenerationAnnotation with constraint metadata."""
 
     constraint_violated: bool
     constraint_details: str = ""

--- a/src/pragmata/core/schemas/annotation_export.py
+++ b/src/pragmata/core/schemas/annotation_export.py
@@ -63,3 +63,24 @@ class GenerationAnnotation(AnnotationBase):
     incomplete: bool
     unsafe_content: bool
     notes: str = ""
+
+
+class RetrievalExportRow(RetrievalAnnotation):
+    """On-disk CSV row for retrieval: annotation plus constraint metadata."""
+
+    constraint_violated: bool
+    constraint_details: str = ""
+
+
+class GroundingExportRow(GroundingAnnotation):
+    """On-disk CSV row for grounding: annotation plus constraint metadata."""
+
+    constraint_violated: bool
+    constraint_details: str = ""
+
+
+class GenerationExportRow(GenerationAnnotation):
+    """On-disk CSV row for generation: annotation plus constraint metadata."""
+
+    constraint_violated: bool
+    constraint_details: str = ""

--- a/tests/unit/core/annotation/test_export_runner.py
+++ b/tests/unit/core/annotation/test_export_runner.py
@@ -8,7 +8,12 @@ from uuid import UUID
 
 import pytest
 
-from pragmata.core.annotation.export_runner import ExportResult, write_export_csv
+from pragmata.core.annotation.export_runner import (
+    TASK_EXPORT_ROW,
+    ExportResult,
+    write_export_csv,
+)
+from pragmata.core.csv_io import read_csv
 from pragmata.core.paths.annotation_paths import AnnotationExportPaths
 from pragmata.core.schemas.annotation_export import (
     GroundingAnnotation,
@@ -212,6 +217,34 @@ class TestWriteExportCsv:
         grounding_fields = list(GroundingAnnotation.model_fields.keys())
         for field in grounding_fields:
             assert field in header
+
+
+# ---------------------------------------------------------------------------
+# Export-row schema round-trip via csv_io
+# ---------------------------------------------------------------------------
+
+
+class TestExportRowRoundTrip:
+    def test_csv_header_matches_export_row_schema(self, tmp_path: Path) -> None:
+        out = tmp_path / "out.csv"
+        write_export_csv([(_retrieval(), [])], out, Task.RETRIEVAL)
+        with out.open() as f:
+            header = next(csv.reader(f))
+        assert header == list(TASK_EXPORT_ROW[Task.RETRIEVAL].model_fields.keys())
+
+    def test_csv_roundtrips_via_read_csv(self, tmp_path: Path) -> None:
+        out = tmp_path / "out.csv"
+        write_export_csv(
+            [(_retrieval(), []), (_retrieval(chunk_id="c2"), ["rule_a", "rule_b"])],
+            out,
+            Task.RETRIEVAL,
+        )
+        rows = read_csv(out, TASK_EXPORT_ROW[Task.RETRIEVAL])
+        assert len(rows) == 2
+        assert rows[0].constraint_violated is False
+        assert rows[0].constraint_details == ""
+        assert rows[1].constraint_violated is True
+        assert rows[1].constraint_details == "rule_a;rule_b"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/core/schemas/test_annotation_export.py
+++ b/tests/unit/core/schemas/test_annotation_export.py
@@ -7,8 +7,11 @@ from pydantic import ValidationError
 
 from pragmata.core.schemas.annotation_export import (
     GenerationAnnotation,
+    GenerationExportRow,
     GroundingAnnotation,
+    GroundingExportRow,
     RetrievalAnnotation,
+    RetrievalExportRow,
 )
 from pragmata.core.schemas.annotation_task import Task
 
@@ -192,3 +195,53 @@ def test_generation_extra_rejected(valid_generation):
     valid_generation["unknown"] = "x"
     with pytest.raises(ValidationError):
         GenerationAnnotation(**valid_generation)
+
+
+def test_retrieval_export_row_constructs(valid_retrieval):
+    """Retrieval export row constructs from annotation fields plus constraint metadata."""
+    row = RetrievalExportRow(**valid_retrieval, constraint_violated=False)
+    assert row.chunk_id == "c1"
+    assert row.constraint_violated is False
+    assert row.constraint_details == ""
+
+
+def test_grounding_export_row_constructs(valid_grounding):
+    row = GroundingExportRow(**valid_grounding, constraint_violated=True, constraint_details="rule_a;rule_b")
+    assert row.constraint_violated is True
+    assert row.constraint_details == "rule_a;rule_b"
+
+
+def test_generation_export_row_constructs(valid_generation):
+    row = GenerationExportRow(**valid_generation, constraint_violated=False)
+    assert row.constraint_details == ""
+
+
+def test_export_row_frozen(valid_retrieval):
+    row = RetrievalExportRow(**valid_retrieval, constraint_violated=False)
+    with pytest.raises(ValidationError):
+        row.constraint_violated = True
+
+
+def test_export_row_extra_rejected(valid_retrieval):
+    with pytest.raises(ValidationError):
+        RetrievalExportRow(**valid_retrieval, constraint_violated=False, unknown="x")
+
+
+def test_export_row_requires_constraint_violated(valid_retrieval):
+    with pytest.raises(ValidationError):
+        RetrievalExportRow(**valid_retrieval)
+
+
+@pytest.mark.parametrize(
+    ("row_cls", "annotation_cls"),
+    [
+        (RetrievalExportRow, RetrievalAnnotation),
+        (GroundingExportRow, GroundingAnnotation),
+        (GenerationExportRow, GenerationAnnotation),
+    ],
+)
+def test_export_row_field_order(row_cls, annotation_cls):
+    """Export row fields are annotation fields followed by the two constraint columns, in order."""
+    fields = list(row_cls.model_fields.keys())
+    expected = list(annotation_cls.model_fields.keys()) + ["constraint_violated", "constraint_details"]
+    assert fields == expected


### PR DESCRIPTION
## Goal

Prep PR for #118. Model the export CSV on-disk row as explicit Pydantic schemas, so the IAA runner can swap its local `_read_csv` + `_to_bool` helpers (with their silent-False bug) for `csv_io.read_csv(path, TASK_EXPORT_ROW[task])`.

Addresses SG's suggestion on #118 comment thread: *"introduce RetrievalExportRow / GroundingExportRow / GenerationExportRow extending each annotation schema with `constraint_violated: bool` and `constraint_details: str`, swap `TASK_SCHEMA` in `export_runner.py` + `iaa_runner.py` to these row schemas, and replace `_read_csv`/`_to_bool` with `csv_io.read_csv(csv_path, TASK_EXPORT_ROW[task])`."* 

## Scope

1. **New export-row schemas** in `core/schemas/annotation_export.py`: `RetrievalExportRow`, `GroundingExportRow`, `GenerationExportRow`. Each extends its annotation schema with `constraint_violated: bool` (required) and `constraint_details: str = ""`. Inherits `frozen=True, extra="forbid"` via `AnnotationBase`.
2. **Split `TASK_SCHEMA`** in `core/annotation/export_runner.py` into two explicit mappings:
   - `TASK_ANNOTATION_SCHEMA`: annotation-only, used downstream for IAA label derivation (bool-field filter stays meaningful, won't pick up `constraint_violated` metadata)
   - `TASK_EXPORT_ROW`: full on-disk row, drives CSV header + construction
3. **Rewrite `write_export_csv`** to build export-row instances from `(annotation, violations)` tuples and serialise via the schema. Removes the out-of-schema column append. `extra="forbid"` on the export row now validates every write.

## Implementation

- `RetrievalExportRow(RetrievalAnnotation)` etc. Pydantic preserves parent-then-child field order in `model_fields`, so the CSV header is byte-identical to the old manual `list(schema.model_fields) + ["constraint_violated", "constraint_details"]` construction.
- `write_export_csv` now routes through `row_cls(**annotation.model_dump(), constraint_violated=bool(violations), constraint_details=";".join(violations))`. The single `model_dump(mode="json")` at the end feeds `_to_csv_value` for scalar serialisation, unchanged.
- Atomicity (`.tmp` + rename + cleanup on failure) preserved. `csv_io.write_csv` is not used directly — it's a no-op on empty input, but `write_export_csv` must always emit a header.

## On `constraint_details: str` vs `list[str]`

Modelled as `str` to preserve the existing on-disk format (`";".join(violations)`) exactly. The honest type is `list[str]`, and semicolon-joining is lossy if a violation message ever contains `;`.

BUT migrating to `list[str]` would require (a) deciding a structured serialisation format, (b) extending `csv_io` with list-field support, and (c) changing on-disk CSV bytes. Potential follow-up PR.

## Testing

- **Existing `TestWriteExportCsv` assertions unchanged and passing** — these check specific on-disk bytes (bool `"true"/"false"`, `;`-joined constraint_details, header-only on empty input, `.tmp` cleanup). Byte-identity confirmed.
- **New `test_export_runner.py::TestExportRowRoundTrip`** — writes CSVs, reads back via `csv_io.read_csv(path, TASK_EXPORT_ROW[task])`, asserts typed `bool` constraint_violated and correct values. Proves the downstream #118 swap will work end-to-end.
- **New tests in `test_annotation_export.py`** — construction, frozen, extra-forbid, required constraint_violated, parametrised field-order invariant across all three row classes.
- Full suite: 491 pass.

## References

- Downstream consumer: #118 (will be rebased onto this; the `_read_csv`/`_to_bool` swap lives there)
- SG's review thread on #118, `src/pragmata/core/annotation/iaa_runner.py` line 43

## Follow-up (flagged, not in scope)

- `constraint_details: list[str]` + `csv_io` list-field support (see above)
- Legacy `TASK_SCHEMA` alias not added; #118's rebase will replace its single import with the two new names