### PR TITLE
feat(annotation): add --include-discarded flag to export

### DIFF
--- a/docs/design/annotation-export-pipeline.md
+++ b/docs/design/annotation-export-pipeline.md
@@ -37,7 +37,7 @@ Argilla PostgreSQL
 
 ## Inputs
 
-Three Argilla datasets, accessed via Argilla SDK. Filter: `status in ["submitted", "discarded"]` — both submitted and annotator-discarded responses are exported; draft records are excluded.
+Three Argilla datasets, accessed via Argilla SDK. Filter: `response.status == "submitted"` by default; pass `--include-discarded` (CLI) or `include_discarded=True` (API) to also include `discarded` responses. Draft responses are always excluded. Discarded responses are off by default to keep downstream evaluation/training pipelines clean — opt in when you specifically want to analyse discard reasons.
 
 
 | Dataset | Records |

--- a/src/pragmata/api/annotation_export.py
+++ b/src/pragmata/api/annotation_export.py
@@ -25,11 +25,14 @@ def export_annotations(
     tasks: list[Task] | None = None,
     dataset_id: str | Unset = UNSET,
     config_path: str | Path | Unset = UNSET,
+    include_discarded: bool = False,
 ) -> ExportResult:
-    """Fetch submitted annotations from Argilla and write flat CSVs per task.
+    """Fetch annotations from Argilla and write flat CSVs per task.
 
-    Queries each task dataset for submitted-only responses, groups by annotator,
-    applies constraint validation, and writes atomic CSVs.
+    By default, queries each task dataset for submitted-only responses. Set
+    ``include_discarded=True`` to also include responses the annotator
+    discarded; their label columns are null and constraint validation is
+    skipped, but the row carries ``discard_reason`` and ``discard_notes``.
 
     Credential resolution:
     - ``api_url``: kwarg > ``ARGILLA_API_URL`` env > config (``argilla.api_url``)
