### PR TITLE
test(integration): slim dev-stack integration tests

### DIFF
--- a/tests/integration/test_dev_stack_integration.py
+++ b/tests/integration/test_dev_stack_integration.py
@@ -1,9 +1,4 @@
-"""Integration tests for the Argilla dev stack.
-
-Requires the stack to be running (make docker-up). The annotation-stack
-preflight in tests/conftest.py gates collection, so these tests skip
-cleanly when the stack is unavailable.
-"""
+"""Integration tests for the Argilla dev stack."""
 
 import json
 import urllib.request

--- a/tests/integration/test_dev_stack_integration.py
+++ b/tests/integration/test_dev_stack_integration.py
@@ -1,7 +1,11 @@
-"""Integration tests for the Docker Compose dev stack (requires Docker)."""
+"""Integration tests for the Argilla dev stack.
+
+Requires the stack to be running (make docker-up). The annotation-stack
+preflight in tests/conftest.py gates collection, so these tests skip
+cleanly when the stack is unavailable.
+"""
 
 import json
-import subprocess
 import urllib.request
 
 import pytest
@@ -9,42 +13,14 @@ import pytest
 pytestmark = [pytest.mark.integration, pytest.mark.annotation]
 
 
-def test_stack_boots_healthy() -> None:
-    """Make setup brings all services to healthy state."""
-    subprocess.run(["make", "setup"], check=True, capture_output=True, timeout=120)
-    try:
-        resp = urllib.request.urlopen("http://localhost:6900/api/docs", timeout=10)
-        assert resp.status == 200, f"Argilla docs returned {resp.status}"
-    finally:
-        subprocess.run(["make", "teardown"], check=True, capture_output=True, timeout=60)
-
-
-def test_argilla_api_authenticated() -> None:
-    """Argilla API responds to authenticated requests."""
-    subprocess.run(["make", "setup"], check=True, capture_output=True, timeout=120)
-    try:
-        req = urllib.request.Request(
-            "http://localhost:6900/api/v1/me",
-            headers={"X-Argilla-Api-Key": "argilla.apikey"},
-        )
-        resp = urllib.request.urlopen(req, timeout=10)
+def test_argilla_api_authenticated_as_owner() -> None:
+    """Argilla API accepts the configured API key and returns the owner account."""
+    req = urllib.request.Request(
+        "http://localhost:6900/api/v1/me",
+        headers={"X-Argilla-Api-Key": "argilla.apikey"},
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:
         assert resp.status == 200
         data = json.loads(resp.read())
-        assert data["username"] == "argilla"
-        assert data["role"] == "owner"
-    finally:
-        subprocess.run(["make", "teardown"], check=True, capture_output=True, timeout=60)
-
-
-def test_teardown_removes_volumes() -> None:
-    """Make teardown removes containers and volumes for clean slate."""
-    subprocess.run(["make", "setup"], check=True, capture_output=True, timeout=120)
-    subprocess.run(["make", "teardown"], check=True, capture_output=True, timeout=60)
-
-    result = subprocess.run(
-        ["docker", "compose", "-f", "deploy/annotation/docker-compose.dev.yml", "ps", "-q"],
-        capture_output=True,
-        text=True,
-        timeout=10,
-    )
-    assert result.stdout.strip() == "", "Containers still running after teardown"
+    assert data["username"] == "argilla"
+    assert data["role"] == "owner"


### PR DESCRIPTION
## Goal

1. the three tests in `tests/integration/test_dev_stack_integration.py` all shell out to `make setup` / `make teardown` = targets that don't exist in the current Makefile, so every test would fail even with Docker running. 
2. they duplicate work that the preflight in #163 already does, and test fundamental (well-tested) docker primitives (rather than our added functionality) -> prune

## Scope

Delete stale tests, keep the one unique assertion that genuinely exercises our stack (authenticated API returns the expected owner payload).

## Implementation

Before: 3 tests × ~50 lines, each spinning up and tearing down the stack (~120s each) inside pytest.

After: 1 test × ~15 lines, asserting `/api/v1/me` returns `{username: argilla, role: owner}`. The preflight from #163 gates collection -> stack orchestration belongs in the Makefile (`make docker-up`, `make test-stack`), not pytest.

Dropped tests and rationale:

| Test | Why dropped |
|---|---|
| `test_stack_boots_healthy` | Redundant with preflight's `argilla_api` check |
| `test_argilla_api_authenticated` | Kept (renamed to `test_argilla_api_authenticated_as_owner`) |
| `test_teardown_removes_volumes` | Orchestration concern - `docker compose down -v` is a well-trusted primitive; (could fold into `make test-stack` if needed) |

## References

- Stacked on #163 (`test/annotation-stack-preflight`). Needs that to merge first. After #163 lands, rebase this onto `main`.