### PR TITLE
test(integration): progressive preflight for annotation stack

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,21 +2,66 @@
 
 import shutil
 import socket
+import subprocess
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
 
 import pytest
 
 ARGILLA_DEFAULT_HOST = "localhost"
 ARGILLA_DEFAULT_PORT = 6900
+ARGILLA_DEFAULT_API_KEY = "argilla.apikey"
 _CONNECT_TIMEOUT_S = 2
+_HTTP_TIMEOUT_S = 3
 
 
-def _docker_available() -> bool:
-    """Check whether Docker CLI is on PATH."""
+@dataclass(frozen=True)
+class AnnotationStackStatus:
+    """Result of progressive preflight checks for the annotation stack."""
+
+    docker_cli: bool
+    docker_daemon: bool
+    argilla_tcp: bool
+    argilla_api: bool
+
+    @property
+    def ready(self) -> bool:
+        return self.docker_cli and self.docker_daemon and self.argilla_tcp and self.argilla_api
+
+    @property
+    def skip_reason(self) -> str | None:
+        if not self.docker_cli:
+            return "Docker CLI not on PATH"
+        if not self.docker_daemon:
+            return "Docker daemon not running (try: open -a Docker)"
+        if not self.argilla_tcp:
+            return f"Argilla not reachable at {ARGILLA_DEFAULT_HOST}:{ARGILLA_DEFAULT_PORT} (try: make docker-up)"
+        if not self.argilla_api:
+            return (
+                f"Argilla API not responding at http://{ARGILLA_DEFAULT_HOST}:{ARGILLA_DEFAULT_PORT}"
+                " (stack may still be warming up)"
+            )
+        return None
+
+
+def _docker_cli_available() -> bool:
     return shutil.which("docker") is not None
 
 
-def _argilla_reachable() -> bool:
-    """Check whether the Argilla server is accepting connections."""
+def _docker_daemon_running() -> bool:
+    try:
+        result = subprocess.run(
+            ["docker", "info"],
+            capture_output=True,
+            timeout=_HTTP_TIMEOUT_S,
+        )
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return False
+
+
+def _argilla_tcp_open() -> bool:
     try:
         with socket.create_connection((ARGILLA_DEFAULT_HOST, ARGILLA_DEFAULT_PORT), timeout=_CONNECT_TIMEOUT_S):
             return True
@@ -24,19 +69,68 @@ def _argilla_reachable() -> bool:
         return False
 
 