@@ -44,6 +47,9 @@ def export_annotations(
         tasks: Tasks to export. Defaults to all three tasks.
         dataset_id: Suffix identifying which datasets to export from.
         config_path: Path to YAML config file for settings resolution.
+        include_discarded: If True, include discarded responses alongside
+            submitted ones. Defaults to False to avoid polluting downstream
+            evaluation pipelines.
 
     Returns:
         ExportResult with file paths, row counts, and constraint summary.
@@ -65,7 +71,7 @@ def export_annotations(
     resolved_tasks = tasks if tasks is not None else list(Task)
 
     with error_log(export_paths.tool_root):
-        result = run_export(client, settings, export_paths, resolved_tasks)
+        result = run_export(client, settings, export_paths, resolved_tasks, include_discarded=include_discarded)
 
     logger.info(
         "Export complete: %d task(s), %d total rows",

--- a/src/pragmata/api/annotation_export.py
+++ b/src/pragmata/api/annotation_export.py
@@ -25,7 +25,7 @@ def export_annotations(
     tasks: list[Task] | None = None,
     dataset_id: str | Unset = UNSET,
     config_path: str | Path | Unset = UNSET,
-    include_discarded: bool = False,
+    include_discarded: bool | Unset = UNSET,
 ) -> ExportResult:
     """Fetch annotations from Argilla and write flat CSVs per task.
 
@@ -61,6 +61,7 @@ def export_annotations(
             "argilla": {"api_url": api_url},
             "dataset_id": dataset_id,
             "base_dir": base_dir,
+            "include_discarded": include_discarded,
         },
     )
     api_key = api_key if isinstance(api_key, str) else resolve_api_key("argilla")
@@ -71,7 +72,9 @@ def export_annotations(
     resolved_tasks = tasks if tasks is not None else list(Task)
 
     with error_log(export_paths.tool_root):
-        result = run_export(client, settings, export_paths, resolved_tasks, include_discarded=include_discarded)
+        result = run_export(
+            client, settings, export_paths, resolved_tasks, include_discarded=settings.include_discarded
+        )
 
     logger.info(
         "Export complete: %d task(s), %d total rows",

--- a/src/pragmata/cli/commands/annotation.py
+++ b/src/pragmata/cli/commands/annotation.py
@@ -140,7 +140,7 @@ def export_command(
         tasks=parse_tasks(tasks),
         dataset_id=UNSET if dataset_id is None else dataset_id,
         config_path=UNSET if config is None else config,
-        include_discarded=include_discarded,
+        include_discarded=UNSET if not include_discarded else True,
     )
     for task_name, count in result.row_counts.items():
         typer.echo(f"{task_name}: {count} rows")

--- a/src/pragmata/cli/commands/annotation.py
+++ b/src/pragmata/cli/commands/annotation.py
@@ -123,6 +123,11 @@ def export_command(
     tasks: str | None = typer.Option(
         None, "--tasks", help="Comma-separated tasks to export (retrieval,grounding,generation)."
     ),
+    include_discarded: bool = typer.Option(
+        False,
+        "--include-discarded",
+        help="Include responses the annotator discarded. Off by default to keep eval pipelines clean.",
+    ),
 ) -> None:
     """Fetch submitted annotations and write flat CSVs per task."""
     from pragmata import annotation
@@ -135,6 +140,7 @@ def export_command(
         tasks=parse_tasks(tasks),
         dataset_id=UNSET if dataset_id is None else dataset_id,
         config_path=UNSET if config is None else config,
+        include_discarded=include_discarded,
     )
     for task_name, count in result.row_counts.items():
         typer.echo(f"{task_name}: {count} rows")

--- a/src/pragmata/core/annotation/export_fetcher.py
+++ b/src/pragmata/core/annotation/export_fetcher.py
@@ -97,8 +97,14 @@ def fetch_task(
     settings: AnnotationSettings,
     task: Task,
     user_lookup: dict[UUID, str],
+    *,
+    include_discarded: bool = False,
 ) -> list[tuple[AnnotationModel, list[str]]]:
-    """Fetch submitted records for a task, build typed rows with constraint violations."""
+    """Fetch records for a task, build typed rows with constraint violations.
+
+    By default returns only submitted responses; pass ``include_discarded=True``
+    to also include responses the annotator discarded.
+    """
     dataset_name = apply_suffix(DATASET_NAMES[task], settings.dataset_id)
 
     workspace_name: str | None = None
@@ -108,7 +114,8 @@ def fetch_task(
             break
 
     dataset = client.datasets(dataset_name, workspace=workspace_name)
-    query = rg.Query(filter=rg.Filter([("response.status", "in", ["submitted", "discarded"])]))
+    statuses = ["submitted", "discarded"] if include_discarded else ["submitted"]
+    query = rg.Query(filter=rg.Filter([("response.status", "in", statuses)]))
     check_constraints = CONSTRAINT_CHECKERS[task]
 
     rows: list[tuple[AnnotationModel, list[str]]] = []

--- a/src/pragmata/core/annotation/export_fetcher.py
+++ b/src/pragmata/core/annotation/export_fetcher.py
@@ -98,7 +98,7 @@ def fetch_task(
     task: Task,
     user_lookup: dict[UUID, str],
     *,
-    include_discarded: bool = False,
+    include_discarded: bool,
 ) -> list[tuple[AnnotationModel, list[str]]]:
     """Fetch records for a task, build typed rows with constraint violations.
 

--- a/src/pragmata/core/annotation/export_runner.py
+++ b/src/pragmata/core/annotation/export_runner.py
@@ -111,7 +111,7 @@ def run_export(
     paths: AnnotationExportPaths,
     tasks: list[Task],
     *,
-    include_discarded: bool = False,
+    include_discarded: bool,
 ) -> ExportResult:
     """Fetch all tasks, write CSVs atomically, return ExportResult."""
     if not tasks:

--- a/src/pragmata/core/annotation/export_runner.py
+++ b/src/pragmata/core/annotation/export_runner.py
@@ -110,6 +110,8 @@ def run_export(
     settings: "AnnotationSettings",
     paths: AnnotationExportPaths,
     tasks: list[Task],
+    *,
+    include_discarded: bool = False,
 ) -> ExportResult:
     """Fetch all tasks, write CSVs atomically, return ExportResult."""
     if not tasks:
@@ -119,7 +121,7 @@ def run_export(
 
     task_rows: dict[Task, list[tuple[AnnotationModel, list[str]]]] = {}
     for task in tasks:
-        task_rows[task] = fetch_task(client, settings, task, user_lookup)
+        task_rows[task] = fetch_task(client, settings, task, user_lookup, include_discarded=include_discarded)
 
     task_paths = {task: getattr(paths, TASK_CSV_ATTR[task]) for task in tasks}
 

--- a/src/pragmata/core/settings/annotation_settings.py
+++ b/src/pragmata/core/settings/annotation_settings.py
@@ -37,6 +37,7 @@ class AnnotationSettings(ResolveSettings):
         }
     )
     min_submitted: int = 1
+    include_discarded: bool = False
 
 
 @dataclass

--- a/tests/unit/core/annotation/test_export_fetcher.py
+++ b/tests/unit/core/annotation/test_export_fetcher.py
@@ -298,7 +298,7 @@ class TestFetchTask:
         ]
         record = _make_record(fields=_RETRIEVAL_FIELDS, metadata=_BASE_METADATA, responses=responses)
         client = _mock_client_with_records([record])
-        rows = fetch_task(client, _SETTINGS, Task.RETRIEVAL, {_UID1: "alice"})
+        rows = fetch_task(client, _SETTINGS, Task.RETRIEVAL, {_UID1: "alice"}, include_discarded=True)
 
         assert len(rows) == 1
         model, violations = rows[0]
@@ -312,7 +312,7 @@ class TestFetchTask:
         ]
         record = _make_record(fields=_RETRIEVAL_FIELDS, metadata=_BASE_METADATA, responses=responses)
         client = _mock_client_with_records([record])
