### PR TITLE
feat: support optional planning-summary context in stage-1 planning

### DIFF
--- a/src/pragmata/core/querygen/planning.py
+++ b/src/pragmata/core/querygen/planning.py
@@ -14,6 +14,11 @@ class PlanningStageError(RuntimeError):
     """Raised when a planning-stage invocation fails."""
 
 
+def normalize_multiline(value: str) -> str:
+    """Normalize multiline text to a single line for prompt safety."""
+    return " ".join(value.splitlines()).strip()
+
+
 def format_weighted_values(values: list[WeightedValue] | None) -> str:
     """Format weighted categorical values for prompt injection.
 
@@ -63,9 +68,9 @@ def _format_planning_summary(
     return (
         "The following prior planning summary is provided as advisory context from earlier planning batches.\n\n"
         "- prior_planning_summary:\n"
-        f"  - redundancy_patterns: {planning_summary.redundancy_patterns}\n"
-        f"  - diversification_targets: {planning_summary.diversification_targets}\n"
-        f"  - coverage_notes: {planning_summary.coverage_notes}\n\n"
+        f"  - redundancy_patterns: {normalize_multiline(planning_summary.redundancy_patterns)}\n"
+        f"  - diversification_targets: {normalize_multiline(planning_summary.diversification_targets)}\n"
+        f"  - coverage_notes: {normalize_multiline(planning_summary.coverage_notes)}\n\n"
     )
 
 

--- a/src/pragmata/core/querygen/planning.py
+++ b/src/pragmata/core/querygen/planning.py
@@ -4,6 +4,7 @@ from pragmata.core.querygen.llm import LlmInitializationError, build_llm_runnabl
 from pragmata.core.querygen.prompts import SYSTEM_PROMPT_PLANNING, USER_PROMPT_PLANNING
 from pragmata.core.schemas.querygen_input import QueryGenSpec, WeightedValue
 from pragmata.core.schemas.querygen_plan import QueryBlueprint, QueryBlueprintList
+from pragmata.core.schemas.querygen_summary import PlanningSummaryState
 from pragmata.core.settings.querygen_settings import LlmSettings
 
 _UNSPECIFIED = "Not specified"
@@ -43,15 +44,60 @@ def format_string_list(values: list[str] | None) -> str:
     return ", ".join(values)
 
 
+def _format_planning_summary(
+    planning_summary: PlanningSummaryState | None,
+) -> str:
+    """Format optional planning summary for prompt injection under CONTEXT.
+
+    Args:
+        planning_summary: Advisory planning summary from earlier planning batches.
+
+    Returns:
+        A deterministic human-readable planning-summary block with trailing spacing
+        suitable for direct prompt injection. Returns an empty string when no
+        planning memory is present.
+    """
+    if planning_summary is None:
+        return ""
+
+    return (
+        "The following prior planning summary is provided as advisory context from earlier planning batches.\n\n"
+        "- prior_planning_summary:\n"
+        f"  - redundancy_patterns: {planning_summary.redundancy_patterns}\n"
+        f"  - diversification_targets: {planning_summary.diversification_targets}\n"
+        f"  - coverage_notes: {planning_summary.coverage_notes}\n\n"
+    )
+
+
+def _format_planning_summary_task_context(
+    planning_summary: PlanningSummaryState | None,
+) -> str:
+    """Format optional planning-summary wording for the planning TASK section.
+
+    Args:
+        planning_summary: Advisory planning summary from earlier planning batches.
+
+    Returns:
+        A short conditional sentence appended to the planning TASK.
+        Returns an empty string when no planning summary is present.
+    """
+    if planning_summary is None:
+        return ""
+
+    return " Use the planning summary as advisory context for avoiding near-duplicate candidates."
+
+
 def _build_planning_prompt_vars(
     spec: QueryGenSpec,
     batch_candidate_ids: list[str],
+    planning_summary: PlanningSummaryState | None = None,
 ) -> dict[str, object]:
     """Build invoke-time prompt variables for one planning-stage batch.
 
     Args:
         spec: Resolved query-generation specification.
         batch_candidate_ids: Candidate IDs assigned to this single planning invocation.
