### PR TITLE
feat: add planning-memory artifact assembly and JSON export

### DIFF
--- a/src/pragmata/core/querygen/assembly.py
+++ b/src/pragmata/core/querygen/assembly.py
@@ -2,9 +2,12 @@
 
 from datetime import UTC, datetime
 
-from pragmata.core.schemas.querygen_output import SyntheticQueriesMeta, SyntheticQueryRow
+from pragmata.core.querygen.planning_memory import fingerprint_querygen_spec
+from pragmata.core.schemas.querygen_input import QueryGenSpec
+from pragmata.core.schemas.querygen_output import PlanningSummaryArtifact, SyntheticQueriesMeta, SyntheticQueryRow
 from pragmata.core.schemas.querygen_plan import QueryBlueprint
 from pragmata.core.schemas.querygen_realize import RealizedQuery
+from pragmata.core.schemas.querygen_summary import PlanningSummaryState
 
 
 def _build_query_ids(
@@ -87,4 +90,28 @@ def assemble_queries_meta(
         model_provider=model_provider,
         planning_model=planning_model,
         realization_model=realization_model,
+    )
+
+
+def assemble_planning_summary(
+    spec: QueryGenSpec,
+    run_id: str,
+    state: PlanningSummaryState,
+) -> PlanningSummaryArtifact:
+    """Assemble a planning-summary artifact from the final summary state.
+
+    Args:
+        spec: Resolved query-generation specification for the run.
+        run_id: Unique run identifier used as the source for the artifact.
+        state: Final run-level planning-summary produced by the summary-updater stage.
+
+    Returns:
+        A validated ``PlanningSummaryArtifact`` with internally generated
+        ``spec_fingerprint`` and ``created_at`` metadata.
+    """
+    return PlanningSummaryArtifact(
+        spec_fingerprint=fingerprint_querygen_spec(spec),
+        source_run_id=run_id,
+        created_at=datetime.now(UTC),
+        state=state,
     )

--- a/src/pragmata/core/querygen/assembly.py
+++ b/src/pragmata/core/querygen/assembly.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-from pragmata.core.querygen.planning_memory import fingerprint_querygen_spec
+from pragmata.core.querygen.planning_summary import fingerprint_querygen_spec
 from pragmata.core.schemas.querygen_input import QueryGenSpec
 from pragmata.core.schemas.querygen_output import PlanningSummaryArtifact, SyntheticQueriesMeta, SyntheticQueryRow
 from pragmata.core.schemas.querygen_plan import QueryBlueprint

--- a/src/pragmata/core/querygen/export.py
+++ b/src/pragmata/core/querygen/export.py
@@ -32,11 +32,11 @@ def export_planning_summary(
     artifact: PlanningSummaryArtifact,
     artifact_path: Path,
 ) -> None:
-    """Write a planning-memory artifact to disk as JSON.
+    """Write a planning-summary artifact to disk as JSON.
 
     Args:
-        artifact: Validated planning-memory artifact to persist.
-        path: Destination path for the JSON artifact.
+        artifact: Validated planning-summary artifact to persist.
+        artifact_path: Destination path for the JSON artifact.
     """
     artifact_path.write_text(
         json.dumps(artifact.model_dump(mode="json")),

--- a/src/pragmata/core/querygen/export.py
+++ b/src/pragmata/core/querygen/export.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 
 from pragmata.core.csv_io import write_csv
-from pragmata.core.schemas.querygen_output import SyntheticQueriesMeta, SyntheticQueryRow
+from pragmata.core.schemas.querygen_output import PlanningSummaryArtifact, SyntheticQueriesMeta, SyntheticQueryRow
 
 
 def export_queries(
@@ -24,5 +24,21 @@ def export_queries(
     write_csv(rows, queries_path)
     meta_path.write_text(
         json.dumps(meta.model_dump(mode="json")),
+        encoding="utf-8",
+    )
+
+
+def export_planning_summary(
+    artifact: PlanningSummaryArtifact,
+    artifact_path: Path,
+) -> None:
+    """Write a planning-memory artifact to disk as JSON.
+
+    Args:
+        artifact: Validated planning-memory artifact to persist.
+        path: Destination path for the JSON artifact.
+    """
+    artifact_path.write_text(
+        json.dumps(artifact.model_dump(mode="json")),
         encoding="utf-8",
     )

--- a/tests/unit/core/querygen/test_assembly.py
+++ b/tests/unit/core/querygen/test_assembly.py
@@ -7,11 +7,15 @@ from pydantic import ValidationError
 
 from pragmata.core.querygen.assembly import (
     _build_query_ids,
+    assemble_planning_summary,
     assemble_queries_meta,
     assemble_query_rows,
 )
+from pragmata.core.querygen.planning_memory import fingerprint_querygen_spec
+from pragmata.core.schemas.querygen_input import QueryGenSpec
 from pragmata.core.schemas.querygen_plan import QueryBlueprint
 from pragmata.core.schemas.querygen_realize import RealizedQuery
+from pragmata.core.schemas.querygen_summary import PlanningSummaryState
 
 
 def _make_blueprint(
@@ -52,6 +56,40 @@ def _make_realized_query(
     return RealizedQuery(
         candidate_id=candidate_id,
         query=query,
+    )
+
+
+def _make_spec() -> QueryGenSpec:
+    """Build a valid QueryGenSpec for planning-summary assembly tests."""
+    return QueryGenSpec(
+        domain_context={
+            "domains": "foundation research",
+            "roles": "program officer",
+            "languages": "en",
+        },
+        knowledge_scope={
+            "topics": "education outcomes",
+        },
+        scenario={
+            "intents": "understand",
+            "tasks": "summarize",
+            "difficulty": "basic",
+        },
+        format_requests={
+            "formats": "bullet list",
+        },
+        safety={
+            "disallowed_topics": ["medical diagnosis"],
+        },
+    )
+
+
+def _make_planning_summary_state() -> PlanningSummaryState:
+    """Build a valid PlanningSummaryState for assembly tests."""
+    return PlanningSummaryState(
+        redundancy_patterns="Repeated briefing-style education-overview requests for internal staff.",
+        diversification_targets="Add more distinct user situations and information needs within the same spec.",
+        coverage_notes="English foundation-research summaries on education outcomes are already well covered.",
     )
 
 
@@ -223,6 +261,43 @@ def test_assemble_queries_meta_stamps_created_at_in_utc_now_range() -> None:
     after = datetime.now(UTC)
 
     assert before <= meta.created_at <= after
+
+
+def test_assemble_planning_summary_builds_artifact_from_spec_run_id_and_state() -> None:
+    """assemble_planning_summary should construct a validated planning-summary artifact."""
+    spec = _make_spec()
+    state = _make_planning_summary_state()
+
+    artifact = assemble_planning_summary(
+        spec=spec,
+        run_id="run123",
+        state=state,
+    )
+
+    assert artifact.model_dump(exclude={"created_at"}) == {
+        "spec_fingerprint": fingerprint_querygen_spec(spec),
+        "source_run_id": "run123",
+        "state": state.model_dump(mode="json"),
+    }
+    assert isinstance(artifact.created_at, datetime)
+    assert artifact.created_at.tzinfo == UTC
+
+
+def test_assemble_planning_summary_stamps_created_at_in_utc_now_range() -> None:
+    """assemble_planning_summary should stamp created_at internally at construction time."""
+    spec = _make_spec()
+    state = _make_planning_summary_state()
+    before = datetime.now(UTC)
+
+    artifact = assemble_planning_summary(
+        spec=spec,
+        run_id="run123",
+        state=state,
+    )
+
+    after = datetime.now(UTC)
+
+    assert before <= artifact.created_at <= after
 
 
 def test_assemble_queries_meta_rejects_non_positive_requested_queries() -> None:

--- a/tests/unit/core/querygen/test_assembly.py
+++ b/tests/unit/core/querygen/test_assembly.py
@@ -3,7 +3,6 @@
 from datetime import UTC, datetime
 
 import pytest
-from pragmata.core.querygen.planning_summary import fingerprint_querygen_spec
 from pydantic import ValidationError
 
 from pragmata.core.querygen.assembly import (
@@ -12,6 +11,7 @@ from pragmata.core.querygen.assembly import (
     assemble_queries_meta,
     assemble_query_rows,
 )
+from pragmata.core.querygen.planning_summary import fingerprint_querygen_spec
 from pragmata.core.schemas.querygen_input import QueryGenSpec
 from pragmata.core.schemas.querygen_plan import QueryBlueprint
 from pragmata.core.schemas.querygen_realize import RealizedQuery

--- a/tests/unit/core/querygen/test_assembly.py
+++ b/tests/unit/core/querygen/test_assembly.py
@@ -3,6 +3,7 @@
 from datetime import UTC, datetime
 
 import pytest
+from pragmata.core.querygen.planning_summary import fingerprint_querygen_spec
 from pydantic import ValidationError
 
 from pragmata.core.querygen.assembly import (
@@ -11,7 +12,6 @@ from pragmata.core.querygen.assembly import (
     assemble_queries_meta,
     assemble_query_rows,
 )
-from pragmata.core.querygen.planning_memory import fingerprint_querygen_spec
 from pragmata.core.schemas.querygen_input import QueryGenSpec
 from pragmata.core.schemas.querygen_plan import QueryBlueprint
 from pragmata.core.schemas.querygen_realize import RealizedQuery

--- a/tests/unit/core/querygen/test_export.py
+++ b/tests/unit/core/querygen/test_export.py
@@ -237,7 +237,8 @@ def test_export_planning_summary_serializes_nested_state_json_values(tmp_path: P
         "created_at": "2026-03-09T10:30:00Z",
         "state": {
             "redundancy_patterns": "Repeated policy-eligibility scenarios for the same target group.",
-            "diversification_targets": "Add more distinct user situations and information needs within the allowed spec.",
+            "diversification_targets": "Add more distinct user situations and information needs "
+            "within the allowed spec.",
             "coverage_notes": "English public-policy eligibility requests are already well covered.",
         },
     }

--- a/tests/unit/core/querygen/test_export.py
+++ b/tests/unit/core/querygen/test_export.py
@@ -5,8 +5,9 @@ import json
 from datetime import UTC, datetime
 from pathlib import Path
 
-from pragmata.core.querygen.export import export_queries
-from pragmata.core.schemas.querygen_output import SyntheticQueriesMeta, SyntheticQueryRow
+from pragmata.core.querygen.export import export_planning_summary, export_queries
+from pragmata.core.schemas.querygen_output import PlanningSummaryArtifact, SyntheticQueriesMeta, SyntheticQueryRow
+from pragmata.core.schemas.querygen_summary import PlanningSummaryState
 
 
 def _make_row(
@@ -56,6 +57,25 @@ def _make_meta(
         model_provider=model_provider,
         planning_model=planning_model,
         realization_model=realization_model,
+    )
+
+
+def _make_planning_summary_artifact(
+    *,
+    spec_fingerprint: str = "abc123fingerprint",
+    source_run_id: str = "run123",
+    created_at: datetime = datetime(2026, 3, 9, 10, 30, tzinfo=UTC),
+) -> PlanningSummaryArtifact:
+    """Build a valid PlanningSummaryArtifact for tests."""
+    return PlanningSummaryArtifact(
+        spec_fingerprint=spec_fingerprint,
+        source_run_id=source_run_id,
+        created_at=created_at,
+        state=PlanningSummaryState(
+            redundancy_patterns="Repeated policy-eligibility scenarios for the same target group.",
+            diversification_targets="Add more distinct user situations and information needs within the allowed spec.",
+            coverage_notes="English public-policy eligibility requests are already well covered.",
+        ),
     )
 
 
@@ -181,4 +201,43 @@ def test_export_queries_serializes_metadata_json_values(tmp_path: Path) -> None:
         "model_provider": "mistralai",
         "planning_model": "magistral-medium-latest",
         "realization_model": "mistral-medium-latest",
+    }
+
+
+def test_export_planning_summary_writes_json_artifact(tmp_path: Path) -> None:
+    """export_planning_summary should write the planning-summary artifact to JSON."""
+    artifact = _make_planning_summary_artifact()
+    artifact_path = tmp_path / "planning_summary.json"
+
+    export_planning_summary(
+        artifact=artifact,
+        artifact_path=artifact_path,
+    )
+
+    assert json.loads(artifact_path.read_text(encoding="utf-8")) == artifact.model_dump(mode="json")
+
+
+def test_export_planning_summary_serializes_nested_state_json_values(tmp_path: Path) -> None:
+    """export_planning_summary should serialize nested PlanningSummaryState as JSON-compatible values."""
+    artifact = _make_planning_summary_artifact(
+        spec_fingerprint="fingerprint-001",
+        source_run_id="run-456",
+        created_at=datetime(2026, 3, 9, 10, 30, tzinfo=UTC),
+    )
+    artifact_path = tmp_path / "planning_summary.json"
+
+    export_planning_summary(
+        artifact=artifact,
+        artifact_path=artifact_path,
+    )
+
+    assert json.loads(artifact_path.read_text(encoding="utf-8")) == {
+        "spec_fingerprint": "fingerprint-001",
+        "source_run_id": "run-456",
+        "created_at": "2026-03-09T10:30:00Z",
+        "state": {
+            "redundancy_patterns": "Repeated policy-eligibility scenarios for the same target group.",
+            "diversification_targets": "Add more distinct user situations and information needs within the allowed spec.",
+            "coverage_notes": "English public-policy eligibility requests are already well covered.",
+        },
     }


### PR DESCRIPTION
**Summary**

Extend the query-generation assembly and export layers so final planning-summary state can be assembled into a typed `PlanningSummaryArtifact` and written to disk as a reusable JSON artifact.

**Key changes**

- Update `core/querygen/assembly.py`:
  - add `assemble_planning_summary()`
  - construct `PlanningSummaryArtifact` from `QueryGenSpec`, `run_id`, and final `PlanningSummaryState`
  - generate `spec_fingerprint` internally via `fingerprint_querygen_spec(spec)`
  - stamp `created_at` internally
  - propagate `source_run_id` from the run ID

- Update `core/querygen/export.py`:
  - add `export_planning_summary()`
  - write `PlanningSummaryArtifact` to disk as JSON via `model_dump(mode="json")`

- Add unit tests covering:
  - planning-summary artifact assembly from spec, run ID, and final state
  - internal fingerprint generation during assembly
  - internal `created_at` stamping
  - propagation of `source_run_id`
  - JSON export of `PlanningSummaryArtifact`
  - correct on-disk serialization of nested planning-summary state

**Status**
Ready for review.

Closes #132