### PR TITLE
feat(cli): add parse_tasks and parse_user_specs parsing helpers

### DIFF
--- a/src/pragmata/annotation/__init__.py
+++ b/src/pragmata/annotation/__init__.py
@@ -24,6 +24,9 @@ from pragmata.core.annotation.export_runner import (
 from pragmata.core.annotation.setup import (
     SetupResult as SetupResult,
 )
+from pragmata.core.schemas.annotation_task import (
+    Task as Task,
+)
 from pragmata.core.schemas.iaa_report import (
     IaaReport as IaaReport,
 )

--- a/src/pragmata/cli/parsing.py
+++ b/src/pragmata/cli/parsing.py
@@ -1,9 +1,13 @@
 """Parsing helpers for CLI option values."""
 
 import json
-from typing import Any
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 from pragmata.api import UNSET
+
+if TYPE_CHECKING:
+    from pragmata.annotation import Task, UserSpec
 
 
 def parse_cli_value(value: str | None) -> Any:
@@ -32,3 +36,30 @@ def parse_cli_value(value: str | None) -> Any:
         return parsed
 
     return value
+
+
+def parse_tasks(raw: str | None) -> "list[Task] | None":
+    """Parse a comma-separated task list (e.g. ``retrieval,grounding``).
+
+    Returns None when no tasks are supplied, leaving task selection to
+    the downstream default.
+    """
+    from pragmata.annotation import Task
+
+    if raw is None:
+        return None
+    return [Task(item.strip()) for item in raw.split(",")]
+
+
+def parse_user_specs(path: str | None) -> "list[UserSpec] | None":
+    """Load annotator user specs from a JSON file.
+
+    The file must contain a list of dicts; each dict is forwarded to
+    ``UserSpec(**entry)``. Returns None when ``path`` is None.
+    """
+    from pragmata.annotation import UserSpec
+
+    if path is None:
+        return None
+    raw = json.loads(Path(path).read_text())
+    return [UserSpec(**entry) for entry in raw]

--- a/src/pragmata/cli/parsing.py
+++ b/src/pragmata/cli/parsing.py
@@ -61,5 +61,5 @@ def parse_user_specs(path: str | None) -> "list[UserSpec] | None":
 
     if path is None:
         return None
-    raw = json.loads(Path(path).read_text())
+    raw = json.loads(Path(path).expanduser().read_text(encoding="utf-8"))
     return [UserSpec(**entry) for entry in raw]

--- a/tests/unit/cli/test_parsing.py
+++ b/tests/unit/cli/test_parsing.py
@@ -1,0 +1,81 @@
+"""Unit tests for CLI parsing helpers."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from pragmata.annotation import Task, UserSpec
+from pragmata.api import UNSET
+from pragmata.cli.parsing import parse_cli_value, parse_tasks, parse_user_specs
+
+
+class TestParseCliValue:
+    def test_none_returns_unset(self) -> None:
+        assert parse_cli_value(None) is UNSET
+
+    def test_plain_string_passthrough(self) -> None:
+        assert parse_cli_value("hello") == "hello"
+
+    def test_json_list_of_strings(self) -> None:
+        assert parse_cli_value('["a", "b"]') == ["a", "b"]
+
+    def test_json_object(self) -> None:
+        assert parse_cli_value('{"x": 1}') == {"x": 1}
+
+
+class TestParseTasks:
+    def test_none_returns_none(self) -> None:
+        assert parse_tasks(None) is None
+
+    def test_single_task(self) -> None:
+        assert parse_tasks("retrieval") == [Task.RETRIEVAL]
+
+    def test_multiple_tasks(self) -> None:
+        assert parse_tasks("retrieval,grounding,generation") == [
+            Task.RETRIEVAL,
+            Task.GROUNDING,
+            Task.GENERATION,
+        ]
+
+    def test_whitespace_tolerant(self) -> None:
+        assert parse_tasks("retrieval, grounding") == [Task.RETRIEVAL, Task.GROUNDING]
+
+    def test_invalid_task_raises(self) -> None:
+        with pytest.raises(ValueError):
+            parse_tasks("nonexistent")
+
+
+class TestParseUserSpecs:
+    def test_none_returns_none(self) -> None:
+        assert parse_user_specs(None) is None
+
+    def test_reads_json_list(self, tmp_path: Path) -> None:
+        spec_file = tmp_path / "users.json"
+        spec_file.write_text(
+            json.dumps(
+                [
+                    {"username": "alice", "role": "annotator", "workspaces": ["retrieval"]},
+                    {"username": "bob", "role": "owner"},
+                ]
+            )
+        )
+
+        specs = parse_user_specs(str(spec_file))
+
+        assert specs is not None
+        assert len(specs) == 2
+        assert specs[0] == UserSpec(username="alice", role="annotator", workspaces=["retrieval"])
+        assert specs[1].username == "bob"
+        assert specs[1].role == "owner"
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            parse_user_specs(str(tmp_path / "missing.json"))
+
+    def test_malformed_entry_raises(self, tmp_path: Path) -> None:
+        spec_file = tmp_path / "users.json"
+        spec_file.write_text(json.dumps([{"username": "alice"}]))  # missing role
+
+        with pytest.raises(TypeError):
+            parse_user_specs(str(spec_file))


### PR DESCRIPTION
## Goal

First of four PRs as prep for the annotation CLI (#119) - centralises CLI input coercion.

## Scope

- Add `parse_tasks(raw: str | None) -> list[Task] | None` - comma-separated task names → list, with facade-lazy `Task` import
- Add `parse_user_specs(path: str | None) -> list[UserSpec] | None` - JSON file → list of `UserSpec`, with facade-lazy import
- Re-export `Task` on the `pragmata.annotation` facade so CLI and external callers don't reach into `core/schemas/`

## Implementation

Both helpers sit in `cli/parsing.py` alongside the existing `parse_cli_value`. Imports of facade types are deferred (inside the function body) to keep `cli/parsing.py` argilla-free at import time.

Annotation facade gains `Task` as a re-export (currently only exposed via `pragmata.core.schemas.annotation_task`).

## Testing

- 13 new tests in `tests/unit/cli/test_parsing.py` covering both helpers, None/empty/malformed inputs, deferred imports
- 535/535 unit tests pass

## References

- Follows \`cli → api → core\` direction per [docs/design/packaging-invocation-surface.md](docs/design/packaging-invocation-surface.md)
- Consumed by #119 (annotation CLI) after PR 4 lands
- Part of replacement progression: this PR → new #144 (facade) → new #143 (API refactor) → #119 rebase