+        planning_summary: Advisory planning summary from earlier planning batches.
 
     Returns:
         Prompt variables aligned with the stage-1 planning prompt placeholders.
@@ -71,6 +117,8 @@ def _build_planning_prompt_vars(
         "formats": format_weighted_values(spec.format_requests.formats),
         "disallowed_topics": format_string_list(spec.safety.disallowed_topics),
         "n_queries": len(batch_candidate_ids),
+        "planning_summary": _format_planning_summary(planning_summary),
+        "planning_summary_task_context": _format_planning_summary_task_context(planning_summary),
     }
 
 
@@ -79,6 +127,7 @@ def run_planning_stage(
     llm_settings: LlmSettings,
     api_key: str,
     batch_candidate_ids: list[str],
+    planning_summary: PlanningSummaryState | None = None,
 ) -> list[QueryBlueprint]:
     """Run one stage-1 planning invocation.
 
@@ -87,6 +136,7 @@ def run_planning_stage(
         llm_settings: LLM settings for the query-generation workflow.
         api_key: Provider API key for the configured planning model.
         batch_candidate_ids: Candidate IDs assigned to this single planning invocation.
+        planning_summary: Advisory planning summary from earlier planning batches.
 
     Returns:
         The list of structured candidate blueprints returned by the planning stage.
@@ -94,6 +144,7 @@ def run_planning_stage(
     prompt_vars = _build_planning_prompt_vars(
         spec=spec,
         batch_candidate_ids=batch_candidate_ids,
+        planning_summary=planning_summary,
     )
 
     try:

--- a/src/pragmata/core/querygen/planning_summary.py
+++ b/src/pragmata/core/querygen/planning_summary.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 
 from pragmata.core.querygen.llm import LlmInitializationError, build_llm_runnable
-from pragmata.core.querygen.planning import format_string_list, format_weighted_values
+from pragmata.core.querygen.planning import format_string_list, format_weighted_values, normalize_multiline
 from pragmata.core.querygen.prompts import (
     SYSTEM_PROMPT_PLANNING_SUMMARY,
     USER_PROMPT_PLANNING_SUMMARY,
@@ -87,11 +87,6 @@ def read_planning_summary_artifact(
     return artifact
 
 
-def _normalize_multiline(value: str) -> str:
-    """Normalize multiline text to a single line for prompt safety."""
-    return " ".join(value.splitlines()).strip()
-
-
 def _format_prior_summary_state(
     prior_summary_state: PlanningSummaryState,
 ) -> str:
@@ -105,11 +100,11 @@ def _format_prior_summary_state(
     """
     return (
         "- redundancy_patterns:\n"
-        f"  {_normalize_multiline(prior_summary_state.redundancy_patterns)}\n"
+        f"  {normalize_multiline(prior_summary_state.redundancy_patterns)}\n"
         "- diversification_targets:\n"
-        f"  {_normalize_multiline(prior_summary_state.diversification_targets)}\n"
+        f"  {normalize_multiline(prior_summary_state.diversification_targets)}\n"
         "- coverage_notes:\n"
-        f"  {_normalize_multiline(prior_summary_state.coverage_notes)}"
+        f"  {normalize_multiline(prior_summary_state.coverage_notes)}"
     )
 
 

--- a/src/pragmata/core/querygen/prompts.py
+++ b/src/pragmata/core/querygen/prompts.py
@@ -94,9 +94,9 @@ Behavioral guardrails:
 
 - Maximize useful diversity across the full candidate set while remaining faithful to the provided weighted \
 specification
-- When planning memory is present, use it as advisory context to reduce redundancy and improve useful diversity across \
+- When planning summary is present, use it as advisory context to reduce redundancy and improve useful diversity across \
 the candidate set
-- Planning memory must not override the weighted specification and must not justify introducing unsupported \
+- Planning summary must not override the weighted specification and must not justify introducing unsupported \
 dimensions, values, constraints, or assumptions
 - Respect all constraints provided in the query-generation specification, including disallowed topics
 - Do not introduce unsupported assumptions or dimensions that were not provided
