### PR TITLE
test(integration): function-scoped fixtures for order-independent annotation tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,14 @@ COMPOSE_FILE := deploy/annotation/docker-compose.dev.yml
 ENV_FILE     := deploy/annotation/.env
 ENV_EXAMPLE  := deploy/annotation/.env.dev.example
 
-.PHONY: docker-up docker-up-external-pg docker-up-external-es docker-up-external docker-down docker-stop docker-logs docker-status ensure-env lint type-check test-stack test test-integration test-all ci
+.PHONY: docker-up docker-down docker-stop docker-logs docker-status ensure-env lint type-check test-stack test test-integration test-all ci
 
-# Profiles: all-bundled (default), external-pg (ext Postgres), external-es (ext ES), no profile (all external)
+# Compose profile options for the multi-target docker-* commands. Profiles
+# determine which backing services run as containers vs. expected externally.
 ALL_PROFILES := --profile all-bundled --profile external-pg --profile external-es
+
+# Default profile for `make docker-up`. 
+PROFILE ?= all-bundled
 
 # ── Docker / Argilla stack ───────────────────────────────────────────
 
@@ -15,26 +19,28 @@ ensure-env:
 		cp $(ENV_EXAMPLE) $(ENV_FILE); \
 	fi
 
-docker-up: ensure-env ## Start Argilla stack (all services bundled)
-	docker compose -f $(COMPOSE_FILE) --env-file $(ENV_FILE) --profile all-bundled up -d --pull always --wait --remove-orphans
-	@echo "Argilla is up at http://localhost:6900"
-
-docker-up-external-pg: ensure-env ## Start Argilla stack with external Postgres (ES + Redis bundled)
-	@. $(ENV_FILE) && test -n "$$ARGILLA_DATABASE_URL" || { echo "Error: ARGILLA_DATABASE_URL must be set for external Postgres"; exit 1; }
-	docker compose -f $(COMPOSE_FILE) --env-file $(ENV_FILE) --profile external-pg up -d --pull always --wait --remove-orphans
-	@echo "Argilla is up at http://localhost:6900 (external Postgres, bundled ES + Redis)"
-
-docker-up-external-es: ensure-env ## Start Argilla stack with external Elasticsearch (Postgres + Redis bundled)
-	@. $(ENV_FILE) && test -n "$$ARGILLA_ELASTICSEARCH" || { echo "Error: ARGILLA_ELASTICSEARCH must be set for external Elasticsearch"; exit 1; }
-	docker compose -f $(COMPOSE_FILE) --env-file $(ENV_FILE) --profile external-es up -d --pull always --wait --remove-orphans
-	@echo "Argilla is up at http://localhost:6900 (external Elasticsearch, bundled Postgres + Redis)"
-
-docker-up-external: ensure-env ## Start Argilla stack with all external backing services
-	@. $(ENV_FILE) && test -n "$$ARGILLA_DATABASE_URL" || { echo "Error: ARGILLA_DATABASE_URL must be set for external Postgres"; exit 1; }
-	@. $(ENV_FILE) && test -n "$$ARGILLA_ELASTICSEARCH" || { echo "Error: ARGILLA_ELASTICSEARCH must be set for external Elasticsearch"; exit 1; }
-	@. $(ENV_FILE) && test -n "$$ARGILLA_REDIS_URL" || { echo "Error: ARGILLA_REDIS_URL must be set for external Redis"; exit 1; }
-	docker compose -f $(COMPOSE_FILE) --env-file $(ENV_FILE) up -d --pull always --wait --remove-orphans
-	@echo "Argilla is up at http://localhost:6900 (all external backing services)"
+docker-up: ensure-env ## Start Argilla stack. Override profile: make docker-up PROFILE=external-pg
+# Default = all-bundled
+# Override on the command line: e.g. make docker-up PROFILE=external-pg
+# Valid values:
+#   all-bundled  — Argilla + Postgres + Elasticsearch + Redis all in containers (default)
+#   external-pg  — external Postgres (set ARGILLA_DATABASE_URL); ES + Redis bundled
+#   external-es  — external Elasticsearch (set ARGILLA_ELASTICSEARCH); Postgres + Redis bundled
+#   external     — all backing services external (set ARGILLA_DATABASE_URL, ARGILLA_ELASTICSEARCH, ARGILLA_REDIS_URL)
+	@case "$(PROFILE)" in \
+		all-bundled) PROFILE_FLAG="--profile all-bundled" ;; \
+		external-pg) PROFILE_FLAG="--profile external-pg"; \
+			. $(ENV_FILE) && test -n "$$ARGILLA_DATABASE_URL" || { echo "Error: ARGILLA_DATABASE_URL must be set for PROFILE=external-pg"; exit 1; } ;; \
+		external-es) PROFILE_FLAG="--profile external-es"; \
+			. $(ENV_FILE) && test -n "$$ARGILLA_ELASTICSEARCH" || { echo "Error: ARGILLA_ELASTICSEARCH must be set for PROFILE=external-es"; exit 1; } ;; \
+		external) PROFILE_FLAG=""; \
+			. $(ENV_FILE) && test -n "$$ARGILLA_DATABASE_URL" || { echo "Error: ARGILLA_DATABASE_URL must be set for PROFILE=external"; exit 1; } && \
+			. $(ENV_FILE) && test -n "$$ARGILLA_ELASTICSEARCH" || { echo "Error: ARGILLA_ELASTICSEARCH must be set for PROFILE=external"; exit 1; } && \
+			. $(ENV_FILE) && test -n "$$ARGILLA_REDIS_URL" || { echo "Error: ARGILLA_REDIS_URL must be set for PROFILE=external"; exit 1; } ;; \
+		*) echo "Error: unknown PROFILE '$(PROFILE)' (valid: all-bundled, external-pg, external-es, external)"; exit 1 ;; \
+	esac && \
+	docker compose -f $(COMPOSE_FILE) --env-file $(ENV_FILE) $$PROFILE_FLAG up -d --pull always --wait --remove-orphans
+	@echo "Argilla is up at http://localhost:6900 (PROFILE=$(PROFILE))"
 
 docker-down: ## Stop stack and remove volumes
 	docker compose -f $(COMPOSE_FILE) --env-file $(ENV_FILE) $(ALL_PROFILES) down -v

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,21 +2,66 @@
 
 import shutil
 import socket
