### PR TITLE
feat: expose near-duplicate tolerance in API

### DIFF
--- a/src/pragmata/api/querygen.py
+++ b/src/pragmata/api/querygen.py
@@ -104,9 +104,10 @@ def gen_queries(
             values use fewer, bigger calls; smaller values split
             generation into more repeated calls. Defaults to 25.
         near_duplicate_tolerance: Similarity tolerance used for semantic
-            near-duplicate blueprint removal. Lower values deduplicate more
-            aggressively; higher values allow more similar blueprints, including
-            close paraphrases, to remain. Defaults to 0.95.
+            near-duplicate blueprint removal. Must be in the range (0, 1],
+            where lower values deduplicate more aggressively and higher values
+            allow more similar blueprints, including close paraphrases, to remain.
+            Defaults to 0.95.
         enable_planning_memory: Whether to enable planning memory for the run.
             Defaults to True. When enabled, an additional LLM updates and persists a
             compact summary of prior blueprint generation across batches and compatible

--- a/src/pragmata/api/querygen.py
+++ b/src/pragmata/api/querygen.py
@@ -69,6 +69,7 @@ def gen_queries(
     base_url: str | Unset = UNSET,
     model_kwargs: dict[str, Any] | Unset = UNSET,
     batch_size: PositiveInt | Unset = UNSET,
+    near_duplicate_tolerance: float | Unset = UNSET,
     enable_planning_memory: bool | Unset = UNSET,
 ) -> QueryGenRunResult:
     """Generate synthetic chatbot queries from a query-generation specification.
@@ -102,6 +103,10 @@ def gen_queries(
         batch_size: Number of queries to generate per LLM call. Larger
             values use fewer, bigger calls; smaller values split
             generation into more repeated calls. Defaults to 25.
+        near_duplicate_tolerance: Similarity tolerance used for semantic
+            near-duplicate blueprint removal. Lower values deduplicate more
+            aggressively; higher values allow more similar blueprints, including
+            close paraphrases, to remain. Defaults to 0.95.
         enable_planning_memory: Whether to enable planning memory for the run.
             Defaults to True. When enabled, an additional LLM updates and persists a
             compact summary of prior blueprint generation across batches and compatible
@@ -168,6 +173,7 @@ def gen_queries(
             "run_id": run_id,
             "n_queries": n_queries,
             "batch_size": batch_size,
+            "near_duplicate_tolerance": near_duplicate_tolerance,
             "enable_planning_memory": enable_planning_memory,
         },
     )
@@ -231,7 +237,10 @@ def gen_queries(
             expected_candidate_ids=candidate_ids,
         )
 
-        selected_blueprints = deduplicate_blueprints(filtered_planning_outputs)
+        selected_blueprints = deduplicate_blueprints(
+            filtered_planning_outputs,
+            near_duplicate_tolerance=settings.near_duplicate_tolerance,
+        )
 
         logger.info(
             "Stage 1 (query planning) complete for run %s (%d planned -> %d selected)",

--- a/src/pragmata/core/querygen/deduplication.py
+++ b/src/pragmata/core/querygen/deduplication.py
@@ -48,9 +48,20 @@ def _blueprint_content_key(candidate: QueryBlueprint) -> str:
 
 def _select_non_duplicate_indices(
     similarities: NDArray[np.float32],
-    threshold: float = 0.95,
+    near_duplicate_tolerance: float,
 ) -> list[int]:
-    """Select non-duplicate indices deterministically from a similarity matrix."""
+    """Select non-duplicate indices deterministically from a similarity matrix.
+
+    Args:
+        similarities: Square pairwise similarity matrix.
+        near_duplicate_tolerance: Maximum allowed semantic similarity before a
+            later blueprint is treated as a near-duplicate and removed. Lower
+            values deduplicate more aggressively; higher values allow more
+            similar blueprints to remain.
+
+    Returns:
+        Deterministically retained indices in original order.
+    """
     matrix = similarities
 
     if matrix.ndim != 2 or matrix.shape[0] != matrix.shape[1]:
@@ -66,7 +77,7 @@ def _select_non_duplicate_indices(
         retained_indices.append(index)
 
         for later_index in range(index + 1, matrix.shape[0]):
-            if matrix[index, later_index] >= threshold:
+            if matrix[index, later_index] >= near_duplicate_tolerance:
                 removed_indices.add(later_index)
 
     return retained_indices
@@ -98,8 +109,22 @@ def _embed_blueprints(candidates: list[QueryBlueprint]) -> NDArray[np.float32]:
     return np.asarray(embeddings, dtype=np.float32)
 
 
-def deduplicate_blueprints(candidates: list[QueryBlueprint]) -> list[QueryBlueprint]:
-    """Remove exact and semantic near-duplicate blueprints deterministically."""
+def deduplicate_blueprints(
+    candidates: list[QueryBlueprint],
+    near_duplicate_tolerance: float,
+) -> list[QueryBlueprint]:
+    """Remove exact and semantic near-duplicate blueprints deterministically.
+
+    Args:
+        candidates: Candidate blueprints to deduplicate.
+        near_duplicate_tolerance: Maximum allowed semantic similarity before a
+            later blueprint is treated as a near-duplicate and removed. Lower
+            values deduplicate more aggressively; higher values allow more
+            similar blueprints to remain.
+
+    Returns:
+        Deduplicated candidate blueprints in deterministic original order.
+    """
     if not candidates:
         return []
 
@@ -123,6 +148,9 @@ def deduplicate_blueprints(candidates: list[QueryBlueprint]) -> list[QueryBluepr
         model.similarity(embeddings, embeddings),
         dtype=np.float32,
     )
-    retained_indices = _select_non_duplicate_indices(similarities)
+    retained_indices = _select_non_duplicate_indices(
+        similarities,
+        near_duplicate_tolerance=near_duplicate_tolerance,
+    )
 
     return [exact_deduplicated[index] for index in retained_indices]

--- a/src/pragmata/core/settings/querygen_settings.py
+++ b/src/pragmata/core/settings/querygen_settings.py
@@ -34,4 +34,5 @@ class QueryGenRunSettings(ResolveSettings):
     run_id: str = Field(default_factory=lambda: uuid4().hex)
     n_queries: PositiveInt = 50
     batch_size: PositiveInt = 25
+    near_duplicate_tolerance: float = Field(default=0.95, gt=0, le=1)
     enable_planning_memory: bool = True

--- a/tests/unit/api/test_querygen.py
+++ b/tests/unit/api/test_querygen.py
@@ -216,7 +216,11 @@ def _install_default_workflow_stubs(
         del expected_candidate_ids
         return items
 
-    def deduplicate_blueprints(candidates: list[QueryBlueprint]) -> list[QueryBlueprint]:
+    def deduplicate_blueprints(
+        candidates: list[QueryBlueprint],
+        near_duplicate_tolerance: float = 0.95,
+    ) -> list[QueryBlueprint]:
+        del near_duplicate_tolerance
         return candidates
 
     def chunk_blueprints(
@@ -341,6 +345,7 @@ def test_gen_queries_combines_user_args_config_and_defaults(tmp_path: Path) -> N
     assert result.paths.run_dir.name == result.settings.run_id
     assert result.settings.llm.realization_model == "mistral-medium-latest"
     assert result.settings.batch_size == 12
+    assert result.settings.near_duplicate_tolerance == 0.95
     assert result.settings.enable_planning_memory is True
 
 
@@ -724,7 +729,11 @@ def test_gen_queries_applies_stage1_filtering_before_deduplication(
         call_order.append("stage2_filter")
         return items
 
-    def deduplicate_blueprints(candidates: list[QueryBlueprint]) -> list[QueryBlueprint]:
+    def deduplicate_blueprints(
+        candidates: list[QueryBlueprint],
+        near_duplicate_tolerance: float = 0.95,
+    ) -> list[QueryBlueprint]:
+        del near_duplicate_tolerance
         call_order.append("deduplicate")
         assert [candidate.candidate_id for candidate in candidates] == ["c001", "c003"]
         return candidates
@@ -753,8 +762,11 @@ def test_gen_queries_drives_realization_batches_from_selected_blueprints(
     ]
     realization_batch_calls: list[list[str]] = []
 
-    def deduplicate_blueprints(candidates: list[QueryBlueprint]) -> list[QueryBlueprint]:
-        del candidates
+    def deduplicate_blueprints(
+        candidates: list[QueryBlueprint],
+        near_duplicate_tolerance: float = 0.95,
+    ) -> list[QueryBlueprint]:
+        del candidates, near_duplicate_tolerance
         return selected_blueprints
 
     def chunk_blueprints(
@@ -804,8 +816,11 @@ def test_gen_queries_applies_stage2_filtering_before_assembly(
     ]
     call_order: list[str] = []
 
-    def deduplicate_blueprints(candidates: list[QueryBlueprint]) -> list[QueryBlueprint]:
-        del candidates
+    def deduplicate_blueprints(
+        candidates: list[QueryBlueprint],
+        near_duplicate_tolerance: float = 0.95,
+    ) -> list[QueryBlueprint]:
+        del candidates, near_duplicate_tolerance
         return selected_blueprints
 
     def filter_aligned_candidate_ids(
@@ -899,8 +914,11 @@ def test_gen_queries_calls_assembly_and_export_with_final_post_filter_outputs(
             return items
         return filtered_realization_outputs
 
-    def deduplicate_blueprints(candidates: list[QueryBlueprint]) -> list[QueryBlueprint]:
-        del candidates
+    def deduplicate_blueprints(
+        candidates: list[QueryBlueprint],
+        near_duplicate_tolerance: float = 0.95,
+    ) -> list[QueryBlueprint]:
+        del candidates, near_duplicate_tolerance
         return selected_blueprints
 
     def chunk_blueprints(
@@ -1213,7 +1231,11 @@ def test_gen_queries_handles_empty_selected_blueprints_after_stage1(
     assemble_meta_calls: list[dict[str, object]] = []
     export_calls: list[dict[str, object]] = []
 
-    monkeypatch.setattr(querygen_api, "deduplicate_blueprints", lambda candidates: [])
+    monkeypatch.setattr(
+        querygen_api,
+        "deduplicate_blueprints",
+        lambda candidates, near_duplicate_tolerance=0.95: [],
+    )
     monkeypatch.setattr(
         querygen_api,
         "run_realization_stage",
@@ -1344,3 +1366,34 @@ def test_gen_queries_enable_planning_memory_arg_overrides_config_value(
     )
 
     assert result.settings.enable_planning_memory is False
+
+
+def test_gen_queries_passes_near_duplicate_tolerance_to_deduplication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit near_duplicate_tolerance is resolved and forwarded to deduplication."""
+    seen: dict[str, object] = {}
+
+    def deduplicate_blueprints(
+        candidates: list[QueryBlueprint],
+        near_duplicate_tolerance: float = 0.95,
+    ) -> list[QueryBlueprint]:
+        seen["candidate_ids"] = [candidate.candidate_id for candidate in candidates]
+        seen["near_duplicate_tolerance"] = near_duplicate_tolerance
+        return candidates
+
+    monkeypatch.setattr(querygen_api, "deduplicate_blueprints", deduplicate_blueprints)
+
+    result = querygen_api.gen_queries(
+        **_required_querygen_kwargs(tmp_path),
+        n_queries=3,
+        near_duplicate_tolerance=0.99,
+        run_id="near-duplicate-tolerance-check",
+    )
+
+    assert result.settings.near_duplicate_tolerance == 0.99
+    assert seen == {
+        "candidate_ids": ["c001", "c002", "c003"],
+        "near_duplicate_tolerance": 0.99,
+    }

--- a/tests/unit/core/querygen/test_deduplication.py
+++ b/tests/unit/core/querygen/test_deduplication.py
@@ -88,7 +88,7 @@ def test_blueprint_content_key_is_deterministic_and_ignores_candidate_id(
 
 
 @pytest.mark.parametrize(
-    ("similarities", "threshold", "expected"),
+    ("similarities", "near_duplicate_tolerance", "expected"),
     [
         (
             np.array(
@@ -124,17 +124,40 @@ def test_blueprint_content_key_is_deterministic_and_ignores_candidate_id(
 )
 def test_select_non_duplicate_indices_returns_first_occurrence_ordered_selection(
     similarities: np.ndarray,
-    threshold: float,
+    near_duplicate_tolerance: float,
     expected: list[int],
 ) -> None:
-    assert _select_non_duplicate_indices(similarities, threshold=threshold) == expected
+    assert _select_non_duplicate_indices(similarities, near_duplicate_tolerance=near_duplicate_tolerance) == expected
 
 
 def test_select_non_duplicate_indices_rejects_non_square_matrices() -> None:
     similarities = np.array([[1.0, 0.9, 0.8]], dtype=np.float32)
 
     with pytest.raises(ValueError, match="similarities must be a square 2D matrix"):
-        _select_non_duplicate_indices(similarities)
+        _select_non_duplicate_indices(similarities, near_duplicate_tolerance=0.95)
+
+
+def test_select_non_duplicate_indices_respects_near_duplicate_tolerance() -> None:
+    similarities = np.array(
+        [
+            [1.00, 0.94, 0.20],
+            [0.94, 1.00, 0.20],
+            [0.20, 0.20, 1.00],
+        ],
+        dtype=np.float32,
+    )
+
+    stricter = _select_non_duplicate_indices(
+        similarities,
+        near_duplicate_tolerance=0.90,
+    )
+    looser = _select_non_duplicate_indices(
+        similarities,
+        near_duplicate_tolerance=0.95,
+    )
+
+    assert stricter == [0, 2]
+    assert looser == [0, 1, 2]
 
 
 def test_embed_blueprints_serializes_in_fixed_order_and_uses_one_normalized_batch(
@@ -261,7 +284,7 @@ def test_deduplicate_blueprints_removes_exact_duplicates_and_preserves_order(
         lambda checkpoint="all-MiniLM-L6-v2": _FakeModel(),
     )
 
-    deduplicated = deduplicate_blueprints(candidates)
+    deduplicated = deduplicate_blueprints(candidates, near_duplicate_tolerance=0.95,)
 
     assert [blueprint.candidate_id for blueprint in deduplicated] == ["c001", "c003"]
 
@@ -309,13 +332,13 @@ def test_deduplicate_blueprints_applies_near_duplicate_selection_in_original_ord
         lambda checkpoint="all-MiniLM-L6-v2": _FakeModel(),
     )
 
-    deduplicated = deduplicate_blueprints(candidates)
+    deduplicated = deduplicate_blueprints(candidates, near_duplicate_tolerance=0.95,)
 
     assert [blueprint.candidate_id for blueprint in deduplicated] == ["c001", "c003", "c004"]
 
 
 def test_deduplicate_blueprints_returns_empty_list_for_empty_input() -> None:
-    assert deduplicate_blueprints([]) == []
+    assert deduplicate_blueprints([], near_duplicate_tolerance=0.95) == []
 
 
 def test_deduplicate_blueprints_short_circuits_when_exact_dedup_leaves_one(
@@ -348,8 +371,53 @@ def test_deduplicate_blueprints_short_circuits_when_exact_dedup_leaves_one(
         _fake_load_embedding_model,
     )
 
-    result = deduplicate_blueprints([first, duplicate])
+    result = deduplicate_blueprints([first, duplicate], near_duplicate_tolerance=0.95,)
 
     assert result == [first]
     assert embed_called is False
     assert load_called is False
+
+
+def test_deduplicate_blueprints_respects_near_duplicate_tolerance(
+    make_blueprint: Callable[..., QueryBlueprint],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    candidates = [
+        make_blueprint(candidate_id="c001", topic="teacher shortages"),
+        make_blueprint(candidate_id="c002", topic="school meals"),
+        make_blueprint(candidate_id="c003", topic="digital learning"),
+    ]
+
+    monkeypatch.setattr(
+        "pragmata.core.querygen.deduplication._embed_blueprints",
+        lambda blueprints: np.array(
+            [
+                [1.0, 0.0],
+                [0.0, 1.0],
+                [0.5, 0.5],
+            ],
+            dtype=np.float32,
+        ),
+    )
+
+    class _FakeModel:
+        def similarity(self, left: np.ndarray, right: np.ndarray) -> np.ndarray:
+            return np.array(
+                [
+                    [1.00, 0.94, 0.20],
+                    [0.94, 1.00, 0.20],
+                    [0.20, 0.20, 1.00],
+                ],
+                dtype=np.float32,
+            )
+
+    monkeypatch.setattr(
+        "pragmata.core.querygen.deduplication._load_embedding_model",
+        lambda checkpoint="all-MiniLM-L6-v2": _FakeModel(),
+    )
+
+    stricter = deduplicate_blueprints(candidates, near_duplicate_tolerance=0.90)
+    looser = deduplicate_blueprints(candidates, near_duplicate_tolerance=0.95)
+
+    assert [blueprint.candidate_id for blueprint in stricter] == ["c001", "c003"]
+    assert [blueprint.candidate_id for blueprint in looser] == ["c001", "c002", "c003"]

--- a/tests/unit/core/querygen/test_deduplication.py
+++ b/tests/unit/core/querygen/test_deduplication.py
@@ -284,7 +284,10 @@ def test_deduplicate_blueprints_removes_exact_duplicates_and_preserves_order(
         lambda checkpoint="all-MiniLM-L6-v2": _FakeModel(),
     )
 
-    deduplicated = deduplicate_blueprints(candidates, near_duplicate_tolerance=0.95,)
+    deduplicated = deduplicate_blueprints(
+        candidates,
+        near_duplicate_tolerance=0.95,
+    )
 
     assert [blueprint.candidate_id for blueprint in deduplicated] == ["c001", "c003"]
 
@@ -332,7 +335,10 @@ def test_deduplicate_blueprints_applies_near_duplicate_selection_in_original_ord
         lambda checkpoint="all-MiniLM-L6-v2": _FakeModel(),
     )
 
-    deduplicated = deduplicate_blueprints(candidates, near_duplicate_tolerance=0.95,)
+    deduplicated = deduplicate_blueprints(
+        candidates,
+        near_duplicate_tolerance=0.95,
+    )
 
     assert [blueprint.candidate_id for blueprint in deduplicated] == ["c001", "c003", "c004"]
 
@@ -371,7 +377,10 @@ def test_deduplicate_blueprints_short_circuits_when_exact_dedup_leaves_one(
         _fake_load_embedding_model,
     )
 
-    result = deduplicate_blueprints([first, duplicate], near_duplicate_tolerance=0.95,)
+    result = deduplicate_blueprints(
+        [first, duplicate],
+        near_duplicate_tolerance=0.95,
+    )
 
     assert result == [first]
     assert embed_called is False

--- a/tests/unit/core/settings/test_querygen_settings.py
+++ b/tests/unit/core/settings/test_querygen_settings.py
@@ -52,6 +52,7 @@ def test_querygen_run_settings_construction_with_defaults() -> None:
     assert settings.run_id
     assert settings.n_queries == 50
     assert settings.batch_size == 25
+    assert settings.near_duplicate_tolerance == 0.95
     assert settings.enable_planning_memory is True
 
 
@@ -163,6 +164,49 @@ def test_querygen_run_settings_resolve_batch_size_override_precedence() -> None:
     )
 
     assert resolved.batch_size == 7
+
+
+def test_querygen_run_settings_accepts_near_duplicate_tolerance_override() -> None:
+    settings = QueryGenRunSettings.model_validate(
+        {
+            "spec": _valid_spec_payload(),
+            "near_duplicate_tolerance": 0.98,
+        }
+    )
+
+    assert settings.near_duplicate_tolerance == 0.98
+
+
+def test_querygen_run_settings_resolve_near_duplicate_tolerance_override_precedence() -> None:
+    """Resolve applies explicit near_duplicate_tolerance overrides over config values."""
+    resolved = QueryGenRunSettings.resolve(
+        config={
+            "spec": _valid_spec_payload(),
+            "near_duplicate_tolerance": 0.92,
+        },
+        overrides={
+            "near_duplicate_tolerance": 0.99,
+        },
+    )
+
+    assert resolved.near_duplicate_tolerance == 0.99
+
+
+def test_querygen_run_settings_rejects_invalid_near_duplicate_tolerance_values() -> None:
+    """QueryGenRunSettings rejects invalid near_duplicate_tolerance values."""
+    invalid_payloads = [
+        {"spec": _valid_spec_payload(), "near_duplicate_tolerance": 0},
+        {"spec": _valid_spec_payload(), "near_duplicate_tolerance": -0.1},
+        {"spec": _valid_spec_payload(), "near_duplicate_tolerance": 1.1},
+    ]
+
+    for payload in invalid_payloads:
+        try:
+            QueryGenRunSettings.model_validate(payload)
+        except ValidationError:
+            pass
+        else:
+            raise AssertionError(f"Expected ValidationError for payload: {payload}")
 
 
 def test_querygen_run_settings_resolve_enable_planning_memory_override() -> None:


### PR DESCRIPTION
**Summary**

Expose `near_duplicate_tolerance` as a user-facing querygen knob in the library/API path so callers can control how strictly semantic near-duplicates are removed during stage-1 blueprint selection.

**Key changes**

- Update `core/querygen/deduplication.py`:
  - replace the hard-coded semantic near-duplicate cutoff with an explicit `near_duplicate_tolerance` parameter
  - require and thread that value through the semantic deduplication path

- Update `core/settings/querygen_settings.py`:
  - add `near_duplicate_tolerance` to `QueryGenRunSettings`

- Update `api/querygen.py`:
  - expose `near_duplicate_tolerance` on `gen_queries()`
  - thread it into `QueryGenRunSettings.resolve(...)`
  - pass the resolved value into `deduplicate_blueprints(...)` during stage-1 blueprint selection

- Add/update unit tests covering:
  - explicit `near_duplicate_tolerance` handling in deduplication tests
  - `near_duplicate_tolerance` in querygen run settings resolution
  - API wiring from `gen_queries()` through resolved settings into blueprint deduplication

**Out of scope**

- CLI wiring in `src/pragmata/cli/commands/querygen.py`
- CLI docs/examples
- CLI parsing/forwarding tests

These are intentionally deferred to a follow-up PR that brings the querygen CLI surface back into sync with the API/settings surface in one pass.

**Status**

Draft