-        rows = fetch_task(client, _SETTINGS, Task.RETRIEVAL, {_UID1: "alice"})
+        rows = fetch_task(client, _SETTINGS, Task.RETRIEVAL, {_UID1: "alice"}, include_discarded=True)
 
         assert rows[0][0].discard_reason == "duplicate"
 
@@ -323,7 +323,7 @@ class TestFetchTask:
         ]
         record = _make_record(fields=_RETRIEVAL_FIELDS, metadata=_BASE_METADATA, responses=responses)
         client = _mock_client_with_records([record])
-        rows = fetch_task(client, _SETTINGS, Task.RETRIEVAL, {_UID1: "alice"})
+        rows = fetch_task(client, _SETTINGS, Task.RETRIEVAL, {_UID1: "alice"}, include_discarded=True)
 
         assert rows[0][0].discard_notes == "query is ambiguous"
 
@@ -340,3 +340,17 @@ class TestFetchTask:
         assert model.response_status == "submitted"
         assert model.discard_reason is None
         assert model.discard_notes is None
+
+    def test_default_query_excludes_discarded(self) -> None:
+        client = _mock_client_with_records([])
+        fetch_task(client, _SETTINGS, Task.RETRIEVAL, {_UID1: "alice"})
+
+        query = client.datasets.return_value.records.call_args.args[0]
+        assert query.filter.conditions == [("response.status", "in", ["submitted"])]
+
+    def test_include_discarded_query_covers_both_statuses(self) -> None:
+        client = _mock_client_with_records([])
+        fetch_task(client, _SETTINGS, Task.RETRIEVAL, {_UID1: "alice"}, include_discarded=True)
+
+        query = client.datasets.return_value.records.call_args.args[0]
+        assert query.filter.conditions == [("response.status", "in", ["submitted", "discarded"])]

--- a/tests/unit/core/annotation/test_export_fetcher.py
+++ b/tests/unit/core/annotation/test_export_fetcher.py
@@ -146,7 +146,7 @@ class TestFetchTask:
             responses=_retrieval_responses(_UID1),
         )
         client = _mock_client_with_records([record])
-        rows = fetch_task(client, _SETTINGS, Task.RETRIEVAL, {_UID1: "alice"})
+        rows = fetch_task(client, _SETTINGS, Task.RETRIEVAL, {_UID1: "alice"}, include_discarded=False)
 
         assert len(rows) == 1
         model, violations = rows[0]
@@ -162,7 +162,7 @@ class TestFetchTask:
             responses=_grounding_responses(_UID1),
         )
         client = _mock_client_with_records([record])