@@ -111,7 +111,7 @@ dimensions, values, constraints, or assumptions
 
 USER_PROMPT_PLANNING = """CONTEXT
 
-{planning_memory}The following is the list of candidate IDs. Each ID corresponds to exactly one candidate blueprint.
+{planning_summary}The following is the list of candidate IDs. Each ID corresponds to exactly one candidate blueprint.
 
 - candidate_ids: {candidate_ids}
 
@@ -142,7 +142,7 @@ distribution for candidate query blueprints.
 TASK
 
 Generate {n_queries} candidate query blueprints from this specification, using exactly the provided candidate IDs.\
-{planning_memory_task_context}
+{planning_summary_task_context}
 """
 
 SYSTEM_PROMPT_REALIZATION = """ROLE

--- a/src/pragmata/core/querygen/prompts.py
+++ b/src/pragmata/core/querygen/prompts.py
@@ -94,8 +94,8 @@ Behavioral guardrails:
 
 - Maximize useful diversity across the full candidate set while remaining faithful to the provided weighted \
 specification
-- When planning summary is present, use it as advisory context to reduce redundancy and improve useful diversity across \
-the candidate set
+- When planning summary is present, use it as advisory context to reduce redundancy and improve useful diversity \
+across the candidate set
 - Planning summary must not override the weighted specification and must not justify introducing unsupported \
 dimensions, values, constraints, or assumptions
 - Respect all constraints provided in the query-generation specification, including disallowed topics

--- a/src/pragmata/core/querygen/prompts.py
+++ b/src/pragmata/core/querygen/prompts.py
@@ -11,6 +11,7 @@ You receive:
 
 - A structured query-generation specification describing the target query space, including semantic dimensions and \
 weighted candidate values for each dimension
+- An optional prior planning summary representing the advisory synthesis from earlier planning batches
 - A requested number of candidate outputs and a corresponding list of candidate IDs, one per output
 - A structured output schema that defines the blueprint format you must produce
 
@@ -35,6 +36,8 @@ Your detailed task entails two tightly coupled components:
   - Combine sampled dimension values into internally coherent, realistic user-query blueprints.
   - Ensure every candidate conforms exactly to the structured output schema.
   - Generate blueprints only and do not realize them into final user-facing queries.
+  - Treat the optional prior planning summary as a compact advisory summary of prior blueprint coverage, intended to \
+  help avoid repeated or near-duplicate candidates.
 
 Taken together, each candidate blueprint is constructed by sampling across the provided dimensions and combining the \
 sampled values into a coherent query specification.
@@ -91,6 +94,10 @@ Behavioral guardrails:
 
 - Maximize useful diversity across the full candidate set while remaining faithful to the provided weighted \
 specification
+- When planning memory is present, use it as advisory context to reduce redundancy and improve useful diversity across \
+the candidate set
+- Planning memory must not override the weighted specification and must not justify introducing unsupported \
+dimensions, values, constraints, or assumptions
 - Respect all constraints provided in the query-generation specification, including disallowed topics
 - Do not introduce unsupported assumptions or dimensions that were not provided
 - Do not force awkward values into a blueprint merely for coverage if they make the result implausible
@@ -104,7 +111,7 @@ specification
 
 USER_PROMPT_PLANNING = """CONTEXT
 
-The following is the list of candidate IDs. Each ID corresponds to exactly one candidate blueprint.
+{planning_memory}The following is the list of candidate IDs. Each ID corresponds to exactly one candidate blueprint.
 
 - candidate_ids: {candidate_ids}
 
@@ -134,7 +141,8 @@ distribution for candidate query blueprints.
 
 TASK
 
-Generate {n_queries} candidate query blueprints from this specification, using exactly the provided candidate IDs.
+Generate {n_queries} candidate query blueprints from this specification, using exactly the provided candidate IDs.\
+{planning_memory_task_context}
 """
 
 SYSTEM_PROMPT_REALIZATION = """ROLE

--- a/tests/unit/core/querygen/test_planning.py
+++ b/tests/unit/core/querygen/test_planning.py
@@ -5,7 +5,14 @@ from unittest.mock import Mock
 import pytest
 
 from pragmata.core.querygen.llm import LlmInitializationError