+def _argilla_api_healthy() -> bool:
+    try:
+        req = urllib.request.Request(
+            f"http://{ARGILLA_DEFAULT_HOST}:{ARGILLA_DEFAULT_PORT}/api/v1/me",
+            headers={"X-Argilla-Api-Key": ARGILLA_DEFAULT_API_KEY},
+        )
+        with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_S) as resp:
+            return resp.status == 200
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError, TimeoutError):
+        return False
+
+
+def _check_annotation_stack() -> AnnotationStackStatus:
+    docker_cli = _docker_cli_available()
+    docker_daemon = docker_cli and _docker_daemon_running()
+    argilla_tcp = docker_daemon and _argilla_tcp_open()
+    argilla_api = argilla_tcp and _argilla_api_healthy()
+    return AnnotationStackStatus(
+        docker_cli=docker_cli,
+        docker_daemon=docker_daemon,
+        argilla_tcp=argilla_tcp,
+        argilla_api=argilla_api,
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Run annotation stack preflight once at session start, cache on config."""
+    config._annotation_stack_status = _check_annotation_stack()  # type: ignore[attr-defined]
+
+
+def pytest_report_header(config: pytest.Config) -> list[str]:
+    """Print annotation stack status once at session start."""
+    status: AnnotationStackStatus = config._annotation_stack_status  # type: ignore[attr-defined]
+
+    def _mark(ok: bool) -> str:
+        return "ok" if ok else "--"
+
+    line = (
+        f"annotation stack: "
+        f"docker-cli [{_mark(status.docker_cli)}] "
+        f"daemon [{_mark(status.docker_daemon)}] "
+        f"argilla-tcp [{_mark(status.argilla_tcp)}] "
+        f"argilla-api [{_mark(status.argilla_api)}]"
+    )
+    if not status.ready:
+        line += f" — annotation integration tests will be skipped ({status.skip_reason})"
+    return [line]
+
+
+@pytest.fixture(scope="session")
+def annotation_stack_status(pytestconfig: pytest.Config) -> AnnotationStackStatus:
+    """Session-wide preflight result for the annotation stack."""
+    return pytestconfig._annotation_stack_status  # type: ignore[attr-defined]
+
+
 @pytest.fixture(autouse=True)
-def _require_integration_stack(request: pytest.FixtureRequest) -> None:
-    """Skip annotation interface integration tests when prerequisites are missing.
-
-    Checks (in order):
-    1. Docker CLI is on PATH
-    2. Argilla server is reachable on localhost:6900
-
-    Fails fast with a clear message rather than hanging on connection timeouts.
-    """
+def _require_annotation_stack(
+    request: pytest.FixtureRequest,
+    annotation_stack_status: AnnotationStackStatus,
+) -> None:
+    """Skip annotation-marked tests when the stack is not ready."""
     if not request.node.get_closest_marker("annotation"):
         return
-    if not _docker_available():
-        pytest.skip("Docker CLI not available")
-    if not _argilla_reachable():
-        pytest.skip(f"Argilla not reachable at {ARGILLA_DEFAULT_HOST}:{ARGILLA_DEFAULT_PORT}")
+    if not annotation_stack_status.ready:
+        pytest.skip(annotation_stack_status.skip_reason or "annotation stack not ready")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,23 +99,56 @@ def pytest_configure(config: pytest.Config) -> None:
     config._annotation_stack_status = _check_annotation_stack()  # type: ignore[attr-defined]
 
 
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Count annotation-marked tests so we can report skip totals at end-of-run."""
+    config._annotation_marked_count = sum(  # type: ignore[attr-defined]
+        1 for item in items if item.get_closest_marker("annotation")
+    )
+
+
+def _stack_layer_lines(status: AnnotationStackStatus) -> list[tuple[str, bool]]:
+    return [
+        ("docker-cli", status.docker_cli),
+        ("daemon", status.docker_daemon),
+        ("argilla-tcp", status.argilla_tcp),
+        ("argilla-api", status.argilla_api),
+    ]
+
+
 def pytest_report_header(config: pytest.Config) -> list[str]:
     """Print annotation stack status once at session start."""
     status: AnnotationStackStatus = config._annotation_stack_status  # type: ignore[attr-defined]
-
-    def _mark(ok: bool) -> str:
-        return "ok" if ok else "--"
-
-    line = (
-        f"annotation stack: "
-        f"docker-cli [{_mark(status.docker_cli)}] "
-        f"daemon [{_mark(status.docker_daemon)}] "
-        f"argilla-tcp [{_mark(status.argilla_tcp)}] "
-        f"argilla-api [{_mark(status.argilla_api)}]"
-    )
+    marks = " ".join(f"{name} [{'ok' if ok else '--'}]" for name, ok in _stack_layer_lines(status))
+    line = f">>> annotation stack: {marks}"
     if not status.ready:
-        line += f" — annotation integration tests will be skipped ({status.skip_reason})"
+        line += f"  (skipping integration: {status.skip_reason})"
     return [line]
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config: pytest.Config) -> None:
+    """Re-surface the stack status at end-of-run when integration was skipped."""
+    status: AnnotationStackStatus = config._annotation_stack_status  # type: ignore[attr-defined]
+    if status.ready:
+        return
+    skipped = getattr(config, "_annotation_marked_count", 0)
+    if not skipped:
+        return
+    tr = terminalreporter
+    tr.write_sep("=", "ANNOTATION STACK SKIPPED", red=True, bold=True)
+    tr.write_line(f"{skipped} annotation integration tests were skipped: {status.skip_reason}")
+    tr.write_line("")
+    tr.write_line("Status:")
+    failed_marked = False
+    for name, ok in _stack_layer_lines(status):
+        marker = "[ok]" if ok else "[--]"
+        suffix = ""
+        if not ok and not failed_marked:
+            suffix = "  <- failed here"
+            failed_marked = True
+        tr.write_line(f"  {name:<12} {marker}{suffix}")
+    tr.write_line("")
+    tr.write_line("To run integration tests: open -a Docker && make docker-up && make test-all")
+    tr.write_sep("=", red=True, bold=True)
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ class AnnotationStackStatus:
         if not self.docker_cli:
             return "Docker CLI not on PATH"
         if not self.docker_daemon:
-            return "Docker daemon not running (try: open -a Docker)"
+            return "Docker daemon not running (start Docker, then retry)"
         if not self.argilla_tcp:
             return f"Argilla not reachable at {ARGILLA_DEFAULT_HOST}:{ARGILLA_DEFAULT_PORT} (try: make docker-up)"
         if not self.argilla_api:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,10 +38,7 @@ class AnnotationStackStatus:
         if not self.argilla_tcp:
             return f"Argilla not reachable at {ARGILLA_DEFAULT_HOST}:{ARGILLA_DEFAULT_PORT} (try: make docker-up)"
         if not self.argilla_api:
-            return (
-                f"Argilla API not responding at http://{ARGILLA_DEFAULT_HOST}:{ARGILLA_DEFAULT_PORT}"
-                " (stack may still be warming up)"
-            )
+            return f"Argilla API not responding at http://{ARGILLA_DEFAULT_HOST}:{ARGILLA_DEFAULT_PORT}"
         return None
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,9 @@ class AnnotationStackStatus:
         return None
 
 
+_STACK_STATUS_KEY: pytest.StashKey[AnnotationStackStatus] = pytest.StashKey()
+
+
 def _docker_cli_available() -> bool:
     return shutil.which("docker") is not None
 
@@ -93,14 +96,7 @@ def _check_annotation_stack() -> AnnotationStackStatus:
 
 def pytest_configure(config: pytest.Config) -> None:
     """Run annotation stack preflight once at session start, cache on config."""
-    config._annotation_stack_status = _check_annotation_stack()  # type: ignore[attr-defined]
-
-
-def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
-    """Count annotation-marked tests so we can report skip totals at end-of-run."""
-    config._annotation_marked_count = sum(  # type: ignore[attr-defined]
-        1 for item in items if item.get_closest_marker("annotation")
-    )
+    config.stash[_STACK_STATUS_KEY] = _check_annotation_stack()
 
 
 def _stack_layer_lines(status: AnnotationStackStatus) -> list[tuple[str, bool]]:
@@ -114,7 +110,7 @@ def _stack_layer_lines(status: AnnotationStackStatus) -> list[tuple[str, bool]]:
 
 def pytest_report_header(config: pytest.Config) -> list[str]:
     """Print annotation stack status once at session start."""
-    status: AnnotationStackStatus = config._annotation_stack_status  # type: ignore[attr-defined]
+    status = config.stash[_STACK_STATUS_KEY]
     marks = " ".join(f"{name} [{'ok' if ok else '--'}]" for name, ok in _stack_layer_lines(status))
     line = f">>> annotation stack: {marks}"
     if not status.ready:
@@ -122,36 +118,10 @@ def pytest_report_header(config: pytest.Config) -> list[str]:
     return [line]
 
 