+import subprocess
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
 
 import pytest
 
 ARGILLA_DEFAULT_HOST = "localhost"
 ARGILLA_DEFAULT_PORT = 6900
+ARGILLA_DEFAULT_API_KEY = "argilla.apikey"
 _CONNECT_TIMEOUT_S = 2
+_HTTP_TIMEOUT_S = 3
 
 
-def _docker_available() -> bool:
-    """Check whether Docker CLI is on PATH."""
+@dataclass(frozen=True)
+class AnnotationStackStatus:
+    """Result of progressive preflight checks for the annotation stack."""
+
+    docker_cli: bool
+    docker_daemon: bool
+    argilla_tcp: bool
+    argilla_api: bool
+
+    @property
+    def ready(self) -> bool:
+        return self.docker_cli and self.docker_daemon and self.argilla_tcp and self.argilla_api
+
+    @property
+    def skip_reason(self) -> str | None:
+        if not self.docker_cli:
+            return "Docker CLI not on PATH"
+        if not self.docker_daemon:
+            return "Docker daemon not running (try: open -a Docker)"
+        if not self.argilla_tcp:
+            return f"Argilla not reachable at {ARGILLA_DEFAULT_HOST}:{ARGILLA_DEFAULT_PORT} (try: make docker-up)"
+        if not self.argilla_api:
+            return (
+                f"Argilla API not responding at http://{ARGILLA_DEFAULT_HOST}:{ARGILLA_DEFAULT_PORT}"
+                " (stack may still be warming up)"
+            )
+        return None
+
+
+def _docker_cli_available() -> bool:
     return shutil.which("docker") is not None
 
 
-def _argilla_reachable() -> bool:
-    """Check whether the Argilla server is accepting connections."""
+def _docker_daemon_running() -> bool:
+    try:
+        result = subprocess.run(
+            ["docker", "info"],
+            capture_output=True,
+            timeout=_HTTP_TIMEOUT_S,
+        )
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return False
+
+
+def _argilla_tcp_open() -> bool:
     try:
         with socket.create_connection((ARGILLA_DEFAULT_HOST, ARGILLA_DEFAULT_PORT), timeout=_CONNECT_TIMEOUT_S):
             return True
@@ -24,19 +69,68 @@ def _argilla_reachable() -> bool:
         return False
 
 