-from pragmata.core.querygen.planning import PlanningStageError, _build_planning_prompt_vars, run_planning_stage
+from pragmata.core.querygen.planning import (
+    PlanningStageError,
+    _build_planning_prompt_vars,
+    _format_planning_summary,
+    _format_planning_summary_task_context,
+    run_planning_stage
+)
+from pragmata.core.schemas.querygen_summary import PlanningSummaryState
 from pragmata.core.querygen.prompts import SYSTEM_PROMPT_PLANNING, USER_PROMPT_PLANNING
 from pragmata.core.schemas.querygen_input import QueryGenSpec
 from pragmata.core.schemas.querygen_plan import QueryBlueprint, QueryBlueprintList
@@ -78,6 +85,16 @@ def minimal_querygen_spec() -> QueryGenSpec:
 
 
 @pytest.fixture
+def planning_summary_state() -> PlanningSummaryState:
+    """Return a representative advisory planning summary."""
+    return PlanningSummaryState(
+        redundancy_patterns="Repeated benefits-letter clarification scenarios for individual patients.",
+        diversification_targets="Add more comparison and decision-support scenarios across adjacent service contexts.",
+        coverage_notes="Basic insurance coverage lookups already well represented across English requests.",
+    )
+
+
+@pytest.fixture
 def llm_settings() -> LlmSettings:
     """Return representative planning-stage LLM settings."""
     return LlmSettings(
@@ -107,6 +124,8 @@ def expected_prompt_vars() -> dict[str, object]:
         "formats": "bullet list (weight=0.5), table (weight=0.5)",
         "disallowed_topics": "self-harm, hate speech",
         "n_queries": 1,
+        "planning_summary": "",
+        "planning_summary_task_context": "",
     }
 
 
@@ -124,6 +143,36 @@ def _make_blueprint(candidate_id: str = "C001") -> QueryBlueprint:
         format=None,
         user_scenario="A patient reviews a benefits letter.",
         information_need="Clarify what is covered.",
+    )
+
+
+def test_format_planning_summary_returns_empty_string_when_absent() -> None:
+    assert _format_planning_summary(None) == ""
+
+
+def test_format_planning_summary_formats_state_deterministically(
+    planning_summary_state: PlanningSummaryState,
+) -> None:
+    result = _format_planning_summary(planning_summary_state)
+
+    assert result == (
+        "The following prior planning summary is provided as advisory context from earlier planning batches.\n\n"
+        "- prior_planning_summary:\n"
+        "  - redundancy_patterns: Repeated benefits-letter clarification scenarios for individual patients.\n"
+        "  - diversification_targets: Add more comparison and decision-support scenarios across adjacent service contexts.\n"
+        "  - coverage_notes: Basic insurance coverage lookups already well represented across English requests.\n\n"
+    )
+
+
+def test_format_planning_summary_task_context_returns_empty_string_when_absent() -> None:
+    assert _format_planning_summary_task_context(None) == ""
+
+
+def test_format_planning_summary_task_context_returns_sentence_when_present(
+    planning_summary_state: PlanningSummaryState,
+) -> None:
+    assert _format_planning_summary_task_context(planning_summary_state) == (
+        " Use the planning summary as advisory context for avoiding near-duplicate candidates."
     )
 
 
@@ -147,6 +196,8 @@ def test_build_planning_prompt_vars_formats_resolved_spec(
         "formats": "bullet list (weight=0.5), table (weight=0.5)",
         "disallowed_topics": "self-harm, hate speech",
         "n_queries": 3,
+        "planning_summary": "",
+        "planning_summary_task_context": "",
     }
 
 
@@ -162,6 +213,30 @@ def test_build_planning_prompt_vars_uses_not_specified_for_missing_optional_fiel
     assert result["formats"] == "Not specified"
     assert result["disallowed_topics"] == "Not specified"
     assert result["n_queries"] == 1
