### PR TITLE
refactor(makefile): consolidate docker-up variants behind PROFILE param

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,19 +2,13 @@ COMPOSE_FILE := deploy/annotation/docker-compose.dev.yml
 ENV_FILE     := deploy/annotation/.env
 ENV_EXAMPLE  := deploy/annotation/.env.dev.example
 
-.PHONY: docker-up docker-down docker-stop docker-logs docker-status ensure-env lint type-check test-stack test test-integration test-all ci
+MAKE .PHONY: docker-up docker-down docker-stop docker-logs docker-status ensure-env lint type-check test-stack test test-integration test-all ci
 
 # Compose profile options for the multi-target docker-* commands. Profiles
 # determine which backing services run as containers vs. expected externally.
 ALL_PROFILES := --profile all-bundled --profile external-pg --profile external-es
 
-# Default profile for `make docker-up`. Override on the command line:
-#   make docker-up PROFILE=external-pg
-# Valid values:
-#   all-bundled  — Argilla + Postgres + Elasticsearch + Redis all in containers (default)
-#   external-pg  — external Postgres (set ARGILLA_DATABASE_URL); ES + Redis bundled
-#   external-es  — external Elasticsearch (set ARGILLA_ELASTICSEARCH); Postgres + Redis bundled
-#   external     — all backing services external (set ARGILLA_DATABASE_URL, ARGILLA_ELASTICSEARCH, ARGILLA_REDIS_URL)
+# Default profile for `make docker-up`. 
 PROFILE ?= all-bundled
 
 # ── Docker / Argilla stack ───────────────────────────────────────────
@@ -26,6 +20,13 @@ ensure-env:
 	fi
 
 docker-up: ensure-env ## Start Argilla stack. Override profile: make docker-up PROFILE=external-pg
+# Default = all-bundled
+# Override on the command line: e.g. make docker-up PROFILE=external-pg
+# Valid values:
+#   all-bundled  — Argilla + Postgres + Elasticsearch + Redis all in containers (default)
+#   external-pg  — external Postgres (set ARGILLA_DATABASE_URL); ES + Redis bundled
+#   external-es  — external Elasticsearch (set ARGILLA_ELASTICSEARCH); Postgres + Redis bundled
+#   external     — all backing services external (set ARGILLA_DATABASE_URL, ARGILLA_ELASTICSEARCH, ARGILLA_REDIS_URL)
 	@case "$(PROFILE)" in \
 		all-bundled) PROFILE_FLAG="--profile all-bundled" ;; \
 		external-pg) PROFILE_FLAG="--profile external-pg"; \

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ COMPOSE_FILE := deploy/annotation/docker-compose.dev.yml
 ENV_FILE     := deploy/annotation/.env
 ENV_EXAMPLE  := deploy/annotation/.env.dev.example
 
-MAKE .PHONY: docker-up docker-down docker-stop docker-logs docker-status ensure-env lint type-check test-stack test test-integration test-all ci
+.PHONY: docker-up docker-down docker-stop docker-logs docker-status ensure-env lint type-check test-stack test test-integration test-all ci
 
 # Compose profile options for the multi-target docker-* commands. Profiles
 # determine which backing services run as containers vs. expected externally.

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,20 @@ COMPOSE_FILE := deploy/annotation/docker-compose.dev.yml
 ENV_FILE     := deploy/annotation/.env
 ENV_EXAMPLE  := deploy/annotation/.env.dev.example
 
-.PHONY: docker-up docker-up-external-pg docker-up-external-es docker-up-external docker-down docker-stop docker-logs docker-status ensure-env lint type-check test-stack test test-integration test-all ci
+.PHONY: docker-up docker-down docker-stop docker-logs docker-status ensure-env lint type-check test-stack test test-integration test-all ci
 
-# Profiles: all-bundled (default), external-pg (ext Postgres), external-es (ext ES), no profile (all external)
+# Compose profile options for the multi-target docker-* commands. Profiles
+# determine which backing services run as containers vs. expected externally.
 ALL_PROFILES := --profile all-bundled --profile external-pg --profile external-es
+
+# Default profile for `make docker-up`. Override on the command line:
+#   make docker-up PROFILE=external-pg
+# Valid values:
+#   all-bundled  — Argilla + Postgres + Elasticsearch + Redis all in containers (default)
+#   external-pg  — external Postgres (set ARGILLA_DATABASE_URL); ES + Redis bundled
+#   external-es  — external Elasticsearch (set ARGILLA_ELASTICSEARCH); Postgres + Redis bundled
+#   external     — all backing services external (set ARGILLA_DATABASE_URL, ARGILLA_ELASTICSEARCH, ARGILLA_REDIS_URL)
+PROFILE ?= all-bundled
 
 # ── Docker / Argilla stack ───────────────────────────────────────────
 
@@ -15,26 +25,21 @@ ensure-env:
 		cp $(ENV_EXAMPLE) $(ENV_FILE); \
 	fi
 