+def _argilla_api_healthy() -> bool:
+    try:
+        req = urllib.request.Request(
+            f"http://{ARGILLA_DEFAULT_HOST}:{ARGILLA_DEFAULT_PORT}/api/v1/me",
+            headers={"X-Argilla-Api-Key": ARGILLA_DEFAULT_API_KEY},
+        )
+        with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_S) as resp:
+            return resp.status == 200
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError, TimeoutError):
+        return False
+
+
+def _check_annotation_stack() -> AnnotationStackStatus:
+    docker_cli = _docker_cli_available()
+    docker_daemon = docker_cli and _docker_daemon_running()
+    argilla_tcp = docker_daemon and _argilla_tcp_open()
+    argilla_api = argilla_tcp and _argilla_api_healthy()
+    return AnnotationStackStatus(
+        docker_cli=docker_cli,
+        docker_daemon=docker_daemon,
+        argilla_tcp=argilla_tcp,
+        argilla_api=argilla_api,
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Run annotation stack preflight once at session start, cache on config."""
+    config._annotation_stack_status = _check_annotation_stack()  # type: ignore[attr-defined]
+
+
+def pytest_report_header(config: pytest.Config) -> list[str]:
+    """Print annotation stack status once at session start."""
+    status: AnnotationStackStatus = config._annotation_stack_status  # type: ignore[attr-defined]
+
+    def _mark(ok: bool) -> str:
+        return "ok" if ok else "--"
+
+    line = (
+        f"annotation stack: "
+        f"docker-cli [{_mark(status.docker_cli)}] "
+        f"daemon [{_mark(status.docker_daemon)}] "
+        f"argilla-tcp [{_mark(status.argilla_tcp)}] "
+        f"argilla-api [{_mark(status.argilla_api)}]"
+    )
+    if not status.ready:
+        line += f" — annotation integration tests will be skipped ({status.skip_reason})"
+    return [line]
+
+
+@pytest.fixture(scope="session")
+def annotation_stack_status(pytestconfig: pytest.Config) -> AnnotationStackStatus:
+    """Session-wide preflight result for the annotation stack."""
+    return pytestconfig._annotation_stack_status  # type: ignore[attr-defined]
+
+
 @pytest.fixture(autouse=True)
-def _require_integration_stack(request: pytest.FixtureRequest) -> None:
-    """Skip annotation interface integration tests when prerequisites are missing.
-
-    Checks (in order):
-    1. Docker CLI is on PATH
-    2. Argilla server is reachable on localhost:6900
-
-    Fails fast with a clear message rather than hanging on connection timeouts.
-    """
+def _require_annotation_stack(
+    request: pytest.FixtureRequest,
+    annotation_stack_status: AnnotationStackStatus,
+) -> None:
+    """Skip annotation-marked tests when the stack is not ready."""
     if not request.node.get_closest_marker("annotation"):
         return
-    if not _docker_available():
-        pytest.skip("Docker CLI not available")
-    if not _argilla_reachable():
-        pytest.skip(f"Argilla not reachable at {ARGILLA_DEFAULT_HOST}:{ARGILLA_DEFAULT_PORT}")
+    if not annotation_stack_status.ready:
+        pytest.skip(annotation_stack_status.skip_reason or "annotation stack not ready")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,23 +99,56 @@ def pytest_configure(config: pytest.Config) -> None:
     config._annotation_stack_status = _check_annotation_stack()  # type: ignore[attr-defined]
 
 
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Count annotation-marked tests so we can report skip totals at end-of-run."""
+    config._annotation_marked_count = sum(  # type: ignore[attr-defined]
+        1 for item in items if item.get_closest_marker("annotation")
+    )
+
+
+def _stack_layer_lines(status: AnnotationStackStatus) -> list[tuple[str, bool]]:
+    return [
+        ("docker-cli", status.docker_cli),
+        ("daemon", status.docker_daemon),
+        ("argilla-tcp", status.argilla_tcp),
+        ("argilla-api", status.argilla_api),
+    ]
+
+
 def pytest_report_header(config: pytest.Config) -> list[str]:
     """Print annotation stack status once at session start."""
     status: AnnotationStackStatus = config._annotation_stack_status  # type: ignore[attr-defined]
-
-    def _mark(ok: bool) -> str:
-        return "ok" if ok else "--"
-
-    line = (
-        f"annotation stack: "
-        f"docker-cli [{_mark(status.docker_cli)}] "
-        f"daemon [{_mark(status.docker_daemon)}] "
-        f"argilla-tcp [{_mark(status.argilla_tcp)}] "
-        f"argilla-api [{_mark(status.argilla_api)}]"
-    )
+    marks = " ".join(f"{name} [{'ok' if ok else '--'}]" for name, ok in _stack_layer_lines(status))
+    line = f">>> annotation stack: {marks}"
     if not status.ready:
-        line += f" — annotation integration tests will be skipped ({status.skip_reason})"
+        line += f"  (skipping integration: {status.skip_reason})"
     return [line]
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config: pytest.Config) -> None:
+    """Re-surface the stack status at end-of-run when integration was skipped."""
+    status: AnnotationStackStatus = config._annotation_stack_status  # type: ignore[attr-defined]
+    if status.ready:
+        return
+    skipped = getattr(config, "_annotation_marked_count", 0)
+    if not skipped:
+        return
+    tr = terminalreporter
+    tr.write_sep("=", "ANNOTATION STACK SKIPPED", red=True, bold=True)
+    tr.write_line(f"{skipped} annotation integration tests were skipped: {status.skip_reason}")
+    tr.write_line("")
+    tr.write_line("Status:")
+    failed_marked = False
+    for name, ok in _stack_layer_lines(status):
+        marker = "[ok]" if ok else "[--]"
+        suffix = ""
+        if not ok and not failed_marked:
+            suffix = "  <- failed here"
+            failed_marked = True
+        tr.write_line(f"  {name:<12} {marker}{suffix}")
+    tr.write_line("")
+    tr.write_line("To run integration tests: open -a Docker && make docker-up && make test-all")
+    tr.write_sep("=", red=True, bold=True)
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/_argilla_cleanup.py
+++ b/tests/integration/_argilla_cleanup.py
@@ -1,0 +1,19 @@
+"""Test helpers for clearing Argilla workspace state between integration tests.
+
+Argilla refuses to delete a workspace while any dataset is linked. Tests that
+exercise full teardown can leave orphan datasets behind across runs, so this
+purge runs *before* `teardown_resources` in test fixtures to keep workspaces
+deletable. Production callers should not need this — they own their dataset
+ids and clean up via `teardown_resources(settings)`.
+"""
+
+import argilla as rg
+
+
+def purge_workspace_datasets(client: rg.Argilla, ws_base: str) -> None:
+    """Delete every dataset in workspace `ws_base`. No-op if workspace is missing."""
+    workspace = client.workspaces(ws_base)
+    if workspace is None:
+        return
+    for dataset in list(workspace.datasets):
+        dataset.delete()

