### PR TITLE
feat: add planning-memory feature flag to querygen settings and public API

### DIFF
--- a/src/pragmata/api/querygen.py
+++ b/src/pragmata/api/querygen.py
@@ -59,6 +59,7 @@ def gen_queries(
     base_url: str | Unset = UNSET,
     model_kwargs: dict[str, Any] | Unset = UNSET,
     batch_size: PositiveInt | Unset = UNSET,
+    enable_planning_memory: bool | Unset = UNSET,
 ) -> QueryGenRunResult:
     """Generate synthetic chatbot queries from a query-generation specification.
 
@@ -91,6 +92,10 @@ def gen_queries(
         batch_size: Number of queries to generate per LLM call. Larger
             values use fewer, bigger calls; smaller values split
             generation into more repeated calls. Defaults to 25.
+        enable_planning_memory: Whether to enable planning memory for the run.
+            Defaults to True. When enabled, an additional LLM updates and persists a
+            compact summary of prior blueprint generation across batches and compatible
+            runs to reduce redundant or near-duplicate queries and improve diversity.
         run_id: Explicit run identifier. Defaults to an auto-generated UUID
             hex string.
         model_provider: Chat model provider to use. Defaults to "mistralai".
@@ -153,6 +158,7 @@ def gen_queries(
             "run_id": run_id,
             "n_queries": n_queries,
             "batch_size": batch_size,
+            "enable_planning_memory": enable_planning_memory,
         },
     )
 

--- a/src/pragmata/core/settings/querygen_settings.py
+++ b/src/pragmata/core/settings/querygen_settings.py
@@ -34,3 +34,4 @@ class QueryGenRunSettings(ResolveSettings):
     run_id: str = Field(default_factory=lambda: uuid4().hex)
     n_queries: PositiveInt = 50
     batch_size: PositiveInt = 25
+    enable_planning_memory: bool = True

--- a/tests/unit/api/test_querygen.py
+++ b/tests/unit/api/test_querygen.py
@@ -261,6 +261,7 @@ def test_gen_queries_combines_user_args_config_and_defaults(tmp_path: Path) -> N
     assert result.paths.run_dir.name == result.settings.run_id
     assert result.settings.llm.realization_model == "mistral-medium-latest"
     assert result.settings.batch_size == 12
+    assert result.settings.enable_planning_memory is True
 
 
 def test_gen_queries_orchestrates_run_paths(tmp_path: Path) -> None:
@@ -905,3 +906,29 @@ def test_gen_queries_handles_empty_selected_blueprints_after_stage1(
             "meta_path": result.paths.synthetic_queries_meta_json,
         }
     ]
+
+
+def test_gen_queries_enable_planning_memory_arg_overrides_config_value(
+    tmp_path: Path,
+) -> None:
+    """Explicit enable_planning_memory arg takes precedence over config value."""
+    config_path = tmp_path / "querygen.yml"
+    config_path.write_text(
+        dedent(
+            """\
+            llm:
+              model_provider: mistralai
+            enable_planning_memory: true
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    result = querygen_api.gen_queries(
+        **_required_querygen_kwargs(tmp_path),
+        config_path=config_path,
+        enable_planning_memory=False,
+        run_id="planning-memory-precedence-check",
+    )
+
+    assert result.settings.enable_planning_memory is False

--- a/tests/unit/core/settings/test_querygen_settings.py
+++ b/tests/unit/core/settings/test_querygen_settings.py
@@ -52,6 +52,7 @@ def test_querygen_run_settings_construction_with_defaults() -> None:
     assert settings.run_id
     assert settings.n_queries == 50
     assert settings.batch_size == 25
+    assert settings.enable_planning_memory is True
 
 
 def test_querygen_run_settings_resolve_deep_merges_nested_llm_settings() -> None:
@@ -162,3 +163,18 @@ def test_querygen_run_settings_resolve_batch_size_override_precedence() -> None:
     )
 
     assert resolved.batch_size == 7
+
+
+def test_querygen_run_settings_resolve_enable_planning_memory_override() -> None:
+    """Resolve applies explicit enable_planning_memory overrides over config values."""
+    resolved = QueryGenRunSettings.resolve(
+        config={
+            "spec": _valid_spec_payload(),
+            "enable_planning_memory": True,
+        },
+        overrides={
+            "enable_planning_memory": False,
+        },
+    )
+
+    assert resolved.enable_planning_memory is False


### PR DESCRIPTION
**Summary**

Add a run-level planning-memory feature flag to synthetic query generation settings and the public API, with planning memory enabled by default.

**Key changes**

- Update `core/settings/querygen_settings.py`:
  - add `enable_planning_memory: bool = True` to `QueryGenRunSettings`

- Update `api/querygen.py`:
  - add `enable_planning_memory: bool | Unset = UNSET` to `gen_queries(...)`
  - thread the new flag through the existing `QueryGenRunSettings.resolve(...)` override payload
  - extend the `gen_queries(...)` docstring to describe the planning-memory option

- Add settings-layer tests:
  - default construction includes `enable_planning_memory=True`
  - explicit `QueryGenRunSettings.resolve(...)` override is applied correctly

- Add API-layer tests:
  - `gen_queries(...)` preserves the default planning-memory setting when omitted
  - explicit `enable_planning_memory` arg overrides config/defaults

**Status**

Ready for review.

Closes #131