+    assert result["planning_summary"] == ""
+    assert result["planning_summary_task_context"] == ""
+
+
+def test_build_planning_prompt_vars_includes_planning_summary_when_present(
+    querygen_spec: QueryGenSpec,
+    planning_summary_state: PlanningSummaryState,
+) -> None:
+    result = _build_planning_prompt_vars(
+        spec=querygen_spec,
+        batch_candidate_ids=["C001"],
+        planning_summary=planning_summary_state,
+    )
+
+    assert result["planning_summary"] == (
+        "The following prior planning summary is provided as advisory context from earlier planning batches.\n\n"
+        "- prior_planning_summary:\n"
+        "  - redundancy_patterns: Repeated benefits-letter clarification scenarios for individual patients.\n"
+        "  - diversification_targets: Add more comparison and decision-support scenarios across adjacent service contexts.\n"
+        "  - coverage_notes: Basic insurance coverage lookups already well represented across English requests.\n\n"
+    )
+    assert result["planning_summary_task_context"] == (
+        " Use the planning summary as advisory context for avoiding near-duplicate candidates."
+    )
 
 
 def test_build_planning_prompt_vars_rejects_empty_candidate_ids(
@@ -212,6 +287,55 @@ def test_run_planning_stage_wires_planning_assets_and_settings_into_llm_builder(
         model_kwargs=llm_settings.model_kwargs,
     )
     mock_runnable.invoke.assert_called_once_with(expected_prompt_vars)
+
+
+def test_run_planning_stage_wires_optional_planning_summary_through_to_runnable(
+    monkeypatch: pytest.MonkeyPatch,
+    querygen_spec: QueryGenSpec,
+    llm_settings: LlmSettings,
+    planning_summary_state: PlanningSummaryState,
+) -> None:
+    mock_runnable = Mock()
+    mock_runnable.invoke.return_value = QueryBlueprintList(candidates=[_make_blueprint()])
+
+    monkeypatch.setattr(
+        "pragmata.core.querygen.planning.build_llm_runnable",
+        Mock(return_value=mock_runnable),
+    )
+
+    run_planning_stage(
+        spec=querygen_spec,
+        llm_settings=llm_settings,
+        api_key="test-api-key",
+        batch_candidate_ids=["C001"],
+        planning_summary=planning_summary_state,
+    )
+
+    mock_runnable.invoke.assert_called_once_with(
+        {
+            "candidate_ids": "\n    - C001",
+            "domains": "healthcare (weight=0.7), education (weight=0.3)",
+            "roles": "patient (weight=1)",
+            "languages": "English (weight=0.5), German (weight=0.5)",
+            "topics": "insurance coverage (weight=0.6), treatment options (weight=0.4)",
+            "intents": "understand (weight=0.5), compare (weight=0.5)",
+            "tasks": "summarize (weight=0.25), recommend (weight=0.75)",
+            "difficulty": "advanced (weight=1)",
+            "formats": "bullet list (weight=0.5), table (weight=0.5)",
+            "disallowed_topics": "self-harm, hate speech",
+            "n_queries": 1,
+            "planning_summary": (
+                "The following prior planning summary is provided as advisory context from earlier planning batches.\n\n"
+                "- prior_planning_summary:\n"
+                "  - redundancy_patterns: Repeated benefits-letter clarification scenarios for individual patients.\n"
+                "  - diversification_targets: Add more comparison and decision-support scenarios across adjacent service contexts.\n"
+                "  - coverage_notes: Basic insurance coverage lookups already well represented across English requests.\n\n"
+            ),
+            "planning_summary_task_context": (
+                " Use the planning summary as advisory context for avoiding near-duplicate candidates."
+            ),
+        }
+    )
 
 
 def test_run_planning_stage_invokes_runnable_once_and_returns_candidates(
@@ -367,4 +491,6 @@ def test_build_planning_prompt_vars_returns_exact_placeholder_mapping(
         "formats",
         "disallowed_topics",
         "n_queries",
+        "planning_summary",
+        "planning_summary_task_context",
     }

--- a/tests/unit/core/querygen/test_planning.py
+++ b/tests/unit/core/querygen/test_planning.py
@@ -10,12 +10,12 @@ from pragmata.core.querygen.planning import (
     _build_planning_prompt_vars,
     _format_planning_summary,
     _format_planning_summary_task_context,
-    run_planning_stage
+    run_planning_stage,
 )
-from pragmata.core.schemas.querygen_summary import PlanningSummaryState
 from pragmata.core.querygen.prompts import SYSTEM_PROMPT_PLANNING, USER_PROMPT_PLANNING
 from pragmata.core.schemas.querygen_input import QueryGenSpec
 from pragmata.core.schemas.querygen_plan import QueryBlueprint, QueryBlueprintList
+from pragmata.core.schemas.querygen_summary import PlanningSummaryState
 from pragmata.core.settings.querygen_settings import LlmSettings
 
 
@@ -159,7 +159,8 @@ def test_format_planning_summary_formats_state_deterministically(
         "The following prior planning summary is provided as advisory context from earlier planning batches.\n\n"
         "- prior_planning_summary:\n"
         "  - redundancy_patterns: Repeated benefits-letter clarification scenarios for individual patients.\n"
-        "  - diversification_targets: Add more comparison and decision-support scenarios across adjacent service contexts.\n"
+        "  - diversification_targets: Add more comparison and decision-support scenarios "
+        "across adjacent service contexts.\n"
         "  - coverage_notes: Basic insurance coverage lookups already well represented across English requests.\n\n"
     )
 
@@ -231,7 +232,8 @@ def test_build_planning_prompt_vars_includes_planning_summary_when_present(
         "The following prior planning summary is provided as advisory context from earlier planning batches.\n\n"
         "- prior_planning_summary:\n"
         "  - redundancy_patterns: Repeated benefits-letter clarification scenarios for individual patients.\n"
-        "  - diversification_targets: Add more comparison and decision-support scenarios across adjacent service contexts.\n"
+        "  - diversification_targets: Add more comparison and decision-support scenarios "
+        "across adjacent service contexts.\n"
         "  - coverage_notes: Basic insurance coverage lookups already well represented across English requests.\n\n"
     )
     assert result["planning_summary_task_context"] == (
@@ -325,11 +327,14 @@ def test_run_planning_stage_wires_optional_planning_summary_through_to_runnable(
             "disallowed_topics": "self-harm, hate speech",
             "n_queries": 1,
             "planning_summary": (
-                "The following prior planning summary is provided as advisory context from earlier planning batches.\n\n"
+                "The following prior planning summary is provided as advisory context "
+                "from earlier planning batches.\n\n"
                 "- prior_planning_summary:\n"
                 "  - redundancy_patterns: Repeated benefits-letter clarification scenarios for individual patients.\n"
-                "  - diversification_targets: Add more comparison and decision-support scenarios across adjacent service contexts.\n"
-                "  - coverage_notes: Basic insurance coverage lookups already well represented across English requests.\n\n"
+                "  - diversification_targets: Add more comparison and decision-support scenarios "
+                "across adjacent service contexts.\n"
+                "  - coverage_notes: Basic insurance coverage lookups already well represented "
+                "across English requests.\n\n"
             ),
             "planning_summary_task_context": (
                 " Use the planning summary as advisory context for avoiding near-duplicate candidates."


### PR DESCRIPTION
**Summary**

Update the stage-1 planning workflow so planning prompts can optionally receive advisory planning-summary context from prior batches, and wire that context through the planning executor.

**Key changes**

- Update stage-1 planning prompt assets in `core/querygen/prompts.py`:
  - extend `SYSTEM_PROMPT_PLANNING` to describe the optional advisory planning summary
  - add guardrails clarifying that planning summary is subordinate to the weighted specification
  - add a conditional `{planning_summary}` placeholder under `CONTEXT` in `USER_PROMPT_PLANNING`
  - add a conditional `{planning_summary_task_context}` placeholder in the planning `TASK` section

- Extend the planning executor in `core/querygen/planning.py`:
  - add formatting helpers for optional planning-summary prompt injection
  - extend `_build_planning_prompt_vars()` with optional planning-summary support
  - resolve planning-summary prompt vars to empty strings when no planning summary is present
  - extend `run_planning_stage()` to accept and pass through optional planning-summary state

- Add unit tests in `tests/unit/core/querygen/test_planning.py` covering:
  - deterministic formatting of `PlanningSummaryState` for prompt injection
  - empty-string resolution when planning summary is absent
  - `_build_planning_prompt_vars()` behavior with planning summary present
  - `_build_planning_prompt_vars()` behavior with planning summary absent
  - correct wiring of optional planning summary through `run_planning_stage()`
  - unchanged one-shot planning invocation behavior apart from the new optional prompt vars

**Status**
Ready for review.

Closes #129  
Closes #130