--- a/tests/integration/test_annotation_import.py
+++ b/tests/integration/test_annotation_import.py
@@ -35,7 +35,9 @@ def _make_raw(n_chunks: int = 2, *, language: str | None = "de") -> dict:
 
 
 @pytest.fixture(scope="module")
-def client() -> rg.Argilla:
+def client(annotation_stack_status) -> rg.Argilla:
+    if not annotation_stack_status.ready:
+        pytest.skip(annotation_stack_status.skip_reason or "annotation stack not ready")
     return rg.Argilla(api_url=_API_URL, api_key=_API_KEY)
 
 

--- a/tests/integration/test_annotation_import.py
+++ b/tests/integration/test_annotation_import.py
@@ -1,7 +1,11 @@
 """Integration tests for annotation import against a live Argilla server.
 
 Run with: pytest tests/integration/test_annotation_import.py -m "integration and annotation" -v
-Requires: make setup (Argilla stack running on localhost:6900)
+Requires: Argilla stack running on localhost:6900 (make docker-up).
+
+Each test runs against a clean Argilla state — workspaces and datasets are
+reset before and after every test. Tests are independently runnable
+(`pytest -k <name>`) and order-independent.
 """
 
 import argilla as rg
@@ -42,20 +46,18 @@ def client(annotation_stack_status) -> rg.Argilla:
     return rg.Argilla(api_url=_API_URL, api_key=_API_KEY)
 
 
-@pytest.fixture(autouse=True, scope="module")
+@pytest.fixture(autouse=True)
 def clean_environment(client: rg.Argilla):
-    """Tear down and re-setup environment before/after all tests.
+    """Reset workspaces and datasets around every test for full isolation.
 
