### PR TITLE
docs(infra): add prod env example

### DIFF
--- a/deploy/annotation/.env.prod.example
+++ b/deploy/annotation/.env.prod.example
@@ -1,0 +1,26 @@
+# Prod environment — template only. Copy to .env.prod and fill in real values.
+# Never commit the filled-in copy.
+#
+# Defaults match .env.dev.example (all-bundled stack). Start with:
+#   docker compose --env-file .env.prod -p annotation-prod up -d
+#
+# Place a reverse proxy in front for TLS / hostname routing.
+
+ARGILLA_PORT=6900
+
+# Admin credentials — generate strong values, e.g. `openssl rand -hex 32`
+ARGILLA_USERNAME=
+ARGILLA_PASSWORD=
+ARGILLA_API_KEY=
+
+POSTGRES_PASSWORD=
+
+# External backing services — leave unset for the all-bundled default.
+# To swap a service for an external one, uncomment the matching var and run
+# the corresponding make target so the bundled image isn't started:
+#   make docker-up-external-pg  →  external Postgres only   (set ARGILLA_DATABASE_URL)
+#   make docker-up-external-es  →  external Elasticsearch   (set ARGILLA_ELASTICSEARCH)
+#   make docker-up-external     →  all three external       (set all three below)
+# ARGILLA_DATABASE_URL=postgresql+asyncpg://USER:PASS@HOST:5432/argilla
+# ARGILLA_ELASTICSEARCH=https://HOST:9200
+# ARGILLA_REDIS_URL=redis://HOST:6379/0


### PR DESCRIPTION
> ⚠️ **DRAFT — NOT READY FOR REVIEW.** Exploratory sketch; structure and defaults are still up for discussion.

## Goal
Provide a starting template for operators setting up a production Argilla stack, in parallel to `.env.dev.example`.

## Scope
- Adds `deploy/annotation/.env.prod.example`.

## Implementation
- Mirrors the layout of `.env.dev.example` so the delta is easy to read.
- Defaults to the all-bundled stack (Postgres / Elasticsearch / Redis containers) for parity with dev.
- Admin credentials (`ARGILLA_USERNAME`, `ARGILLA_PASSWORD`, `ARGILLA_API_KEY`) and `POSTGRES_PASSWORD` are left blank so operators are forced to set strong values. Suggests `openssl rand -hex 32`.
- External-service URLs are commented out with a pointer to the matching `make docker-up-external*` targets, so swapping any of Postgres / Elasticsearch / Redis for an external instance is a single uncomment + make target.
- Notes `-p annotation-prod` for Compose project-name isolation and mentions that TLS / hostname routing should be handled by a reverse proxy in front of Argilla.

## Testing
N/A — doc-only addition.

## References
- `deploy/annotation/.env.dev.example`
- `deploy/annotation/docker-compose.dev.yml`