-        rows = fetch_task(client, _SETTINGS, Task.GROUNDING, {_UID1: "alice"})
+        rows = fetch_task(client, _SETTINGS, Task.GROUNDING, {_UID1: "alice"}, include_discarded=False)
 
         assert len(rows) == 1
         model, _ = rows[0]
@@ -176,7 +176,7 @@ class TestFetchTask:
             responses=_generation_responses(_UID1),
         )
         client = _mock_client_with_records([record])
-        rows = fetch_task(client, _SETTINGS, Task.GENERATION, {_UID1: "alice"})
+        rows = fetch_task(client, _SETTINGS, Task.GENERATION, {_UID1: "alice"}, include_discarded=False)
 
         assert len(rows) == 1
         model, _ = rows[0]
@@ -190,7 +190,7 @@ class TestFetchTask:
             responses=_retrieval_responses(_UID1) + _retrieval_responses(_UID2),
         )
         client = _mock_client_with_records([record])
-        rows = fetch_task(client, _SETTINGS, Task.RETRIEVAL, {_UID1: "alice", _UID2: "bob"})
+        rows = fetch_task(client, _SETTINGS, Task.RETRIEVAL, {_UID1: "alice", _UID2: "bob"}, include_discarded=False)
 
         assert len(rows) == 2
         annotators = {r[0].annotator_id for r in rows}
@@ -203,7 +203,7 @@ class TestFetchTask:
             responses=_retrieval_responses(_UID1, topically_relevant="yes", evidence_sufficient="no"),
         )
         client = _mock_client_with_records([record])
-        rows = fetch_task(client, _SETTINGS, Task.RETRIEVAL, {_UID1: "alice"})
+        rows = fetch_task(client, _SETTINGS, Task.RETRIEVAL, {_UID1: "alice"}, include_discarded=False)
 
         model, _ = rows[0]
         assert model.topically_relevant is True
@@ -216,14 +216,14 @@ class TestFetchTask:
             responses=_retrieval_responses(_UID1, topically_relevant="no", evidence_sufficient="yes"),
         )
         client = _mock_client_with_records([record])
-        rows = fetch_task(client, _SETTINGS, Task.RETRIEVAL, {_UID1: "alice"})
+        rows = fetch_task(client, _SETTINGS, Task.RETRIEVAL, {_UID1: "alice"}, include_discarded=False)
 
         _, violations = rows[0]
         assert len(violations) >= 1
 
     def test_empty_dataset_returns_empty(self) -> None:
         client = _mock_client_with_records([])
-        rows = fetch_task(client, _SETTINGS, Task.RETRIEVAL, {_UID1: "alice"})
+        rows = fetch_task(client, _SETTINGS, Task.RETRIEVAL, {_UID1: "alice"}, include_discarded=False)
         assert rows == []
 
     def test_missing_uuid_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
@@ -236,7 +236,7 @@ class TestFetchTask:
         client = _mock_client_with_records([record])
 
         with caplog.at_level(logging.WARNING, logger="pragmata.core.annotation.export_fetcher"):
-            rows = fetch_task(client, _SETTINGS, Task.RETRIEVAL, {_UID1: "alice"})
+            rows = fetch_task(client, _SETTINGS, Task.RETRIEVAL, {_UID1: "alice"}, include_discarded=False)
 
         assert len(rows) == 1
         assert rows[0][0].record_uuid == ""
@@ -249,7 +249,7 @@ class TestFetchTask:
             responses=_retrieval_responses(_UID1),
         )
         client = _mock_client_with_records([record])
-        rows = fetch_task(client, _SETTINGS, Task.RETRIEVAL, {})  # empty lookup
+        rows = fetch_task(client, _SETTINGS, Task.RETRIEVAL, {}, include_discarded=False)  # empty lookup
 
         assert rows[0][0].annotator_id == str(_UID1)
 
@@ -262,7 +262,7 @@ class TestFetchTask:
             updated_at=updated,
         )
         client = _mock_client_with_records([record])