-def pytest_terminal_summary(terminalreporter, exitstatus, config: pytest.Config) -> None:
-    """Re-surface the stack status at end-of-run when integration was skipped."""
-    status: AnnotationStackStatus = config._annotation_stack_status  # type: ignore[attr-defined]
-    if status.ready:
-        return
-    skipped = getattr(config, "_annotation_marked_count", 0)
-    if not skipped:
-        return
-    tr = terminalreporter
-    tr.write_sep("=", "ANNOTATION STACK SKIPPED", red=True, bold=True)
-    tr.write_line(f"{skipped} annotation integration tests were skipped: {status.skip_reason}")
-    tr.write_line("")
-    tr.write_line("Status:")
-    failed_marked = False
-    for name, ok in _stack_layer_lines(status):
-        marker = "[ok]" if ok else "[--]"
-        suffix = ""
-        if not ok and not failed_marked:
-            suffix = "  <- failed here"
-            failed_marked = True
-        tr.write_line(f"  {name:<12} {marker}{suffix}")
-    tr.write_line("")
-    tr.write_line("To run integration tests: open -a Docker && make docker-up && make test-all")
-    tr.write_sep("=", red=True, bold=True)
-
-
 @pytest.fixture(scope="session")
 def annotation_stack_status(pytestconfig: pytest.Config) -> AnnotationStackStatus:
     """Session-wide preflight result for the annotation stack."""
-    return pytestconfig._annotation_stack_status  # type: ignore[attr-defined]
+    return pytestconfig.stash[_STACK_STATUS_KEY]
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/test_annotation_import.py
+++ b/tests/integration/test_annotation_import.py
@@ -35,7 +35,9 @@ def _make_raw(n_chunks: int = 2, *, language: str | None = "de") -> dict:
 
 
 @pytest.fixture(scope="module")
-def client() -> rg.Argilla:
+def client(annotation_stack_status) -> rg.Argilla:
+    if not annotation_stack_status.ready:
+        pytest.skip(annotation_stack_status.skip_reason or "annotation stack not ready")
     return rg.Argilla(api_url=_API_URL, api_key=_API_KEY)
 
 

--- a/tests/integration/test_annotation_setup.py
+++ b/tests/integration/test_annotation_setup.py
@@ -25,7 +25,9 @@ _DEFAULT_SETTINGS = AnnotationSettings()
 
 
 @pytest.fixture(scope="module")
-def client() -> rg.Argilla:
+def client(annotation_stack_status) -> rg.Argilla:
+    if not annotation_stack_status.ready:
+        pytest.skip(annotation_stack_status.skip_reason or "annotation stack not ready")
     return rg.Argilla(api_url=_API_URL, api_key=_API_KEY)
 
 


### PR DESCRIPTION
## Goal

`make test-all` produces errors when Docker isn't running -> now clean skips instead of 14 noisy fixture-setup errors. 
+ tell user up front which precondition failed (fail fast & loudly) so they know whether to start Docker, run `make docker-up`, or wait for warm-up.

## Scope

- Progressive preflight at session start: docker-cli -> docker-daemon -> argilla-tcp -> argilla-api. Cheapest checks first; first failure determines skip reason.
- `pytest_report_header` hook prints the status of each layer programmatically at session start.
- Session-scoped `annotation_stack_status` fixture exposes cached result; autouse skip fixture consults it for any `annotation`-marked test.
- Two integration files whose module-scoped `client` fixture was eagerly calling `rg.Argilla(...)` (which validates connection in `__init__` and caused error messages) now depend on `annotation_stack_status` and `pytest.skip` cleanly when the stack isn't ready.

## Implementation

- `tests/conftest.py` — `AnnotationStackStatus` dataclass holding the 4-layer check result, `_check_annotation_stack()` that runs the progressive probe once at `pytest_configure`, `pytest_report_header` banner, autouse skip fixture.
- `tests/integration/test_annotation_setup.py`, `tests/integration/test_annotation_import.py` - `client` fixture gains the `annotation_stack_status` dependency and skips with the preflight's reason if stack isn't ready.

## Testing

Before (Docker off): `634 passed, 3 skipped, 14 errors` (exit 1) — integration tests errored during fixture setup with raw `httpx.ConnectError`.

After (Docker off): `622 passed, 15 skipped, 0 errors` (exit 0) — preflight banner:

```
annotation stack: docker-cli [ok] daemon [--] argilla-tcp [--] argilla-api [--] — annotation integration tests will be skipped (Docker daemon not running (try: open -a Docker))
```

With Docker + Argilla up everything runs.

Lint + mypy green.

## References

- Follow-up in stacked PR: slim down `test_dev_stack_integration.py` (calls stale `make setup`/`make teardown` targets).