-    Orphan datasets from earlier runs are purged first — Argilla blocks
-    workspace deletion while any dataset is linked.
+    Orphan datasets from earlier runs are purged before teardown — Argilla
+    blocks workspace deletion while any dataset is linked.
     """
-    teardown_resources(client, _SETTINGS)
     for ws_base in AnnotationSettings().workspace_dataset_map:
         purge_workspace_datasets(client, ws_base)
     teardown_resources(client, AnnotationSettings())
     setup_workspaces(client, _SETTINGS)
     yield
-    teardown_resources(client, _SETTINGS)
     for ws_base in AnnotationSettings().workspace_dataset_map:
         purge_workspace_datasets(client, ws_base)
     teardown_resources(client, AnnotationSettings())
@@ -169,21 +171,11 @@ def test_invalid_records_skipped_with_errors(client: rg.Argilla) -> None:
 def test_dataset_auto_creation(client: rg.Argilla) -> None:
     """Import auto-creates datasets when they don't exist."""
     auto_id = "autotest"
-    auto_settings = AnnotationSettings(dataset_id=auto_id)
 
-    # Clean up any prior run
-    teardown_resources(client, auto_settings)
-
-    # Import without prior setup_datasets — datasets should be auto-created
     result = import_records([_make_raw(1)], dataset_id=auto_id, **_CREDS)
 
     assert result.total_records == 1
     assert result.errors == []
-
-    # Datasets exist
     assert client.datasets(f"retrieval_{auto_id}", workspace="retrieval") is not None
     assert client.datasets(f"grounding_{auto_id}", workspace="grounding") is not None
     assert client.datasets(f"generation_{auto_id}", workspace="generation") is not None
-
-    # Clean up
-    teardown_resources(client, auto_settings)

--- a/tests/integration/test_annotation_import.py
+++ b/tests/integration/test_annotation_import.py
@@ -10,6 +10,7 @@ import pytest
 from pragmata.api.annotation_import import ImportResult, import_records
 from pragmata.core.annotation.setup import setup_workspaces, teardown_resources
 from pragmata.core.settings.annotation_settings import AnnotationSettings
+from tests.integration._argilla_cleanup import purge_workspace_datasets
 
 pytestmark = [pytest.mark.integration, pytest.mark.annotation]
 
@@ -43,12 +44,20 @@ def client(annotation_stack_status) -> rg.Argilla:
 
 @pytest.fixture(autouse=True, scope="module")
 def clean_environment(client: rg.Argilla):
-    """Tear down and re-setup environment before/after all tests."""
+    """Tear down and re-setup environment before/after all tests.
+
+    Orphan datasets from earlier runs are purged first — Argilla blocks
+    workspace deletion while any dataset is linked.
+    """
     teardown_resources(client, _SETTINGS)
+    for ws_base in AnnotationSettings().workspace_dataset_map:
+        purge_workspace_datasets(client, ws_base)
     teardown_resources(client, AnnotationSettings())
     setup_workspaces(client, _SETTINGS)
     yield
     teardown_resources(client, _SETTINGS)
+    for ws_base in AnnotationSettings().workspace_dataset_map:
+        purge_workspace_datasets(client, ws_base)
     teardown_resources(client, AnnotationSettings())
 
 

--- a/tests/integration/test_annotation_setup.py
+++ b/tests/integration/test_annotation_setup.py
@@ -14,6 +14,7 @@ from pragmata.core.annotation.setup import (
     teardown_resources,
 )
 from pragmata.core.settings.annotation_settings import AnnotationSettings, UserSpec
+from tests.integration._argilla_cleanup import purge_workspace_datasets
 
 pytestmark = [pytest.mark.integration, pytest.mark.annotation]
 
@@ -33,9 +34,17 @@ def client(annotation_stack_status) -> rg.Argilla:
 
 @pytest.fixture(autouse=True, scope="module")
 def clean_slate(client: rg.Argilla):
-    """Tear down before and after the full module so tests start and end clean."""
+    """Tear down before and after the full module so tests start and end clean.
+
+    Orphan datasets from earlier runs are purged first — Argilla blocks
+    workspace deletion while any dataset is linked.
+    """
+    for ws_base in _DEFAULT_SETTINGS.workspace_dataset_map:
+        purge_workspace_datasets(client, ws_base)
     teardown_resources(client, _DEFAULT_SETTINGS)
     yield
+    for ws_base in _DEFAULT_SETTINGS.workspace_dataset_map:
+        purge_workspace_datasets(client, ws_base)
     teardown_resources(client, _DEFAULT_SETTINGS)
 
 