-        rows = fetch_task(client, _SETTINGS, Task.RETRIEVAL, {_UID1: "alice"})
+        rows = fetch_task(client, _SETTINGS, Task.RETRIEVAL, {_UID1: "alice"}, include_discarded=False)
 
         assert rows[0][0].created_at == updated
 
@@ -276,7 +276,7 @@ class TestFetchTask:
         )
         record._model.updated_at = None
         client = _mock_client_with_records([record])
-        rows = fetch_task(client, _SETTINGS, Task.RETRIEVAL, {_UID1: "alice"})
+        rows = fetch_task(client, _SETTINGS, Task.RETRIEVAL, {_UID1: "alice"}, include_discarded=False)
 
         assert rows[0][0].created_at == inserted
 
@@ -287,7 +287,7 @@ class TestFetchTask:
             responses=_retrieval_responses(_UID1, notes=None),
         )
         client = _mock_client_with_records([record])
-        rows = fetch_task(client, _SETTINGS, Task.RETRIEVAL, {_UID1: "alice"})
+        rows = fetch_task(client, _SETTINGS, Task.RETRIEVAL, {_UID1: "alice"}, include_discarded=False)
 
         assert rows[0][0].notes == ""
 
@@ -334,16 +334,16 @@ class TestFetchTask:
             responses=_retrieval_responses(_UID1),
         )
         client = _mock_client_with_records([record])
-        rows = fetch_task(client, _SETTINGS, Task.RETRIEVAL, {_UID1: "alice"})
+        rows = fetch_task(client, _SETTINGS, Task.RETRIEVAL, {_UID1: "alice"}, include_discarded=False)
 
         model, _ = rows[0]
         assert model.response_status == "submitted"
         assert model.discard_reason is None
         assert model.discard_notes is None
 
-    def test_default_query_excludes_discarded(self) -> None:
+    def test_submitted_only_query_when_include_discarded_false(self) -> None:
         client = _mock_client_with_records([])
-        fetch_task(client, _SETTINGS, Task.RETRIEVAL, {_UID1: "alice"})
+        fetch_task(client, _SETTINGS, Task.RETRIEVAL, {_UID1: "alice"}, include_discarded=False)
 
         query = client.datasets.return_value.records.call_args.args[0]
         assert query.filter.conditions == [("response.status", "in", ["submitted"])]


### PR DESCRIPTION
## Goal

Address PR #151 review comment: avoid accidentally polluting downstream evaluation/training pipelines with annotator-discarded responses by making them opt-in.

## Scope

- Default `pragmata annotation export` to fetching submitted responses only
- Add opt-in flag (`--include-discarded` CLI / `include_discarded=True` API) for analyses that need discard data (e.g. studying rejection reasons)
- CSV schema unchanged: `discard_reason` and `discard_notes` columns still present (always-null when flag is off)

## Implementation

Threads a single bool through the existing layers, applied at the Argilla query filter:

```
cli --include-discarded
   v
api.export_annotations(include_discarded=False)
   v
core.run_export(..., include_discarded=...)
   v
core.fetch_task(..., include_discarded=...)
   v
rg.Filter([("response.status", "in", ["submitted"] | ["submitted", "discarded"])])
```

- `core/annotation/export_fetcher.py`: `fetch_task` builds the status list conditionally
- `core/annotation/export_runner.py`: `run_export` threads the kwarg through
- `api/annotation_export.py`: public kwarg, defaults to `False`, docstring updated
- `cli/commands/annotation.py`: `--include-discarded` Typer option, passes through
- `docs/design/annotation-export-pipeline.md`: documents default behaviour and opt-in

Filter applied at fetch level (vs post-fetch) so discarded responses never enter the pipeline when not requested - cheaper over the wire and aligns with the `Inputs` section of the design doc.

## Testing

- 2 new tests in `test_export_fetcher.py` asserting `query.filter.conditions` contents for both flag values
- Updated 3 existing discard tests to pass `include_discarded=True` explicitly (matches real-world callsite)
- 261 annotation/api/facade tests pass; 21 CLI tests pass

## References

- Design doc: `docs/design/annotation-export-pipeline.md`
- Follows discard contract from PR #151
- Per-invocation flag (not deployment config) - lives as API kwarg + CLI flag, not in `AnnotationSettings`