-docker-up: ensure-env ## Start Argilla stack (all services bundled)
-	docker compose -f $(COMPOSE_FILE) --env-file $(ENV_FILE) --profile all-bundled up -d --pull always --wait --remove-orphans
-	@echo "Argilla is up at http://localhost:6900"
-
-docker-up-external-pg: ensure-env ## Start Argilla stack with external Postgres (ES + Redis bundled)
-	@. $(ENV_FILE) && test -n "$$ARGILLA_DATABASE_URL" || { echo "Error: ARGILLA_DATABASE_URL must be set for external Postgres"; exit 1; }
-	docker compose -f $(COMPOSE_FILE) --env-file $(ENV_FILE) --profile external-pg up -d --pull always --wait --remove-orphans
-	@echo "Argilla is up at http://localhost:6900 (external Postgres, bundled ES + Redis)"
-
-docker-up-external-es: ensure-env ## Start Argilla stack with external Elasticsearch (Postgres + Redis bundled)
-	@. $(ENV_FILE) && test -n "$$ARGILLA_ELASTICSEARCH" || { echo "Error: ARGILLA_ELASTICSEARCH must be set for external Elasticsearch"; exit 1; }
-	docker compose -f $(COMPOSE_FILE) --env-file $(ENV_FILE) --profile external-es up -d --pull always --wait --remove-orphans
-	@echo "Argilla is up at http://localhost:6900 (external Elasticsearch, bundled Postgres + Redis)"
-
-docker-up-external: ensure-env ## Start Argilla stack with all external backing services
-	@. $(ENV_FILE) && test -n "$$ARGILLA_DATABASE_URL" || { echo "Error: ARGILLA_DATABASE_URL must be set for external Postgres"; exit 1; }
-	@. $(ENV_FILE) && test -n "$$ARGILLA_ELASTICSEARCH" || { echo "Error: ARGILLA_ELASTICSEARCH must be set for external Elasticsearch"; exit 1; }
-	@. $(ENV_FILE) && test -n "$$ARGILLA_REDIS_URL" || { echo "Error: ARGILLA_REDIS_URL must be set for external Redis"; exit 1; }
-	docker compose -f $(COMPOSE_FILE) --env-file $(ENV_FILE) up -d --pull always --wait --remove-orphans
-	@echo "Argilla is up at http://localhost:6900 (all external backing services)"
+docker-up: ensure-env ## Start Argilla stack. Override profile: make docker-up PROFILE=external-pg
+	@case "$(PROFILE)" in \
+		all-bundled) PROFILE_FLAG="--profile all-bundled" ;; \
+		external-pg) PROFILE_FLAG="--profile external-pg"; \
+			. $(ENV_FILE) && test -n "$$ARGILLA_DATABASE_URL" || { echo "Error: ARGILLA_DATABASE_URL must be set for PROFILE=external-pg"; exit 1; } ;; \
+		external-es) PROFILE_FLAG="--profile external-es"; \
+			. $(ENV_FILE) && test -n "$$ARGILLA_ELASTICSEARCH" || { echo "Error: ARGILLA_ELASTICSEARCH must be set for PROFILE=external-es"; exit 1; } ;; \
+		external) PROFILE_FLAG=""; \
+			. $(ENV_FILE) && test -n "$$ARGILLA_DATABASE_URL" || { echo "Error: ARGILLA_DATABASE_URL must be set for PROFILE=external"; exit 1; } && \
+			. $(ENV_FILE) && test -n "$$ARGILLA_ELASTICSEARCH" || { echo "Error: ARGILLA_ELASTICSEARCH must be set for PROFILE=external"; exit 1; } && \
+			. $(ENV_FILE) && test -n "$$ARGILLA_REDIS_URL" || { echo "Error: ARGILLA_REDIS_URL must be set for PROFILE=external"; exit 1; } ;; \
+		*) echo "Error: unknown PROFILE '$(PROFILE)' (valid: all-bundled, external-pg, external-es, external)"; exit 1 ;; \
+	esac && \
+	docker compose -f $(COMPOSE_FILE) --env-file $(ENV_FILE) $$PROFILE_FLAG up -d --pull always --wait --remove-orphans
+	@echo "Argilla is up at http://localhost:6900 (PROFILE=$(PROFILE))"
 
 docker-down: ## Stop stack and remove volumes
 	docker compose -f $(COMPOSE_FILE) --env-file $(ENV_FILE) $(ALL_PROFILES) down -v


### PR DESCRIPTION
## Goal

Replace four near-identical `docker-up*` Makefile targets with a single parameterised `make docker-up PROFILE=<name>`. Reduces duplication, makes the profile choice explicit at the call site, and aligns with the principle that the Makefile passes through to the underlying compose CLI rather than baking configuration into target names.

## Scope

`Makefile` only.

Before:
```makefile
docker-up
docker-up-external-pg
docker-up-external-es
docker-up
```

After:
```makefile
docker-up                                # defaults to PROFILE=all-bundled
make docker-up PROFILE=external-pg       # explicit override
make docker-up PROFILE=external-es
make docker-up PROFILE=external
```

## Implementation

- `PROFILE ?= all-bundled` makes `all-bundled` the default while allowing override on the command line.
- A single `case` statement in the recipe routes by `PROFILE`:
  - Sets the appropriate `--profile` flag (or empty for `external`).
  - Runs the env-var validation specific to that profile (`ARGILLA_DATABASE_URL` for `external-pg`, etc.).
- Unknown PROFILE values fail with a clear error listing the valid options.
- Top-of-file comment block documents the four valid values.
- `down/stop/logs/status` still use `$(ALL_PROFILES)` so they affect every profile's containers regardless of which one started the stack.

## Testing

- `make docker-up` (default) → starts stack as `all-bundled`. Argilla up at :6900 — verified.
- `make docker-up PROFILE=garbage` → `Error: unknown PROFILE 'garbage' (valid: all-bundled, external-pg, external-es, external)`, exit 1.
- `make docker-up PROFILE=external-pg` (without `ARGILLA_DATABASE_URL` in `.env`) → `Error: ARGILLA_DATABASE_URL must be set for PROFILE=external-pg`, exit 1.
- `make ci` green (598 passed, 39 deselected).
- `make test-all` green (637 passed).
- `tests/unit/test_dev_stack.py::test_makefile_defines_expected_targets` still passes — the unit test only pins canonical targets (`docker-up`, `docker-down`, etc.), not the variant targets that this PR removes.

## References

- Stacked on #166. Final PR in the integration-test cleanup chain.