--- a/tests/integration/test_annotation_setup.py
+++ b/tests/integration/test_annotation_setup.py
@@ -25,7 +25,9 @@ _DEFAULT_SETTINGS = AnnotationSettings()
 
 
 @pytest.fixture(scope="module")
-def client() -> rg.Argilla:
+def client(annotation_stack_status) -> rg.Argilla:
+    if not annotation_stack_status.ready:
+        pytest.skip(annotation_stack_status.skip_reason or "annotation stack not ready")
     return rg.Argilla(api_url=_API_URL, api_key=_API_KEY)
 
 

--- a/tests/integration/test_annotation_setup.py
+++ b/tests/integration/test_annotation_setup.py
@@ -1,7 +1,11 @@
 """Integration tests for annotation setup against a live Argilla server.
 
 Run with: pytest tests/integration/test_annotation_setup.py -m "integration and annotation" -v
-Requires: make setup (Argilla stack running on localhost:6900)
+Requires: Argilla stack running on localhost:6900 (make docker-up).
+
+Each test runs against a clean Argilla state — workspaces, datasets, and the
+test user are reset before and after every test. Tests are independently
+runnable (`pytest -k <name>`) and order-independent.
 """
 
 import argilla as rg
@@ -32,20 +36,30 @@ def client(annotation_stack_status) -> rg.Argilla:
     return rg.Argilla(api_url=_API_URL, api_key=_API_KEY)
 
 
