### PR TITLE
feat: wire recursive planning-memory orchestration into gen_queries()

### DIFF
--- a/src/pragmata/api/querygen.py
+++ b/src/pragmata/api/querygen.py
@@ -10,16 +10,21 @@ from pydantic import BaseModel, ConfigDict, PositiveInt
 from pragmata.api._error_log import error_log
 from pragmata.core.paths.paths import WorkspacePaths
 from pragmata.core.paths.querygen_paths import QueryGenRunPaths, resolve_querygen_paths
-from pragmata.core.querygen.assembly import assemble_queries_meta, assemble_query_rows
+from pragmata.core.querygen.assembly import assemble_planning_summary, assemble_queries_meta, assemble_query_rows
 from pragmata.core.querygen.batching import build_candidate_ids, chunk_blueprints, iter_batch_sizes
 from pragmata.core.querygen.deduplication import deduplicate_blueprints
-from pragmata.core.querygen.export import export_queries
+from pragmata.core.querygen.export import export_planning_summary, export_queries
 from pragmata.core.querygen.filtering import filter_aligned_candidate_ids
 from pragmata.core.querygen.planning import run_planning_stage
-from pragmata.core.querygen.planning_summary import fingerprint_querygen_spec
+from pragmata.core.querygen.planning_summary import (
+    fingerprint_querygen_spec,
+    read_planning_summary_artifact,
+    run_planning_summary,
+)
 from pragmata.core.querygen.realization import run_realization_stage
 from pragmata.core.schemas.querygen_plan import QueryBlueprint
 from pragmata.core.schemas.querygen_realize import RealizedQuery
+from pragmata.core.schemas.querygen_summary import PlanningSummaryState
 from pragmata.core.settings.querygen_settings import QueryGenRunSettings
 from pragmata.core.settings.settings_base import UNSET, Unset, load_config_file, resolve_api_key
 
@@ -183,6 +188,16 @@ def gen_queries(
     )
 
     with error_log(paths.run_dir):
+        planning_summary_state: PlanningSummaryState | None = None
+
+        if settings.enable_planning_memory:
+            planning_summary_artifact = read_planning_summary_artifact(
+                artifact_path=paths.planning_summary_artifact_json,
+                spec=settings.spec,
+            )
+            if planning_summary_artifact is not None:
+                planning_summary_state = planning_summary_artifact.state
+
         # Stage 1: planning
         candidate_ids = build_candidate_ids(settings.n_queries)
         candidate_id_iter = iter(candidate_ids)
@@ -193,14 +208,23 @@ def gen_queries(
             batch_size=settings.batch_size,
         ):
             batch_candidate_ids = list(islice(candidate_id_iter, current_batch_size))
