### PR TITLE
feat: extend querygen path bundle for reusable planning-memory artifact location

### DIFF
--- a/src/pragmata/api/querygen.py
+++ b/src/pragmata/api/querygen.py
@@ -16,6 +16,7 @@ from pragmata.core.querygen.deduplication import deduplicate_blueprints
 from pragmata.core.querygen.export import export_queries
 from pragmata.core.querygen.filtering import filter_aligned_candidate_ids
 from pragmata.core.querygen.planning import run_planning_stage
+from pragmata.core.querygen.planning_summary import fingerprint_querygen_spec
 from pragmata.core.querygen.realization import run_realization_stage
 from pragmata.core.schemas.querygen_plan import QueryBlueprint
 from pragmata.core.schemas.querygen_realize import RealizedQuery
@@ -171,6 +172,7 @@ def gen_queries(
     paths = resolve_querygen_paths(
         workspace=WorkspacePaths.from_base_dir(settings.base_dir),
         run_id=settings.run_id,
+        spec_fingerprint=fingerprint_querygen_spec(settings.spec),
     ).ensure_dirs()
 
     logger.info(

--- a/src/pragmata/core/paths/querygen_paths.py
+++ b/src/pragmata/core/paths/querygen_paths.py
@@ -12,14 +12,18 @@ class QueryGenRunPaths:
     """Path bundle for a synthetic query generation run.
 
     Attributes:
+       tool_root: Root directory for the query generation tool.
        run_dir: Root directory for the query generation run.
        synthetic_queries_csv: Output path for the generated query rows CSV.
        synthetic_queries_meta_json: Output path for the dataset metadata.
+       planning_summary_artifact_json: Output path for the planning-summary artifact.
     """
 
+    tool_root: Path
     run_dir: Path
     synthetic_queries_csv: Path
     synthetic_queries_meta_json: Path
+    planning_summary_artifact_json: Path
 
     def ensure_dirs(
         self,
@@ -33,20 +37,25 @@ def resolve_querygen_paths(
     *,
     workspace: WorkspacePaths,
     run_id: str,
+    spec_fingerprint: str,
 ) -> QueryGenRunPaths:
     """Build the path bundle for a synthetic query generation run.
 
     Args:
         workspace: Workspace path bundle.
         run_id: Unique run identifier.
+        spec_fingerprint: Fingerprint of the resolved querygen spec.
 
     Returns:
         Path bundle for the query generation run.
     """
+    tool_root = workspace.tool_root("querygen")
     run_dir = workspace.run_root(tool="querygen", run_id=run_id)
 
     return QueryGenRunPaths(
+        tool_root=tool_root,
         run_dir=run_dir,
         synthetic_queries_csv=run_dir / "synthetic_queries.csv",
         synthetic_queries_meta_json=run_dir / "synthetic_queries.meta.json",
+        planning_summary_artifact_json=tool_root / f"{spec_fingerprint}.json",
     )

--- a/tests/unit/api/test_querygen.py
+++ b/tests/unit/api/test_querygen.py
@@ -7,6 +7,7 @@ from textwrap import dedent
 import pytest
 
 import pragmata.api.querygen as querygen_api
+from pragmata.core.paths.querygen_paths import QueryGenRunPaths
 from pragmata.core.schemas.querygen_output import SyntheticQueriesMeta, SyntheticQueryRow
 from pragmata.core.schemas.querygen_plan import QueryBlueprint
 from pragmata.core.schemas.querygen_realize import RealizedQuery
@@ -271,12 +272,69 @@ def test_gen_queries_orchestrates_run_paths(tmp_path: Path) -> None:
         run_id="run-123",
     )
 
-    expected_run_dir = tmp_path.resolve() / "querygen" / "runs" / "run-123"
+    expected_tool_root = tmp_path.resolve() / "querygen"
+    expected_run_dir = expected_tool_root / "runs" / "run-123"
 
+    assert result.paths.tool_root == expected_tool_root
     assert result.paths.run_dir == expected_run_dir
     assert result.paths.synthetic_queries_csv == expected_run_dir / "synthetic_queries.csv"
     assert result.paths.synthetic_queries_meta_json == expected_run_dir / "synthetic_queries.meta.json"
+    assert result.paths.planning_summary_artifact_json.parent == expected_tool_root
+    assert result.paths.planning_summary_artifact_json.suffix == ".json"
     assert expected_run_dir.is_dir()
+
+
+def test_gen_queries_fingerprints_spec_before_resolving_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """gen_queries fingerprints the resolved spec before querygen paths are resolved."""
+    call_order: list[str] = []
+    seen: dict[str, object] = {}
+
+    def fingerprint_querygen_spec(spec):  # noqa: ANN001
+        call_order.append("fingerprint")
+        seen["fingerprint_spec"] = spec
+        return "spec-fingerprint-123"
+
+    def resolve_querygen_paths(
+        *,
+        workspace,  # noqa: ANN001
+        run_id: str,
+        spec_fingerprint: str,
+    ) -> QueryGenRunPaths:
+        call_order.append("resolve_paths")
+        seen["workspace_base_dir"] = workspace.base_dir
+        seen["run_id"] = run_id
+        seen["spec_fingerprint"] = spec_fingerprint
+
+        tool_root = tmp_path.resolve() / "querygen"
+        run_dir = tool_root / "runs" / run_id
+
+        return QueryGenRunPaths(
+            tool_root=tool_root,
+            run_dir=run_dir,
+            synthetic_queries_csv=run_dir / "synthetic_queries.csv",
+            synthetic_queries_meta_json=run_dir / "synthetic_queries.meta.json",
+            planning_summary_artifact_json=tool_root / f"{spec_fingerprint}.json",
+        )
+
+    monkeypatch.setattr(querygen_api, "fingerprint_querygen_spec", fingerprint_querygen_spec)
+    monkeypatch.setattr(querygen_api, "resolve_querygen_paths", resolve_querygen_paths)
+
+    result = querygen_api.gen_queries(
+        **_required_querygen_kwargs(tmp_path),
+        run_id="fingerprint-order-check",
+    )
+
+    assert call_order == ["fingerprint", "resolve_paths"]
+    assert seen["run_id"] == "fingerprint-order-check"
+    assert seen["workspace_base_dir"] == tmp_path.resolve()
+    assert seen["spec_fingerprint"] == "spec-fingerprint-123"
+    assert seen["fingerprint_spec"] == result.settings.spec
+    assert result.paths.planning_summary_artifact_json == (
+        tmp_path.resolve() / "querygen" / "spec-fingerprint-123.json"
+    )
 
 
 def test_gen_queries_returns_result_object(tmp_path: Path) -> None:

--- a/tests/unit/core/paths/test_querygen_paths.py
+++ b/tests/unit/core/paths/test_querygen_paths.py
@@ -22,14 +22,22 @@ def test_resolve_querygen_paths_returns_expected_bundle(
 ) -> None:
     """Resolver returns the expected run and artifact paths."""
     run_id = "run-26"
+    spec_fingerprint = "abc123fingerprint"
 
-    paths = resolve_querygen_paths(workspace=workspace, run_id=run_id)
+    paths = resolve_querygen_paths(
+        workspace=workspace,
+        run_id=run_id,
+        spec_fingerprint=spec_fingerprint,
+    )
+    expected_tool_root = workspace.base_dir / "querygen"
     expected_run_dir = workspace.base_dir / "querygen" / "runs" / run_id
 
     assert paths == QueryGenRunPaths(
+        tool_root=expected_tool_root,
         run_dir=expected_run_dir,
         synthetic_queries_csv=expected_run_dir / "synthetic_queries.csv",
         synthetic_queries_meta_json=expected_run_dir / "synthetic_queries.meta.json",
+        planning_summary_artifact_json=expected_tool_root / f"{spec_fingerprint}.json",
     )
 
 
@@ -37,11 +45,58 @@ def test_ensure_dirs_creates_run_directory_and_returns_self(
     workspace: WorkspacePaths,
 ) -> None:
     """ensure_dirs creates the run directory scaffold and returns self."""
-    paths = resolve_querygen_paths(workspace=workspace, run_id="new-run")
+    paths = resolve_querygen_paths(
+        workspace=workspace,
+        run_id="new-run",
+        spec_fingerprint="fingerprint-001",
+    )
 
     assert not paths.run_dir.exists()
+    assert not paths.tool_root.exists()
 
     returned = paths.ensure_dirs()
 
     assert returned is paths
+    assert paths.tool_root.is_dir()
     assert paths.run_dir.is_dir()
+
+
+def test_planning_summary_artifact_path_is_fingerprint_specific_and_run_independent(
+    workspace: WorkspacePaths,
+) -> None:
+    """Reusable planning-summary path depends on fingerprint, not run directory."""
+    first = resolve_querygen_paths(
+        workspace=workspace,
+        run_id="run-a",
+        spec_fingerprint="fingerprint-001",
+    )
+    second = resolve_querygen_paths(
+        workspace=workspace,
+        run_id="run-b",
+        spec_fingerprint="fingerprint-001",
+    )
+    third = resolve_querygen_paths(
+        workspace=workspace,
+        run_id="run-a",
+        spec_fingerprint="fingerprint-002",
+    )
+
+    assert first.planning_summary_artifact_json == second.planning_summary_artifact_json
+    assert first.planning_summary_artifact_json != third.planning_summary_artifact_json
+    assert first.planning_summary_artifact_json.parent == first.tool_root
+
+
+def test_ensure_dirs_keeps_planning_summary_parent_available(
+    workspace: WorkspacePaths,
+) -> None:
+    """ensure_dirs creates the reusable planning-summary parent directory implicitly."""
+    paths = resolve_querygen_paths(
+        workspace=workspace,
+        run_id="run-ensure",
+        spec_fingerprint="fingerprint-001",
+    )
+
+    returned = paths.ensure_dirs()
+
+    assert returned is paths
+    assert paths.planning_summary_artifact_json.parent.is_dir()


### PR DESCRIPTION
**Summary**

Extend the query-generation path bundle so it resolves a planning-summary artifact path at the querygen tool root, keyed by spec fingerprint.

**Key changes**

- Update `core/paths/querygen_paths.py`:
  - extend `QueryGenRunPaths` with:
    - `tool_root`
    - `planning_summary_artifact_json`
  - extend `resolve_querygen_paths()` to accept `spec_fingerprint`
  - resolve the reusable planning-summary artifact directly under the querygen tool root as a fingerprint-specific JSON path
  - keep the run-level path structure unchanged for existing synthetic-query outputs

- Update `api/querygen.py`:
  - compute `spec_fingerprint` from the resolved `settings.spec`
  - pass the fingerprint into `resolve_querygen_paths()` before path resolution

- Add/update unit tests covering:
  - expected run-level querygen path structure
  - expected reusable planning-summary artifact path at the querygen tool root
  - fingerprint-specific artifact path resolution independent of run directory
  - `ensure_dirs()` behavior for the updated path bundle
  - API-level forwarding of the computed spec fingerprint into path resolution

**Status**
Ready for review.

Closes #128