-@pytest.fixture(autouse=True, scope="module")
-def clean_slate(client: rg.Argilla):
-    """Tear down before and after the full module so tests start and end clean.
+def _purge_test_user(client: rg.Argilla) -> None:
+    user = client.users(_TEST_USER)
+    if user is not None:
+        user.delete()
 
-    Orphan datasets from earlier runs are purged first — Argilla blocks
-    workspace deletion while any dataset is linked.
+
+@pytest.fixture(autouse=True)
+def clean_slate(client: rg.Argilla):
+    """Reset Argilla state (workspaces, datasets, test user) around every test.
+
+    Orphan datasets from earlier runs are purged before teardown — Argilla
+    blocks workspace deletion while any dataset is linked. teardown_resources
+    intentionally leaves users intact in production, so we purge the test
+    user explicitly to keep tests independent.
     """
     for ws_base in _DEFAULT_SETTINGS.workspace_dataset_map:
         purge_workspace_datasets(client, ws_base)
     teardown_resources(client, _DEFAULT_SETTINGS)
+    _purge_test_user(client)
     yield
     for ws_base in _DEFAULT_SETTINGS.workspace_dataset_map:
         purge_workspace_datasets(client, ws_base)
     teardown_resources(client, _DEFAULT_SETTINGS)
+    _purge_test_user(client)
 
 
 # ---------------------------------------------------------------------------
@@ -54,24 +68,19 @@ def clean_slate(client: rg.Argilla):
 
 
 def test_setup_creates_workspaces(client: rg.Argilla) -> None:
-    teardown_resources(client, _DEFAULT_SETTINGS)
-
     result = setup_workspaces(client, _DEFAULT_SETTINGS)
 
     assert isinstance(result, SetupResult)
-
-    # 3 workspaces (one per task)
     assert client.workspaces("retrieval") is not None
     assert client.workspaces("grounding") is not None
     assert client.workspaces("generation") is not None
-
-    # Result accounting
     assert set(result.created_workspaces) == {"retrieval", "grounding", "generation"}
     assert result.skipped_workspaces == []
 
 
 def test_idempotent_rerun(client: rg.Argilla) -> None:
-    # Workspaces already exist from prior test — re-run should skip all
+    setup_workspaces(client, _DEFAULT_SETTINGS)
+
     result = setup_workspaces(client, _DEFAULT_SETTINGS)
 
     assert result.created_workspaces == []
@@ -79,6 +88,8 @@ def test_idempotent_rerun(client: rg.Argilla) -> None:
 
 
 def test_user_provisioning(client: rg.Argilla) -> None:
+    setup_workspaces(client, _DEFAULT_SETTINGS)
+
     result = provision_users(
         client,
         [UserSpec(username=_TEST_USER, role="annotator", workspaces=["retrieval"])],
@@ -88,26 +99,24 @@ def test_user_provisioning(client: rg.Argilla) -> None:
     assert _TEST_USER in result.created_users
     assert _TEST_USER in result.generated_passwords
     assert len(result.generated_passwords[_TEST_USER]) == 16
-
-    # User exists in Argilla
-    user = client.users(_TEST_USER)
-    assert user is not None
+    assert client.users(_TEST_USER) is not None
 
 
 def test_user_workspace_reconciliation_on_rerun(client: rg.Argilla) -> None:
     """Rerunning provision_users assigns existing user to newly-requested workspace."""
-    # First run: user in retrieval only
+    setup_workspaces(client, _DEFAULT_SETTINGS)
     provision_users(
         client,
         [UserSpec(username=_TEST_USER, role="annotator", workspaces=["retrieval"])],
         _DEFAULT_SETTINGS,
     )
-    # Second run: user now also in grounding
+
     provision_users(
         client,
         [UserSpec(username=_TEST_USER, role="annotator", workspaces=["retrieval", "grounding"])],
         _DEFAULT_SETTINGS,
     )
+
     ws_grounding = client.workspaces("grounding")
     assert ws_grounding is not None
     user = client.users(_TEST_USER)
@@ -115,6 +124,7 @@ def test_user_workspace_reconciliation_on_rerun(client: rg.Argilla) -> None:
 
 
 def test_teardown_retains_user_accounts(client: rg.Argilla) -> None:
+    setup_workspaces(client, _DEFAULT_SETTINGS)
     provision_users(
         client,
         [UserSpec(username=_TEST_USER, role="annotator", workspaces=["retrieval"])],
@@ -123,16 +133,16 @@ def test_teardown_retains_user_accounts(client: rg.Argilla) -> None:
 
     teardown_resources(client, _DEFAULT_SETTINGS)
 
-    # Workspaces gone
     assert client.workspaces("retrieval") is None
     assert client.workspaces("grounding") is None
     assert client.workspaces("generation") is None
-
-    # User still exists
     assert client.users(_TEST_USER) is not None
 
 
 def test_rerun_after_teardown(client: rg.Argilla) -> None:
+    setup_workspaces(client, _DEFAULT_SETTINGS)
+    teardown_resources(client, _DEFAULT_SETTINGS)
+
     result = setup_workspaces(client, _DEFAULT_SETTINGS)
 
     assert set(result.created_workspaces) == {"retrieval", "grounding", "generation"}
@@ -141,14 +151,11 @@ def test_rerun_after_teardown(client: rg.Argilla) -> None:
 
 def test_scoped_teardown_preserves_workspaces(client: rg.Argilla) -> None:
     """Teardown with dataset_id only deletes matching datasets, not workspaces."""
-    teardown_resources(client, _DEFAULT_SETTINGS)
     setup_workspaces(client, _DEFAULT_SETTINGS)
 
-    # Scoped teardown with a dataset_id should not delete workspaces
     scoped_settings = AnnotationSettings(dataset_id="run1")
     teardown_resources(client, scoped_settings)
 
-    # Workspaces still exist
     assert client.workspaces("retrieval") is not None
     assert client.workspaces("grounding") is not None
     assert client.workspaces("generation") is not None

--- a/tests/integration/test_dev_stack_integration.py
+++ b/tests/integration/test_dev_stack_integration.py
@@ -1,7 +1,11 @@
-"""Integration tests for the Docker Compose dev stack (requires Docker)."""
+"""Integration tests for the Argilla dev stack.
+
+Requires the stack to be running (make docker-up). The annotation-stack
+preflight in tests/conftest.py gates collection, so these tests skip
+cleanly when the stack is unavailable.
+"""
 
 import json
-import subprocess
 import urllib.request
 
 import pytest
@@ -9,42 +13,14 @@ import pytest
 pytestmark = [pytest.mark.integration, pytest.mark.annotation]
 
 
-def test_stack_boots_healthy() -> None:
-    """Make setup brings all services to healthy state."""
-    subprocess.run(["make", "setup"], check=True, capture_output=True, timeout=120)
-    try:
-        resp = urllib.request.urlopen("http://localhost:6900/api/docs", timeout=10)
-        assert resp.status == 200, f"Argilla docs returned {resp.status}"
-    finally:
-        subprocess.run(["make", "teardown"], check=True, capture_output=True, timeout=60)
-
-
-def test_argilla_api_authenticated() -> None:
-    """Argilla API responds to authenticated requests."""
-    subprocess.run(["make", "setup"], check=True, capture_output=True, timeout=120)
-    try:
-        req = urllib.request.Request(
-            "http://localhost:6900/api/v1/me",
-            headers={"X-Argilla-Api-Key": "argilla.apikey"},
-        )
-        resp = urllib.request.urlopen(req, timeout=10)
+def test_argilla_api_authenticated_as_owner() -> None:
+    """Argilla API accepts the configured API key and returns the owner account."""
+    req = urllib.request.Request(
+        "http://localhost:6900/api/v1/me",
+        headers={"X-Argilla-Api-Key": "argilla.apikey"},
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:
         assert resp.status == 200
         data = json.loads(resp.read())
-        assert data["username"] == "argilla"
-        assert data["role"] == "owner"
-    finally:
-        subprocess.run(["make", "teardown"], check=True, capture_output=True, timeout=60)
-
-
-def test_teardown_removes_volumes() -> None:
-    """Make teardown removes containers and volumes for clean slate."""
-    subprocess.run(["make", "setup"], check=True, capture_output=True, timeout=120)
-    subprocess.run(["make", "teardown"], check=True, capture_output=True, timeout=60)
-
-    result = subprocess.run(
-        ["docker", "compose", "-f", "deploy/annotation/docker-compose.dev.yml", "ps", "-q"],
-        capture_output=True,
-        text=True,
-        timeout=10,
-    )
-    assert result.stdout.strip() == "", "Containers still running after teardown"
+    assert data["username"] == "argilla"
+    assert data["role"] == "owner"


### PR DESCRIPTION
## Goal

Make the annotation integration tests truly order-independent. They were structured as an implicit scenario chain (`scope="module"` fixtures, each test depending on what the previous one left in Argilla), which broke whenever you ran `pytest -k <one_test>` or in any order other than the alphabetical default.

## Scope

Both `test_annotation_setup.py` and `test_annotation_import.py`:

- Change autouse cleanup fixtures from `scope="module"` to function scope.
- Each test now sets up its own preconditions (e.g. tests that need workspaces call `setup_workspaces` themselves rather than relying on a previous test).
- `test_annotation_setup.py` purges the test user account around every test (production `teardown_resources` deliberately preserves users, so test isolation needs an explicit purge).
- Drop redundant per-test cleanup that the autouse fixture now subsumes (`test_dataset_auto_creation` no longer manually tears down).
- Drop the unused first `teardown_resources(client, _SETTINGS)` call in `test_annotation_import.py` — a full teardown (empty `dataset_id`) clears every dataset in the workspace anyway, so the scoped teardown beforehand is redundant.

## Implementation

Setup fixture before:
```python
@pytest.fixture(autouse=True, scope="module")
def clean_slate(client):
    teardown_resources(client, _DEFAULT_SETTINGS)
    yield
    teardown_resources(client, _DEFAULT_SETTINGS)
```

After (combines #165's orphan-purge with this PR's user-purge + function scope):
```python
@pytest.fixture(autouse=True)  # function scope (default)
def clean_slate(client):
    for ws_base in _DEFAULT_SETTINGS.workspace_dataset_map:
        purge_workspace_datasets(client, ws_base)
    teardown_resources(client, _DEFAULT_SETTINGS)
    _purge_test_user(client)
    yield
    for ws_base in _DEFAULT_SETTINGS.workspace_dataset_map:
        purge_workspace_datasets(client, ws_base)
    teardown_resources(client, _DEFAULT_SETTINGS)
    _purge_test_user(client)
```

Each test then explicitly bootstraps its preconditions:

```python
def test_idempotent_rerun(client):
    setup_workspaces(client, _DEFAULT_SETTINGS)  # explicit, not implicit

    result = setup_workspaces(client, _DEFAULT_SETTINGS)

    assert result.created_workspaces == []
```

## Trade-offs

Slower: each test re-creates workspaces (~3-5x slower, but still seconds, not minutes — each Argilla op is HTTP). Worth it for proper isolation. Alternative would be folding the seven setup tests into a single stateful scenario test, but the tests are answering distinct questions about library functions, not narrating a user workflow — function scope is the right idiom.

## Testing

- `pytest tests/integration/test_annotation_setup.py tests/integration/test_annotation_import.py -m "integration and annotation"` (Docker up): **14 passed**, no pre-existing-state required.
- All 7 setup tests pass individually (`pytest -k <name>`).
- All 7 import tests pass when reordered or run individually.
- Pytest's standard ordering, reverse ordering, and arbitrary subsets all green.

## References

- Stacked on #165 (uses `purge_workspace_datasets` helper introduced there).
- Surfaced by the preflight in #163.