-            planning_outputs.extend(
-                run_planning_stage(
+            batch_blueprints = run_planning_stage(
+                spec=settings.spec,
+                llm_settings=settings.llm,
+                api_key=api_key,
+                batch_candidate_ids=batch_candidate_ids,
+                planning_summary=planning_summary_state,
+            )
+            planning_outputs.extend(batch_blueprints)
+
+            if settings.enable_planning_memory:
+                planning_summary_state = run_planning_summary(
                     spec=settings.spec,
+                    candidates=batch_blueprints,
                     llm_settings=settings.llm,
                     api_key=api_key,
-                    batch_candidate_ids=batch_candidate_ids,
+                    prior_summary_state=planning_summary_state,
                 )
-            )
 
         filtered_planning_outputs = filter_aligned_candidate_ids(
             items=planning_outputs,
@@ -265,6 +289,17 @@ def gen_queries(
             queries_path=paths.synthetic_queries_csv,
             meta_path=paths.synthetic_queries_meta_json,
         )
+
+        if settings.enable_planning_memory and planning_summary_state is not None:
+            planning_summary_artifact = assemble_planning_summary(
+                spec=settings.spec,
+                run_id=settings.run_id,
+                state=planning_summary_state,
+            )
+            export_planning_summary(
+                artifact=planning_summary_artifact,
+                artifact_path=paths.planning_summary_artifact_json,
+            )
 
     logger.info(
         "Query generation run %s complete (%d returned queries)",

--- a/tests/integration/test_querygen.py
+++ b/tests/integration/test_querygen.py
@@ -415,7 +415,6 @@ def test_gen_queries_executes_staged_workflow_with_recursive_planning_summary_an
     )
 
 
-
 def test_gen_queries_raises_when_provider_api_key_missing(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/integration/test_querygen.py
+++ b/tests/integration/test_querygen.py
@@ -8,12 +8,14 @@ import pytest
 
 import pragmata.core.querygen.deduplication as deduplication
 import pragmata.core.querygen.planning as planning
+import pragmata.core.querygen.planning_summary as planning_summary_stage
 import pragmata.core.querygen.realization as realization
 from pragmata import querygen
 from pragmata.core.csv_io import read_csv
-from pragmata.core.schemas.querygen_output import SyntheticQueriesMeta, SyntheticQueryRow
+from pragmata.core.schemas.querygen_output import PlanningSummaryArtifact, SyntheticQueriesMeta, SyntheticQueryRow
 from pragmata.core.schemas.querygen_plan import QueryBlueprint, QueryBlueprintList
 from pragmata.core.schemas.querygen_realize import RealizedQuery, RealizedQueryList
+from pragmata.core.schemas.querygen_summary import PlanningSummaryState
 from pragmata.core.settings.settings_base import MissingSecretError
 
 pytestmark = [pytest.mark.integration, pytest.mark.querygen]
@@ -77,8 +79,8 @@ def _parse_candidate_ids_block(block: str) -> list[str]:
     return [line.strip().removeprefix("- ").strip() for line in block.splitlines() if line.strip()]
 
 
-def _parse_realization_candidate_ids(block: str) -> list[str]:
-    """Parse candidate IDs from the realization blueprint block."""
+def _parse_blueprint_candidate_ids(block: str) -> list[str]:
+    """Parse candidate IDs from a formatted blueprint block."""
     candidate_ids: list[str] = []
 
     for line in block.splitlines():
@@ -105,8 +107,13 @@ class _SimilarityModelStub:
 class _PlanningRunnableStub:
     """Planning runnable stub keyed by candidate-id batches."""
 
-    def __init__(self, planning_calls: list[list[str]]) -> None:
+    def __init__(
+        self,
+        planning_calls: list[list[str]],
+        planning_summary_contexts: list[str],
+    ) -> None:
         self._planning_calls = planning_calls
+        self._planning_summary_contexts = planning_summary_contexts
         self._duplicate_blueprint_kwargs = {
             "topic": "coverage appeals",
             "user_scenario": ("My insurer denied a request and I need help understanding the appeal process."),
@@ -117,6 +124,7 @@ class _PlanningRunnableStub:
         """Return structured planning output for the requested batch."""
         batch_candidate_ids = _parse_candidate_ids_block(str(prompt_vars["candidate_ids"]))
         self._planning_calls.append(batch_candidate_ids)
+        self._planning_summary_contexts.append(str(prompt_vars["planning_summary"]))
 
         if batch_candidate_ids == ["c001", "c002"]:
             return QueryBlueprintList(
@@ -144,6 +152,48 @@ class _PlanningRunnableStub:
         pytest.fail(f"Unexpected planning batch: {batch_candidate_ids}")
 
 
+class _PlanningSummaryRunnableStub:
+    """Planning-summary runnable stub keyed by blueprint batches."""
+
+    def __init__(self, planning_summary_calls: list[dict[str, object]]) -> None:
+        self._planning_summary_calls = planning_summary_calls
+
+    def invoke(self, prompt_vars: dict[str, object]) -> PlanningSummaryState:
+        """Return structured planning-summary output for the requested batch."""
+        batch_candidate_ids = _parse_blueprint_candidate_ids(str(prompt_vars["query_blueprints"]))
+        prior_planning_summary = str(prompt_vars["prior_planning_summary"])
+
+        self._planning_summary_calls.append(
+            {
+                "candidate_ids": batch_candidate_ids,
+                "prior_planning_summary": prior_planning_summary,
+            }
+        )
+
+        if batch_candidate_ids == ["c001", "c002"]:
+            return PlanningSummaryState(
+                redundancy_patterns="Repeated coverage checks for standard patient scenarios.",
+                diversification_targets="Broaden toward caregiver and comparison scenarios.",
+                coverage_notes="Basic coverage lookup questions are well covered.",
+            )
+
+        if batch_candidate_ids == ["c003", "wrong-c004"]:
+            return PlanningSummaryState(
+                redundancy_patterns="Appeal-process questions are already well represented.",
+                diversification_targets="Broaden toward exclusions, deductibles, and out-of-network cases.",
+                coverage_notes="Coverage appeals and denial scenarios are now covered.",
+            )
+
+        if batch_candidate_ids == ["c005"]:
+            return PlanningSummaryState(
+                redundancy_patterns="Appeal instructions should not be revisited too closely again.",
+                diversification_targets="Broaden toward cost estimates and preauthorization requirements.",
+                coverage_notes="Appeal and denial workflows are strongly covered.",
+            )
+
+        pytest.fail(f"Unexpected planning-summary batch: {batch_candidate_ids}")
+
+
 class _RealizationRunnableStub:
     """Realization runnable stub keyed by blueprint batches."""
 
@@ -152,7 +202,7 @@ class _RealizationRunnableStub:
 
     def invoke(self, prompt_vars: dict[str, object]) -> RealizedQueryList:
         """Return structured realization output for the requested batch."""
-        batch_candidate_ids = _parse_realization_candidate_ids(str(prompt_vars["query_blueprints"]))
+        batch_candidate_ids = _parse_blueprint_candidate_ids(str(prompt_vars["query_blueprints"]))
         self._realization_calls.append(batch_candidate_ids)
 
         if batch_candidate_ids == ["c001", "c002"]:
@@ -197,20 +247,31 @@ class _TimeoutRunnableStub:
 @pytest.fixture
 def happy_path_workflow_stubs(
     monkeypatch: pytest.MonkeyPatch,
-) -> dict[str, list[list[str]]]:
+) -> dict[str, list[object]]:
     """Install happy-path LLM and deduplication stubs for end-to-end API tests."""
     planning_calls: list[list[str]] = []
+    planning_summary_contexts: list[str] = []
+    planning_summary_calls: list[dict[str, object]] = []
     realization_calls: list[list[str]] = []
 
     def fake_planning_build_llm_runnable(**kwargs: object) -> _PlanningRunnableStub:
         del kwargs
-        return _PlanningRunnableStub(planning_calls)
+        return _PlanningRunnableStub(planning_calls, planning_summary_contexts)
+
+    def fake_planning_summary_build_llm_runnable(**kwargs: object) -> _PlanningSummaryRunnableStub:
+        del kwargs
+        return _PlanningSummaryRunnableStub(planning_summary_calls)
 
     def fake_realization_build_llm_runnable(**kwargs: object) -> _RealizationRunnableStub:
         del kwargs
         return _RealizationRunnableStub(realization_calls)
 
     monkeypatch.setattr(planning, "build_llm_runnable", fake_planning_build_llm_runnable)
+    monkeypatch.setattr(
+        planning_summary_stage,
+        "build_llm_runnable",
+        fake_planning_summary_build_llm_runnable,
+    )
     monkeypatch.setattr(realization, "build_llm_runnable", fake_realization_build_llm_runnable)
     monkeypatch.setattr(
         deduplication,
@@ -225,12 +286,14 @@ def happy_path_workflow_stubs(
 
     return {
         "planning_calls": planning_calls,
+        "planning_summary_contexts": planning_summary_contexts,
+        "planning_summary_calls": planning_summary_calls,
         "realization_calls": realization_calls,
     }
 
 
-def test_gen_queries_executes_staged_workflow_and_writes_expected_artifacts(
-    happy_path_workflow_stubs: dict[str, list[list[str]]],
+def test_gen_queries_executes_staged_workflow_with_recursive_planning_summary_and_writes_expected_artifacts(
+    happy_path_workflow_stubs: dict[str, list[object]],
     tmp_path: Path,
 ) -> None:
     base_dir = tmp_path / "workspace"
@@ -260,9 +323,47 @@ def test_gen_queries_executes_staged_workflow_and_writes_expected_artifacts(
         ["c003"],
     ]
 
+    planning_summary_calls = happy_path_workflow_stubs["planning_summary_calls"]
+    assert planning_summary_calls == [
+        {
+            "candidate_ids": ["c001", "c002"],
+            "prior_planning_summary": "No prior planning summary available yet.",
+        },
+        {
+            "candidate_ids": ["c003", "wrong-c004"],
+            "prior_planning_summary": (
+                "- redundancy_patterns:\n"
+                "  Repeated coverage checks for standard patient scenarios.\n"
+                "- diversification_targets:\n"
+                "  Broaden toward caregiver and comparison scenarios.\n"
+                "- coverage_notes:\n"
+                "  Basic coverage lookup questions are well covered."
+            ),
+        },
+        {
+            "candidate_ids": ["c005"],
+            "prior_planning_summary": (
+                "- redundancy_patterns:\n"
+                "  Appeal-process questions are already well represented.\n"
+                "- diversification_targets:\n"
+                "  Broaden toward exclusions, deductibles, and out-of-network cases.\n"
+                "- coverage_notes:\n"
+                "  Coverage appeals and denial scenarios are now covered."
+            ),
+        },
+    ]
+
+    planning_summary_contexts = happy_path_workflow_stubs["planning_summary_contexts"]
+    assert planning_summary_contexts[0] == ""
+    assert "Repeated coverage checks for standard patient scenarios." in planning_summary_contexts[1]
+    assert "Broaden toward caregiver and comparison scenarios." in planning_summary_contexts[1]
+    assert "Appeal-process questions are already well represented." in planning_summary_contexts[2]
+    assert "Broaden toward exclusions, deductibles, and out-of-network cases." in planning_summary_contexts[2]
+
     assert result.paths.run_dir.exists()
     assert result.paths.synthetic_queries_csv.exists()
     assert result.paths.synthetic_queries_meta_json.exists()
+    assert result.paths.planning_summary_artifact_json.exists()
 
     rows = read_csv(result.paths.synthetic_queries_csv, SyntheticQueryRow)
     assert rows == [
@@ -301,6 +402,18 @@ def test_gen_queries_executes_staged_workflow_and_writes_expected_artifacts(
     assert meta.model_provider == "mistralai"
     assert meta.planning_model == "magistral-medium-latest"
     assert meta.realization_model == "mistral-medium-latest"
+
+    planning_summary_artifact = PlanningSummaryArtifact.model_validate(
+        json.loads(result.paths.planning_summary_artifact_json.read_text(encoding="utf-8"))
+    )
+    assert planning_summary_artifact.spec_fingerprint == result.paths.planning_summary_artifact_json.stem
+    assert planning_summary_artifact.source_run_id == run_id
+    assert planning_summary_artifact.state == PlanningSummaryState(
+        redundancy_patterns="Appeal instructions should not be revisited too closely again.",
+        diversification_targets="Broaden toward cost estimates and preauthorization requirements.",
+        coverage_notes="Appeal and denial workflows are strongly covered.",
+    )
+
 
 
 def test_gen_queries_raises_when_provider_api_key_missing(

--- a/tests/unit/api/test_querygen.py
+++ b/tests/unit/api/test_querygen.py
@@ -8,9 +8,10 @@ import pytest
 
 import pragmata.api.querygen as querygen_api
 from pragmata.core.paths.querygen_paths import QueryGenRunPaths
-from pragmata.core.schemas.querygen_output import SyntheticQueriesMeta, SyntheticQueryRow
+from pragmata.core.schemas.querygen_output import PlanningSummaryArtifact, SyntheticQueriesMeta, SyntheticQueryRow
 from pragmata.core.schemas.querygen_plan import QueryBlueprint
 from pragmata.core.schemas.querygen_realize import RealizedQuery
+from pragmata.core.schemas.querygen_summary import PlanningSummaryState
 
 pytestmark = pytest.mark.usefixtures("workflow_stubs")
 
@@ -130,6 +131,36 @@ def _make_meta(
     )
 
 
+def _make_planning_summary_state(
+    *,
+    redundancy_patterns: str = "Repeated service-access questions for the same administrative scenario.",
+    diversification_targets: str = "Broaden toward comparison, explanation, and eligibility scenarios.",
+    coverage_notes: str = "Basic public-service access requests are already well covered.",
+) -> PlanningSummaryState:
+    """Build a valid PlanningSummaryState for tests."""
+    return PlanningSummaryState(
+        redundancy_patterns=redundancy_patterns,
+        diversification_targets=diversification_targets,
+        coverage_notes=coverage_notes,
+    )
+
+
+def _make_planning_summary_artifact(
+    *,
+    spec_fingerprint: str = "spec-fingerprint-123",
+    source_run_id: str = "prior-run",
+    created_at: datetime | None = None,
+    state: PlanningSummaryState | None = None,
+) -> PlanningSummaryArtifact:
+    """Build a valid PlanningSummaryArtifact for tests."""
+    return PlanningSummaryArtifact(
+        spec_fingerprint=spec_fingerprint,
+        source_run_id=source_run_id,
+        created_at=created_at or datetime(2026, 1, 1, tzinfo=UTC),
+        state=state or _make_planning_summary_state(),
+    )
+
+
 def _install_default_workflow_stubs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -143,15 +174,40 @@ def _install_default_workflow_stubs(
         del batch_size
         return iter([n_queries])
 
+    def read_planning_summary_artifact(
+        *,
+        artifact_path: Path,
+        spec,  # noqa: ANN001
+    ) -> PlanningSummaryArtifact | None:
+        del artifact_path, spec
+        return None
+
     def run_planning_stage(
         *,
         spec,  # noqa: ANN001
         llm_settings,  # noqa: ANN001
         api_key: str,
         batch_candidate_ids: list[str],
+        planning_summary: PlanningSummaryState | None = None,
     ) -> list[QueryBlueprint]:
-        del spec, llm_settings, api_key
+        del spec, llm_settings, api_key, planning_summary
         return [_make_blueprint(candidate_id) for candidate_id in batch_candidate_ids]
+
+    def run_planning_summary(
+        *,
+        spec,  # noqa: ANN001
+        candidates: list[QueryBlueprint],
+        llm_settings,  # noqa: ANN001
+        api_key: str,
+        prior_summary_state: PlanningSummaryState | None = None,
+    ) -> PlanningSummaryState:
+        del spec, llm_settings, api_key, prior_summary_state
+        first_candidate_id = candidates[0].candidate_id
+        return _make_planning_summary_state(
+            redundancy_patterns=f"Repeated patterns around {first_candidate_id}.",
+            diversification_targets=f"Diversify beyond {first_candidate_id}.",
+            coverage_notes=f"Coverage includes {first_candidate_id}.",
+        )
 
     def filter_aligned_candidate_ids(
         items: list[object],
@@ -212,6 +268,18 @@ def _install_default_workflow_stubs(
             realization_model=realization_model,
         )
 
+    def assemble_planning_summary(
+        *,
+        spec,  # noqa: ANN001
+        run_id: str,
+        state: PlanningSummaryState,
+    ) -> PlanningSummaryArtifact:
+        del spec
+        return _make_planning_summary_artifact(
+            source_run_id=run_id,
+            state=state,
+        )
+
     def export_queries(
         *,
         rows: list[SyntheticQueryRow],
@@ -221,16 +289,27 @@ def _install_default_workflow_stubs(
     ) -> None:
         del rows, meta, queries_path, meta_path
 
+    def export_planning_summary(
+        *,
+        artifact: PlanningSummaryArtifact,
+        artifact_path: Path,
+    ) -> None:
+        del artifact, artifact_path
+
     monkeypatch.setattr(querygen_api, "build_candidate_ids", build_candidate_ids)
     monkeypatch.setattr(querygen_api, "iter_batch_sizes", iter_batch_sizes)
+    monkeypatch.setattr(querygen_api, "read_planning_summary_artifact", read_planning_summary_artifact)
     monkeypatch.setattr(querygen_api, "run_planning_stage", run_planning_stage)
+    monkeypatch.setattr(querygen_api, "run_planning_summary", run_planning_summary)
     monkeypatch.setattr(querygen_api, "filter_aligned_candidate_ids", filter_aligned_candidate_ids)
     monkeypatch.setattr(querygen_api, "deduplicate_blueprints", deduplicate_blueprints)
     monkeypatch.setattr(querygen_api, "chunk_blueprints", chunk_blueprints)
     monkeypatch.setattr(querygen_api, "run_realization_stage", run_realization_stage)
     monkeypatch.setattr(querygen_api, "assemble_query_rows", assemble_query_rows)
     monkeypatch.setattr(querygen_api, "assemble_queries_meta", assemble_queries_meta)
+    monkeypatch.setattr(querygen_api, "assemble_planning_summary", assemble_planning_summary)
     monkeypatch.setattr(querygen_api, "export_queries", export_queries)
+    monkeypatch.setattr(querygen_api, "export_planning_summary", export_planning_summary)
 
 
 def test_gen_queries_combines_user_args_config_and_defaults(tmp_path: Path) -> None:
@@ -337,6 +416,41 @@ def test_gen_queries_fingerprints_spec_before_resolving_paths(
     )
 
 
+def test_gen_queries_reads_planning_summary_artifact_from_resolved_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """gen_queries loads the initial planning-summary artifact from the reusable artifact path."""
+    read_calls: list[dict[str, object]] = []
+
+    def read_planning_summary_artifact(
+        *,
+        artifact_path: Path,
+        spec,  # noqa: ANN001
+    ) -> PlanningSummaryArtifact | None:
+        read_calls.append(
+            {
+                "artifact_path": artifact_path,
+                "spec": spec,
+            }
+        )
+        return None
+
+    monkeypatch.setattr(querygen_api, "read_planning_summary_artifact", read_planning_summary_artifact)
+
+    result = querygen_api.gen_queries(
+        **_required_querygen_kwargs(tmp_path),
+        run_id="planning-summary-read-check",
+    )
+
+    assert read_calls == [
+        {
+            "artifact_path": result.paths.planning_summary_artifact_json,
+            "spec": result.settings.spec,
+        }
+    ]
+
+
 def test_gen_queries_returns_result_object(tmp_path: Path) -> None:
     """gen_queries returns the structured run result."""
     result = querygen_api.gen_queries(
@@ -414,8 +528,9 @@ def test_gen_queries_repeats_planning_batches_and_applies_stage1_filter_to_aggre
         llm_settings,  # noqa: ANN001
         api_key: str,
         batch_candidate_ids: list[str],
+        planning_summary: PlanningSummaryState | None = None,
     ) -> list[QueryBlueprint]:
-        del spec, llm_settings, api_key
+        del spec, llm_settings, api_key, planning_summary
         planning_batch_calls.append(list(batch_candidate_ids))
         return [_make_blueprint(candidate_id) for candidate_id in batch_candidate_ids]
 
@@ -452,6 +567,142 @@ def test_gen_queries_repeats_planning_batches_and_applies_stage1_filter_to_aggre
             "item_ids": ["c001", "c002", "c003", "c004", "c005"],
             "expected_ids": ["c001", "c002", "c003", "c004", "c005"],
         }
+    ]
+
+
+def test_gen_queries_invokes_first_planning_batch_with_none_summary_when_no_prior_artifact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When no prior artifact is available, the first planning batch starts with no planning summary."""
+    planning_summary_seen: list[PlanningSummaryState | None] = []
+
+    monkeypatch.setattr(querygen_api, "read_planning_summary_artifact", lambda **kwargs: None)
+
+    def run_planning_stage(
+        *,
+        spec,  # noqa: ANN001
+        llm_settings,  # noqa: ANN001
+        api_key: str,
+        batch_candidate_ids: list[str],
+        planning_summary: PlanningSummaryState | None = None,
+    ) -> list[QueryBlueprint]:
+        del spec, llm_settings, api_key
+        planning_summary_seen.append(planning_summary)
+        return [_make_blueprint(candidate_id) for candidate_id in batch_candidate_ids]
+
+    monkeypatch.setattr(querygen_api, "run_planning_stage", run_planning_stage)
+
+    querygen_api.gen_queries(
+        **_required_querygen_kwargs(tmp_path),
+        n_queries=3,
+        run_id="first-planning-summary-none-check",
+    )
+
+    assert planning_summary_seen == [None]
+
+
+def test_gen_queries_threads_planning_summary_state_across_batches(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Planning-summary state is updated after each batch and threaded into the next planning batch."""
+    candidate_ids = ["c001", "c002", "c003", "c004", "c005"]
+    planning_batch_calls: list[dict[str, object]] = []
+    planning_summary_calls: list[dict[str, object]] = []
+
+    summary_state_1 = _make_planning_summary_state(
+        redundancy_patterns="summary-state-1 redundancy",
+        diversification_targets="summary-state-1 targets",
+        coverage_notes="summary-state-1 coverage",
+    )
+    summary_state_2 = _make_planning_summary_state(
+        redundancy_patterns="summary-state-2 redundancy",
+        diversification_targets="summary-state-2 targets",
+        coverage_notes="summary-state-2 coverage",
+    )
+    summary_state_3 = _make_planning_summary_state(
+        redundancy_patterns="summary-state-3 redundancy",
+        diversification_targets="summary-state-3 targets",
+        coverage_notes="summary-state-3 coverage",
+    )
+    returned_states = iter([summary_state_1, summary_state_2, summary_state_3])
+
+    monkeypatch.setattr(querygen_api, "build_candidate_ids", lambda n_queries: candidate_ids)
+    monkeypatch.setattr(querygen_api, "iter_batch_sizes", lambda n_queries, batch_size: iter([2, 2, 1]))
+    monkeypatch.setattr(querygen_api, "read_planning_summary_artifact", lambda **kwargs: None)
+
+    def run_planning_stage(
+        *,
+        spec,  # noqa: ANN001
+        llm_settings,  # noqa: ANN001
+        api_key: str,
+        batch_candidate_ids: list[str],
+        planning_summary: PlanningSummaryState | None = None,
+    ) -> list[QueryBlueprint]:
+        del spec, llm_settings, api_key
+        planning_batch_calls.append(
+            {
+                "batch_candidate_ids": list(batch_candidate_ids),
+                "planning_summary": planning_summary,
+            }
+        )
+        return [_make_blueprint(candidate_id) for candidate_id in batch_candidate_ids]
+
+    def run_planning_summary(
+        *,
+        spec,  # noqa: ANN001
+        candidates: list[QueryBlueprint],
+        llm_settings,  # noqa: ANN001
+        api_key: str,
+        prior_summary_state: PlanningSummaryState | None = None,
+    ) -> PlanningSummaryState:
+        del spec, llm_settings, api_key
+        planning_summary_calls.append(
+            {
+                "candidate_ids": [candidate.candidate_id for candidate in candidates],
+                "prior_summary_state": prior_summary_state,
+            }
+        )
+        return next(returned_states)
+
+    monkeypatch.setattr(querygen_api, "run_planning_stage", run_planning_stage)
+    monkeypatch.setattr(querygen_api, "run_planning_summary", run_planning_summary)
+
+    querygen_api.gen_queries(
+        **_required_querygen_kwargs(tmp_path),
+        n_queries=5,
+        batch_size=2,
+        run_id="planning-summary-threading-check",
+    )
+
+    assert planning_batch_calls == [
+        {
+            "batch_candidate_ids": ["c001", "c002"],
+            "planning_summary": None,
+        },
+        {
+            "batch_candidate_ids": ["c003", "c004"],
+            "planning_summary": summary_state_1,
+        },
+        {
+            "batch_candidate_ids": ["c005"],
+            "planning_summary": summary_state_2,
+        },
+    ]
+    assert planning_summary_calls == [
+        {
+            "candidate_ids": ["c001", "c002"],
+            "prior_summary_state": None,
+        },
+        {
+            "candidate_ids": ["c003", "c004"],
+            "prior_summary_state": summary_state_1,
+        },
+        {
+            "candidate_ids": ["c005"],
+            "prior_summary_state": summary_state_2,
+        },
     ]
 
 
@@ -634,8 +885,9 @@ def test_gen_queries_calls_assembly_and_export_with_final_post_filter_outputs(
         llm_settings,  # noqa: ANN001
         api_key: str,
         batch_candidate_ids: list[str],
+        planning_summary: PlanningSummaryState | None = None,
     ) -> list[QueryBlueprint]:
-        del spec, llm_settings, api_key
+        del spec, llm_settings, api_key, planning_summary
         return [_make_blueprint(candidate_id) for candidate_id in batch_candidate_ids]
 
     def filter_aligned_candidate_ids(
@@ -766,6 +1018,98 @@ def test_gen_queries_calls_assembly_and_export_with_final_post_filter_outputs(
     ]
 
 
+def test_gen_queries_assembles_and_exports_final_planning_summary_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Final planning-summary assembly and export run once at the end of a successful run."""
+    summary_state_1 = _make_planning_summary_state(
+        redundancy_patterns="state-1 redundancy",
+        diversification_targets="state-1 targets",
+        coverage_notes="state-1 coverage",
+    )
+    summary_state_2 = _make_planning_summary_state(
+        redundancy_patterns="state-2 redundancy",
+        diversification_targets="state-2 targets",
+        coverage_notes="state-2 coverage",
+    )
+    assembled_artifact = _make_planning_summary_artifact(
+        spec_fingerprint="final-spec-fingerprint",
+        source_run_id="planning-summary-export-check",
+        state=summary_state_2,
+    )
+
+    monkeypatch.setattr(querygen_api, "build_candidate_ids", lambda n_queries: ["c001", "c002", "c003"])
+    monkeypatch.setattr(querygen_api, "iter_batch_sizes", lambda n_queries, batch_size: iter([2, 1]))
+    monkeypatch.setattr(querygen_api, "read_planning_summary_artifact", lambda **kwargs: None)
+
+    returned_states = iter([summary_state_1, summary_state_2])
+
+    def run_planning_summary(
+        *,
+        spec,  # noqa: ANN001
+        candidates: list[QueryBlueprint],
+        llm_settings,  # noqa: ANN001
+        api_key: str,
+        prior_summary_state: PlanningSummaryState | None = None,
+    ) -> PlanningSummaryState:
+        del spec, candidates, llm_settings, api_key, prior_summary_state
+        return next(returned_states)
+
+    assemble_calls: list[dict[str, object]] = []
+    export_calls: list[dict[str, object]] = []
+
+    def assemble_planning_summary(
+        *,
+        spec,  # noqa: ANN001
+        run_id: str,
+        state: PlanningSummaryState,
+    ) -> PlanningSummaryArtifact:
+        assemble_calls.append(
+            {
+                "spec": spec,
+                "run_id": run_id,
+                "state": state,
+            }
+        )
+        return assembled_artifact
+
+    def export_planning_summary(
+        *,
+        artifact: PlanningSummaryArtifact,
+        artifact_path: Path,
+    ) -> None:
+        export_calls.append(
+            {
+                "artifact": artifact,
+                "artifact_path": artifact_path,
+            }
+        )
+
+    monkeypatch.setattr(querygen_api, "run_planning_summary", run_planning_summary)
+    monkeypatch.setattr(querygen_api, "assemble_planning_summary", assemble_planning_summary)
+    monkeypatch.setattr(querygen_api, "export_planning_summary", export_planning_summary)
+
+    result = querygen_api.gen_queries(
+        **_required_querygen_kwargs(tmp_path),
+        n_queries=3,
+        batch_size=2,
+        run_id="planning-summary-export-check",
+    )
+
+    assert len(assemble_calls) == 1
+    assert assemble_calls[0]["run_id"] == "planning-summary-export-check"
+    assert assemble_calls[0]["state"] == summary_state_2
+    assert assemble_calls[0]["spec"] == result.settings.spec
+
+    assert export_calls == [
+        {
+            "artifact": assembled_artifact,
+            "artifact_path": result.paths.planning_summary_artifact_json,
+        }
+    ]
+
+
 def test_gen_queries_raises_when_provider_secret_resolution_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -814,6 +1158,11 @@ def test_gen_queries_propagates_planning_failure_and_stops_downstream_work(
         "export_queries",
         lambda **kwargs: pytest.fail("export_queries must not run after planning failure"),
     )
+    monkeypatch.setattr(
+        querygen_api,
+        "export_planning_summary",
+        lambda **kwargs: pytest.fail("export_planning_summary must not run after planning failure"),
+    )
 
     with pytest.raises(RuntimeError, match="planning failed"):
         querygen_api.gen_queries(
@@ -841,6 +1190,11 @@ def test_gen_queries_propagates_realization_failure_and_stops_downstream_work(
         querygen_api,
         "export_queries",
         lambda **kwargs: pytest.fail("export_queries must not run after realization failure"),
+    )
+    monkeypatch.setattr(
+        querygen_api,
+        "export_planning_summary",
+        lambda **kwargs: pytest.fail("export_planning_summary must not run after realization failure"),
     )
 
     with pytest.raises(RuntimeError, match="realization failed"):


### PR DESCRIPTION
**Summary**

Wire recursive planning-summary orchestration into `gen_queries()` so stage-1 planning can condition on prior planning-summary state across planning batches, load an initial reusable planning-summary seed when available, and persist the final reusable planning-summary artifact at the end of a successful run.

**Key changes**

- Update `api/querygen.py`:
  - load the initial planning-summary artifact via `read_planning_summary_artifact(paths.planning_summary_artifact_json, settings.spec)`
  - initialize and thread a working in-memory `planning_summary_state` through repeated stage-1 planning batches
  - pass `planning_summary=planning_summary_state` into `run_planning_stage(...)`
  - call `run_planning_summary(...)` after each planning batch using the returned batch blueprints and prior summary state
  - replace the working planning-summary state with the returned updated summary after each batch
  - assemble and export the final reusable planning-summary artifact at the end of a successful run via:
    - `assemble_planning_summary(...)`
    - `export_planning_summary(...)`

- Add/update unit tests in `tests/unit/.../test_querygen.py` covering:
  - loading the reusable planning-summary artifact from `paths.planning_summary_artifact_json`
  - first planning batch receives `planning_summary=None` when no prior artifact is available
  - repeated planning batches receive the current threaded planning-summary state
  - `run_planning_summary(...)` is invoked after each planning batch with the returned batch blueprints and prior state
  - updated planning-summary state is threaded forward into later planning batches
  - final planning-summary artifact assembly/export is called once at the end of a successful run
  - existing querygen orchestration behavior remains covered

- Add/update integration tests in `tests/integration/test_querygen.py` covering:
  - end-to-end query generation with recursive planning-summary updates across repeated planning batches
  - planning stage receives updated planning-summary context in later batches
  - final reusable planning-summary artifact is written to the resolved reusable artifact path
  - existing staged workflow expectations continue to hold for planning, filtering, deduplication, realization, and export

**Status**

Ready for review.

Closes #133