### PR TITLE
feat(annotation): partial-overlap calibration / production split for IAA

### DIFF
--- a/src/pragmata/api/annotation_import.py
+++ b/src/pragmata/api/annotation_import.py
@@ -3,6 +3,7 @@
 import logging
 import os
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 
 from pragmata.api._error_log import error_log
@@ -10,10 +11,16 @@ from pragmata.core.annotation.client import resolve_argilla_client
 from pragmata.core.annotation.loaders import RecordInput, resolve_records
 from pragmata.core.annotation.record_builder import (
     RecordError,
+    assign_partitions,
     fan_out_records,
+    load_partition_manifest,
     validate_records,
+    write_partition_manifest,
 )
-from pragmata.core.paths.annotation_paths import resolve_annotation_paths
+from pragmata.core.paths.annotation_paths import (
+    resolve_annotation_paths,
+    resolve_import_paths,
+)
 from pragmata.core.paths.paths import WorkspacePaths
 from pragmata.core.settings.annotation_settings import AnnotationSettings
 from pragmata.core.settings.settings_base import UNSET, Unset, load_config_file, resolve_api_key
@@ -28,11 +35,17 @@ class ImportResult:
     Attributes:
         total_records: Number of raw dicts received as input.
         dataset_counts: Records submitted per dataset name.
+        calibration_count: Records routed to the calibration dataset.
+        production_count: Records routed to the production dataset.
+        calibration_fraction: Effective fraction in force this run.
         errors: Per-record validation failures (index + detail).
     """
 
     total_records: int
     dataset_counts: dict[str, int]
+    calibration_count: int = 0
+    production_count: int = 0
+    calibration_fraction: float = 0.0
     errors: list[RecordError] = field(default_factory=list)
 
 
@@ -45,18 +58,25 @@ def import_records(
     dataset_id: str | Unset = UNSET,
     base_dir: str | Path | Unset = UNSET,
     config_path: str | Path | Unset = UNSET,
+    calibration_fraction: float = 0.1,
 ) -> ImportResult:
-    """Validate and fan out records to the three Argilla annotation datasets.
+    """Validate and fan out records to per-purpose Argilla annotation datasets.
 
     Accepts raw dicts, file paths (JSON, JSONL, CSV), HuggingFace Datasets,
     or pandas DataFrames. File format is detected by extension or overridden
     via the format kwarg. All inputs are resolved to list[dict] before
     validation against the canonical import schema.
 
-    Valid records produce entries in retrieval (one per chunk), grounding
-    (one per pair), and generation (one per pair) datasets. Validation
-    failures are collected in ImportResult.errors — invalid records are
-    skipped, not raised.
+    Valid records are partitioned into calibration vs production buckets via
+    a deterministic record_uuid hash. Calibration records go to
+    ``task_<task>_calibration`` (overlap = ``calibration_min_submitted``),
+    production records go to ``task_<task>_production`` (overlap =
+    ``production_min_submitted``). The partition is locked across re-imports
+    via a manifest sidecar at
+    ``annotation/imports/{dataset_id}/partition.meta.json``.
+
+    Validation failures are collected in ImportResult.errors — invalid
+    records are skipped, not raised.
 
     Datasets are auto-created if they don't exist. Workspaces must already
     exist (call setup() first). Record IDs are derived from content hashes
@@ -76,10 +96,23 @@ def import_records(
         dataset_id: Suffix appended to dataset names for run scoping.
         base_dir: Workspace base directory. Defaults to cwd.
         config_path: Path to YAML config file for settings resolution.
+        calibration_fraction: Fraction of records routed to the calibration
+            dataset for this import. Default 0.1 (industry standard for IAA
+            pilots). Set to 0.0 for production-only batches; use a non-zero
+            value when starting a calibration phase or re-calibrating.
 
     Returns:
-        ImportResult with totals, per-dataset counts, and validation errors.
+        ImportResult with totals, per-dataset counts, partition counts, and
+        validation errors.
+
+    Raises:
+        ValueError: ``calibration_fraction`` is outside [0.0, 1.0], or is
+            > 0 when topology declares no calibration dataset for any task
+            receiving records.
     """
+    if not 0.0 <= calibration_fraction <= 1.0:
+        raise ValueError(f"calibration_fraction must be in [0.0, 1.0]; got {calibration_fraction}")
+
     raw = resolve_records(records, format=format)
     settings = AnnotationSettings.resolve(
         config=load_config_file(config_path) if isinstance(config_path, (str, Path)) else None,
@@ -90,18 +123,71 @@ def import_records(
             "base_dir": base_dir,
         },
     )
+
+    if calibration_fraction > 0.0:
+        missing = [
+            task.value
+            for task_overlaps in settings.workspace_dataset_map.values()
+            for task, overlap in task_overlaps.items()
+            if overlap.calibration_min_submitted is None
+        ]
+        if missing:
+            raise ValueError(
+                f"calibration_fraction={calibration_fraction} > 0 but topology has no "
+                f"calibration dataset for tasks: {sorted(set(missing))}. Either set "
+                f"calibration_fraction=0.0 or enable calibration in workspace_dataset_map."
+            )
+
     api_key = api_key if isinstance(api_key, str) else resolve_api_key("argilla")
     client = resolve_argilla_client(settings.argilla.api_url, api_key)
     workspace = WorkspacePaths.from_base_dir(settings.base_dir)
     paths = resolve_annotation_paths(workspace=workspace).ensure_dirs()
+    import_paths = resolve_import_paths(workspace=workspace, dataset_id=settings.dataset_id).ensure_dirs()
+
+    import_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%f")
+
     with error_log(paths.tool_root):
         validation = validate_records(raw)
         if validation.errors:
             logger.warning("Validation failed for %d of %d records", len(validation.errors), len(raw))
-        dataset_counts = fan_out_records(client, validation.valid, settings)
-    logger.info("Import complete: %d records across %d datasets", len(raw), len(dataset_counts))
+
+        manifest = load_partition_manifest(
+            import_paths.partition_manifest,
+            dataset_id=settings.dataset_id,
+            partition_seed=settings.calibration_partition_seed,
+        )
+        if manifest.partition_seed != settings.calibration_partition_seed:
+            logger.warning(
+                "calibration_partition_seed=%d differs from manifest's stored seed=%d; "
+                "using stored seed (existing assignments preserved, new records use stored seed)",
+                settings.calibration_partition_seed,
+                manifest.partition_seed,
+            )
+
+        assignments = assign_partitions(
+            validation.valid,
+            manifest=manifest,
+            fraction=calibration_fraction,
+            import_id=import_id,
+        )
+        write_partition_manifest(import_paths.partition_manifest, manifest)
+
+        dataset_counts, calibration_count, production_count = fan_out_records(
+            client, validation.valid, settings, assignments=assignments
+        )
+    logger.info(
+        "Import complete: %d records across %d datasets (calibration=%d, production=%d, fraction=%.3f)",
+        len(raw),
+        len(dataset_counts),
+        calibration_count,
+        production_count,
+        calibration_fraction,
+    )
     return ImportResult(
         total_records=len(raw),
         dataset_counts=dataset_counts,
+        calibration_count=calibration_count,
+        production_count=production_count,
+        calibration_fraction=calibration_fraction,
         errors=validation.errors,
     )

--- a/src/pragmata/api/annotation_setup.py
+++ b/src/pragmata/api/annotation_setup.py
@@ -20,7 +20,6 @@ def setup(
     *,
     api_url: str | Unset = UNSET,
     api_key: str | Unset = UNSET,
-    min_submitted: int | Unset = UNSET,
     base_dir: str | Path | Unset = UNSET,
     config_path: str | Path | Unset = UNSET,
 ) -> SetupResult:
@@ -31,7 +30,9 @@ def setup(
     workspaces. Existing resources are skipped.
 
     Datasets are not created here — they are auto-created on import,
-    scoped by dataset_id.
+    scoped by dataset_id. Per-task overlap (production and calibration
+    ``min_submitted``) is declared in
+    ``AnnotationSettings.workspace_dataset_map``.
 
     Settings are resolved from config file and/or keyword overrides. Omitted
     values fall through to config-file defaults, then built-in defaults.
@@ -44,7 +45,6 @@ def setup(
         users: User accounts to provision. Pass None to skip user setup.
         api_url: Argilla server URL.
         api_key: Argilla API key.
-        min_submitted: Minimum annotations required per record.
         base_dir: Workspace base directory. Defaults to cwd.
         config_path: Path to YAML config file for settings resolution.
 
@@ -56,7 +56,6 @@ def setup(
         env={"argilla": {"api_url": os.environ.get("ARGILLA_API_URL")}} if os.environ.get("ARGILLA_API_URL") else None,
         overrides={
             "argilla": {"api_url": api_url},
-            "min_submitted": min_submitted,
             "base_dir": base_dir,
         },
     )

--- a/src/pragmata/cli/commands/annotation.py
+++ b/src/pragmata/cli/commands/annotation.py
@@ -24,9 +24,6 @@ def setup_command(
     api_key: str | None = _api_key_opt,
     base_dir: str | None = _base_dir_opt,
     config: str | None = _config_opt,
-    min_submitted: int | None = typer.Option(
-        None, "--min-submitted", help="Minimum submitted annotations required per record before it is complete."
-    ),
     users_json: str | None = typer.Option(
         None,
         "--users",
@@ -36,7 +33,9 @@ def setup_command(
 ) -> None:
     """Create Argilla workspaces and (optionally) user accounts.
 
-    Datasets are created automatically on import, not here.
+    Datasets are created automatically on import, not here. Per-task overlap
+    (production and calibration ``min_submitted``) is configured via
+    ``workspace_dataset_map`` in the YAML config or ``AnnotationSettings``.
     """
     from pragmata import annotation
 
@@ -44,7 +43,6 @@ def setup_command(
         parse_user_specs(users_json),
         api_url=UNSET if api_url is None else api_url,
         api_key=UNSET if api_key is None else api_key,
-        min_submitted=UNSET if min_submitted is None else min_submitted,
         base_dir=UNSET if base_dir is None else base_dir,
         config_path=UNSET if config is None else config,
     )
@@ -88,10 +86,18 @@ def import_command(
     format: str | None = typer.Option(
         None, "--format", help="File format override (json, jsonl, csv). Auto-detected by default."
     ),
+    calibration_fraction: float = typer.Option(
+        0.1,
+        "--calibration-fraction",
+        help="Fraction of records routed to the calibration dataset for this batch. "
+        "Set to 0.0 for production-only batches.",
+    ),
 ) -> None:
     """Validate and import records into annotation datasets.
 
-    Datasets are auto-created if they don't exist.
+    Datasets are auto-created if they don't exist. Records are partitioned
+    deterministically into calibration vs production buckets; the partition
+    is locked across re-imports via a sidecar manifest scoped to ``dataset_id``.
     """
     from pragmata import annotation
 
@@ -103,8 +109,13 @@ def import_command(
         dataset_id=UNSET if dataset_id is None else dataset_id,
         base_dir=UNSET if base_dir is None else base_dir,
         config_path=UNSET if config is None else config,
+        calibration_fraction=calibration_fraction,
     )
     typer.echo(f"Total records: {result.total_records}")
+    typer.echo(
+        f"Calibration: {result.calibration_count}, "
+        f"production: {result.production_count} (fraction={result.calibration_fraction:.3f})"
+    )
     for ds, count in result.dataset_counts.items():
         typer.echo(f"  {ds}: {count}")
     if result.errors:

--- a/src/pragmata/core/annotation/argilla_task_definitions.py
+++ b/src/pragmata/core/annotation/argilla_task_definitions.py
@@ -6,7 +6,7 @@ core/settings/). They encode the annotation protocol (fields, questions, labels)
 and are hardcoded per ADR-0009.
 
 Distribution (min_submitted) is intentionally omitted — it is an operational
-setting controlled by AnnotationSettings.min_submitted and applied at
+setting controlled by AnnotationSettings.workspace_dataset_map and applied at
 dataset creation time.
 """
 
@@ -16,6 +16,7 @@ from string import Template
 
 import argilla as rg
 
+from pragmata.core.annotation.argilla_ops import apply_suffix
 from pragmata.core.schemas.annotation_task import DiscardReason, Task
 
 DATASET_NAMES: dict[Task, str] = {
@@ -23,6 +24,19 @@ DATASET_NAMES: dict[Task, str] = {
     Task.GROUNDING: "grounding",
     Task.GENERATION: "generation",
 }
+
+
+def dataset_name(task: Task, *, calibration: bool, dataset_id: str = "") -> str:
+    """Always-suffixed Argilla dataset name for a task and purpose.
+
+    Names are unconditional: production datasets are always
+    ``task_<task>_production`` and calibration datasets are always
+    ``task_<task>_calibration``. The ``dataset_id`` suffix is appended for
+    run-scoping when present.
+    """
+    base = DATASET_NAMES[task]
+    suffix = "_calibration" if calibration else "_production"
+    return apply_suffix(f"{base}{suffix}", dataset_id)
 
 
 def _collapsible_field(name: str, title: str, template_text: str) -> rg.CustomField:

--- a/src/pragmata/core/annotation/export_fetcher.py
+++ b/src/pragmata/core/annotation/export_fetcher.py
@@ -10,8 +10,7 @@ from uuid import UUID
 
 import argilla as rg
 
-from pragmata.core.annotation.argilla_ops import apply_suffix
-from pragmata.core.annotation.argilla_task_definitions import DATASET_NAMES
+from pragmata.core.annotation.argilla_task_definitions import dataset_name
 from pragmata.core.annotation.constraints import CONSTRAINT_CHECKERS
 from pragmata.core.schemas.annotation_export import (
     GenerationAnnotation,
@@ -100,20 +99,27 @@ def fetch_task(
     *,
     include_discarded: bool,
 ) -> list[tuple[AnnotationModel, list[str]]]:
-    """Fetch records for a task, build typed rows with constraint violations.
+    """Fetch records for a task across calibration and production datasets.
+
+    Iterates the production dataset (always present) and the calibration
+    dataset (when topology declares one for this task). Each row is tagged
+    with ``calibration: bool`` so downstream consumers can filter.
 
     By default returns only submitted responses; pass ``include_discarded=True``
     to also include responses the annotator discarded.
     """
-    dataset_name = apply_suffix(DATASET_NAMES[task], settings.dataset_id)
-
     workspace_name: str | None = None
-    for ws_base, tasks in settings.workspace_dataset_map.items():
-        if task in tasks:
+    overlap = None
+    for ws_base, task_overlaps in settings.workspace_dataset_map.items():
+        if task in task_overlaps:
             workspace_name = ws_base
+            overlap = task_overlaps[task]
             break
 
-    dataset = client.datasets(dataset_name, workspace=workspace_name)
+    purposes: list[bool] = [False]
+    if overlap is not None and overlap.calibration_min_submitted is not None:
+        purposes.append(True)
+
     statuses = ["submitted", "discarded"] if include_discarded else ["submitted"]
     query = rg.Query(filter=rg.Filter([("response.status", "in", statuses)]))
     check_constraints = CONSTRAINT_CHECKERS[task]
@@ -121,34 +127,45 @@ def fetch_task(
     rows: list[tuple[AnnotationModel, list[str]]] = []
     missing_uuid_count = 0
 
-    for record in dataset.records(query, with_responses=True):
-        record_uuid: str = record.metadata.get("record_uuid", "")
-        if not record_uuid:
-            missing_uuid_count += 1
+    for calibration in purposes:
+        ds_name = dataset_name(task, calibration=calibration, dataset_id=settings.dataset_id)
+        dataset = client.datasets(ds_name, workspace=workspace_name)
+        if dataset is None:
+            # Calibration dataset may not yet exist if no records were ever
+            # routed to it (lazy creation). Production should always exist
+            # post-import; if missing, fall through silently to match prior
+            # "skip empty CSV" behaviour.
+            continue
 
-        created_at: datetime = record._model.updated_at or record._model.inserted_at
-        inserted_at: datetime = record._model.inserted_at
-        language: str | None = record.metadata.get("language")
-        record_status: str = record.status
+        for record in dataset.records(query, with_responses=True):
+            record_uuid: str = record.metadata.get("record_uuid", "")
+            if not record_uuid:
+                missing_uuid_count += 1
 
-        grouped = _group_responses_by_user(record)
-        for user_id, (response_status, answers) in grouped.items():
-            base = {
-                "record_uuid": record_uuid,
-                "annotator_id": user_lookup.get(user_id, str(user_id)),
-                "language": language,
-                "inserted_at": inserted_at,
-                "created_at": created_at,
-                "record_status": record_status,
-                "response_status": response_status,
-                "discard_reason": answers.get("discard_reason"),
-                "discard_notes": answers.get("discard_notes"),
-                "notes": answers.get("notes") or "",
-            }
+            created_at: datetime = record._model.updated_at or record._model.inserted_at
+            inserted_at: datetime = record._model.inserted_at
+            language: str | None = record.metadata.get("language")
+            record_status: str = record.status
 
-            row = _build_row(task, base=base, answers=answers, fields=record.fields, metadata=record.metadata)
-            violations = check_constraints(row) if response_status == "submitted" else []
-            rows.append((row, violations))
+            grouped = _group_responses_by_user(record)
+            for user_id, (response_status, answers) in grouped.items():
+                base = {
+                    "record_uuid": record_uuid,
+                    "annotator_id": user_lookup.get(user_id, str(user_id)),
+                    "language": language,
+                    "calibration": calibration,
+                    "inserted_at": inserted_at,
+                    "created_at": created_at,
+                    "record_status": record_status,
+                    "response_status": response_status,
+                    "discard_reason": answers.get("discard_reason"),
+                    "discard_notes": answers.get("discard_notes"),
+                    "notes": answers.get("notes") or "",
+                }
+
+                row = _build_row(task, base=base, answers=answers, fields=record.fields, metadata=record.metadata)
+                violations = check_constraints(row) if response_status == "submitted" else []
+                rows.append((row, violations))
 
     if missing_uuid_count:
         logger.warning(

--- a/src/pragmata/core/annotation/export_runner.py
+++ b/src/pragmata/core/annotation/export_runner.py
@@ -109,6 +109,18 @@ def write_export_csv(
         raise
 
 
+def _resolve_calibration_enabled(settings: "AnnotationSettings", tasks: list[Task]) -> dict[Task, bool]:
+    """Per-task calibration topology lookup from settings."""
+    flags: dict[Task, bool] = {}
+    for task_overlaps in settings.workspace_dataset_map.values():
+        for task, overlap in task_overlaps.items():
+            if task in tasks:
+                flags[task] = overlap.calibration_min_submitted is not None
+    for task in tasks:
+        flags.setdefault(task, False)
+    return flags
+
+
 def assemble_export_meta(
     export_id: str,
     dataset_id: str | None,
@@ -116,6 +128,7 @@ def assemble_export_meta(
     include_discarded: bool,
     row_counts: dict[Task, int],
     n_annotators: dict[Task, int],
+    calibration_enabled: dict[Task, bool],
     constraint_summary: dict[str, int],
 ) -> AnnotationExportMeta:
     """Assemble run-level provenance metadata for an annotation export.
@@ -127,6 +140,8 @@ def assemble_export_meta(
         include_discarded: Whether discarded responses were included.
         row_counts: Rows written per task.
         n_annotators: Distinct annotator count per task.
+        calibration_enabled: Whether the topology declared a calibration
+            dataset for each task.
         constraint_summary: Constraint violation count per rule name.
 
     Returns:
@@ -140,6 +155,7 @@ def assemble_export_meta(
         include_discarded=include_discarded,
         row_counts=row_counts,
         n_annotators=n_annotators,
+        calibration_enabled=calibration_enabled,
         constraint_summary=constraint_summary,
     )
 
@@ -171,6 +187,7 @@ def run_export(
             include_discarded=include_discarded,
             row_counts={},
             n_annotators={},
+            calibration_enabled={},
             constraint_summary={},
         )
         write_export_meta(meta, paths.export_meta_json)
@@ -197,6 +214,7 @@ def run_export(
 
     row_counts = {task: len(task_rows[task]) for task in tasks}
     n_annotators = {task: len({row.annotator_id for row, _ in task_rows[task]}) for task in tasks}
+    calibration_enabled = _resolve_calibration_enabled(settings, tasks)
 
     constraint_summary: dict[str, int] = {}
     for task in tasks:
@@ -211,6 +229,7 @@ def run_export(
         include_discarded=include_discarded,
         row_counts=row_counts,
         n_annotators=n_annotators,
+        calibration_enabled=calibration_enabled,
         constraint_summary=constraint_summary,
     )
     write_export_meta(meta, paths.export_meta_json)

--- a/src/pragmata/core/annotation/iaa_runner.py
+++ b/src/pragmata/core/annotation/iaa_runner.py
@@ -108,7 +108,12 @@ def _filter_rows(
     after: datetime | None = None,
     before: datetime | None = None,
 ) -> list[AnnotationBase]:
-    """Filter annotation rows to submitted responses, by annotator, and/or time window.
+    """Filter annotation rows to submitted, calibration responses by annotator and time.
+
+    Calibration filter is the primary purpose: IAA is only meaningful on
+    overlapped (calibration) records. Production rows are excluded by
+    default - downstream consumers wanting production-IAA can compute it
+    externally from the CSV.
 
     Discarded rows are always excluded: IAA measures agreement over labels, and
     discarded responses have no labels to agree on.
@@ -116,6 +121,8 @@ def _filter_rows(
     excluded = set(exclude_annotators) if exclude_annotators else set()
     filtered = []
     for row in rows:
+        if not row.calibration:
+            continue
         if row.response_status != "submitted":
             continue
         if row.annotator_id in excluded:
@@ -171,7 +178,10 @@ def run_iaa(
             before=before,
         )
         if not rows:
-            logger.warning("Skipping %s: CSV is empty", task.value)
+            logger.warning(
+                "Skipping %s: no calibration rows after filtering (calibration disabled or no overlap)",
+                task.value,
+            )
             continue
 
         labels = TASK_LABELS[task]

--- a/src/pragmata/core/annotation/record_builder.py
+++ b/src/pragmata/core/annotation/record_builder.py
@@ -1,23 +1,31 @@
 """Annotation import implementation — validation, record building, and fan-out.
 
 Validates raw dicts against the canonical schema, builds Argilla Record
-objects from typed QueryResponsePair inputs, and logs them to the
-appropriate datasets. The api/ layer resolves settings and delegates here.
+objects from typed QueryResponsePair inputs, partitions them into calibration
+vs production buckets per task, and logs them to the matching Argilla
+datasets. The api/ layer resolves settings and delegates here.
 """
 
 import hashlib
+import json
 import logging
 from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 import argilla as rg
 from argilla.records._dataset_records import RecordErrorHandling  # no public re-export in argilla v2; pinned to ==2.6.0
 
-from pragmata.core.annotation.argilla_ops import apply_suffix, create_dataset
-from pragmata.core.annotation.argilla_task_definitions import DATASET_NAMES, build_task_settings
-from pragmata.core.schemas.annotation_import import QueryResponsePair
+from pragmata.core.annotation.argilla_ops import create_dataset
+from pragmata.core.annotation.argilla_task_definitions import build_task_settings, dataset_name
+from pragmata.core.schemas.annotation_import import (
+    PartitionManifest,
+    PartitionManifestEntry,
+    QueryResponsePair,
+)
 from pragmata.core.schemas.annotation_task import Task
-from pragmata.core.settings.annotation_settings import AnnotationSettings
+from pragmata.core.settings.annotation_settings import AnnotationSettings, TaskOverlap
 
 logger = logging.getLogger(__name__)
 
@@ -142,73 +150,206 @@ def build_generation_record(pair: QueryResponsePair, record_uuid: str) -> rg.Rec
     )
 
 
-def _invert_workspace_map(workspace_dataset_map: dict[str, list[Task]]) -> dict[Task, str]:
-    """Invert workspace_dataset_map to task → workspace_base lookup."""
-    task_to_ws: dict[Task, str] = {}
-    for ws_base, tasks in workspace_dataset_map.items():
-        for task in tasks:
-            task_to_ws[task] = ws_base
+def _invert_workspace_map(
+    workspace_dataset_map: dict[str, dict[Task, TaskOverlap]],
+) -> dict[Task, tuple[str, TaskOverlap]]:
+    """Invert workspace_dataset_map to task → (workspace_base, overlap)."""
+    task_to_ws: dict[Task, tuple[str, TaskOverlap]] = {}
+    for ws_base, task_overlaps in workspace_dataset_map.items():
+        for task, overlap in task_overlaps.items():
+            task_to_ws[task] = (ws_base, overlap)
     return task_to_ws
 
 
-def _build_batches(records: list[QueryResponsePair]) -> dict[Task, list[rg.Record]]:
-    """Build Argilla records per task from canonical input pairs."""
-    batches: dict[Task, list[rg.Record]] = {task: [] for task in Task}
+# ---------------------------------------------------------------------------
+# Partition logic
+# ---------------------------------------------------------------------------
+
+
+def _bucket_calibration(record_uuid: str, fraction: float, seed: int) -> bool:
+    """Deterministic per-record assignment: hash(seed || uuid) < fraction * 2^32."""
+    if fraction <= 0.0:
+        return False
+    if fraction >= 1.0:
+        return True
+    digest = hashlib.sha256(f"{seed}\x00{record_uuid}".encode()).hexdigest()[:8]
+    return int(digest, 16) < int(fraction * (2**32))
+
+
+# ---------------------------------------------------------------------------
+# Partition manifest IO
+# ---------------------------------------------------------------------------
+
+
+def load_partition_manifest(path: Path, *, dataset_id: str, partition_seed: int) -> PartitionManifest:
+    """Load an existing manifest from disk or create an empty one."""
+    if path.exists():
+        return PartitionManifest.model_validate_json(path.read_text(encoding="utf-8"))
+    now = datetime.now(timezone.utc)
+    return PartitionManifest(
+        dataset_id=dataset_id,
+        created_at=now,
+        updated_at=now,
+        partition_seed=partition_seed,
+        assignments={},
+    )
+
+
+def write_partition_manifest(path: Path, manifest: PartitionManifest) -> None:
+    """Write manifest atomically (write-tmp-then-rename)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(manifest.model_dump(mode="json"), indent=2)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(payload, encoding="utf-8")
+    tmp.replace(path)
+
+
+def assign_partitions(
+    pairs: list[QueryResponsePair],
+    *,
+    manifest: PartitionManifest,
+    fraction: float,
+    import_id: str,
+) -> dict[str, bool]:
+    """Resolve each pair's calibration assignment, mutating the manifest in place.
+
+    Existing records keep their prior assignment (re-import safety). New
+    records are bucketed via ``_bucket_calibration`` using the manifest's
+    stored seed and the current import's fraction; the assignment is recorded
+    with import-time provenance.
+
+    Returns a record_uuid -> calibration map covering every input pair.
+    """
+    assignments: dict[str, bool] = {}
+    now = datetime.now(timezone.utc)
+    for pair in pairs:
+        rid = derive_record_uuid(pair)
+        existing = manifest.assignments.get(rid)
+        if existing is not None:
+            assignments[rid] = existing.calibration
+            continue
+        is_cal = _bucket_calibration(rid, fraction, manifest.partition_seed)
+        manifest.assignments[rid] = PartitionManifestEntry(
+            calibration=is_cal,
+            import_id=import_id,
+            calibration_fraction_at_import=fraction,
+            assigned_at=now,
+        )
+        assignments[rid] = is_cal
+    manifest.updated_at = now
+    return assignments
+
+
+# ---------------------------------------------------------------------------
+# Fan-out
+# ---------------------------------------------------------------------------
+
+
+def _build_batches(
+    records: list[QueryResponsePair],
+    assignments: dict[str, bool],
+) -> dict[tuple[Task, bool], list[rg.Record]]:
+    """Build Argilla records keyed by (task, calibration) bucket."""
+    batches: dict[tuple[Task, bool], list[rg.Record]] = {
+        (task, is_cal): [] for task in Task for is_cal in (False, True)
+    }
     for pair in records:
         record_uuid = derive_record_uuid(pair)
-        batches[Task.RETRIEVAL].extend(build_retrieval_records(pair, record_uuid))
-        batches[Task.GROUNDING].append(build_grounding_record(pair, record_uuid))
-        batches[Task.GENERATION].append(build_generation_record(pair, record_uuid))
+        is_cal = assignments[record_uuid]
+        batches[(Task.RETRIEVAL, is_cal)].extend(build_retrieval_records(pair, record_uuid))
+        batches[(Task.GROUNDING, is_cal)].append(build_grounding_record(pair, record_uuid))
+        batches[(Task.GENERATION, is_cal)].append(build_generation_record(pair, record_uuid))
     return batches
+
+
+def _ensure_dataset(
+    client: rg.Argilla,
+    *,
+    task: Task,
+    calibration: bool,
+    min_submitted: int,
+    ws_base: str,
+    dataset_id: str,
+    task_settings_map: dict[Task, rg.Settings],
+) -> rg.Dataset:
+    """Resolve or create the Argilla dataset for a (task, purpose) pair."""
+    ds_name = dataset_name(task, calibration=calibration, dataset_id=dataset_id)
+    workspace = client.workspaces(ws_base)
+    if workspace is None:
+        raise RuntimeError(f"Workspace {ws_base!r} not found. Run setup() first.")
+    base_settings = task_settings_map[task]
+    task_cfg = rg.Settings(
+        fields=base_settings.fields,
+        questions=base_settings.questions,
+        metadata=base_settings.metadata,
+        guidelines=base_settings.guidelines,
+        distribution=rg.TaskDistribution(min_submitted=min_submitted),
+    )
+    dataset, ds_created = create_dataset(client, ds_name, ws_base, task_cfg)
+    if ds_created:
+        logger.info("Auto-created dataset %r in workspace %r", ds_name, ws_base)
+    return dataset
 
 
 def fan_out_records(
     client: rg.Argilla,
     records: list[QueryResponsePair],
     settings: AnnotationSettings,
-) -> dict[str, int]:
-    """Build and log Argilla records to all three datasets.
+    *,
+    assignments: dict[str, bool],
+) -> tuple[dict[str, int], int, int]:
+    """Build and log Argilla records to per-purpose datasets.
 
     Datasets are created on-the-fly if they don't exist (idempotent).
     Workspaces must already exist (call setup() first).
 
-    Returns counts of records submitted per dataset (not confirmed — individual
-    record failures are logged as warnings by Argilla but not reflected in counts).
+    Args:
+        client: Argilla client.
+        records: Validated input pairs.
+        settings: Annotation settings (topology, dataset_id).
+        assignments: Per-record calibration assignment from
+            ``assign_partitions``. The caller has already pinned each record
+            to a bucket via the manifest.
+
+    Returns:
+        ``(dataset_counts, calibration_count, production_count)``.
     """
     task_to_ws = _invert_workspace_map(settings.workspace_dataset_map)
     task_settings_map = build_task_settings()
-    batches = _build_batches(records)
+    batches = _build_batches(records, assignments)
 
     dataset_counts: dict[str, int] = {}
+    calibration_count = sum(1 for is_cal in assignments.values() if is_cal)
+    production_count = len(assignments) - calibration_count
 
-    for task, rg_records in batches.items():
+    for (task, calibration), rg_records in batches.items():
         if not rg_records:
             continue
-        ws_base = task_to_ws.get(task)
-        if ws_base is None:
+        binding = task_to_ws.get(task)
+        if binding is None:
             logger.warning("Task %r not in workspace_dataset_map — skipping", task)
             continue
-
-        ds_name = apply_suffix(DATASET_NAMES[task], settings.dataset_id)
-
-        workspace = client.workspaces(ws_base)
-        if workspace is None:
-            raise RuntimeError(f"Workspace {ws_base!r} not found. Run setup() first.")
-
-        base_settings = task_settings_map[task]
-        task_cfg = rg.Settings(
-            fields=base_settings.fields,
-            questions=base_settings.questions,
-            metadata=base_settings.metadata,
-            guidelines=base_settings.guidelines,
-            distribution=rg.TaskDistribution(min_submitted=settings.min_submitted),
+        ws_base, overlap = binding
+        if calibration and overlap.calibration_min_submitted is None:
+            # Defensive: should not happen because assign_partitions only
+            # assigns calibration when topology supports it. Surface as an
+            # error rather than silently route to production.
+            raise RuntimeError(f"Task {task.value} has calibration records assigned but topology disables calibration")
+        min_submitted = overlap.calibration_min_submitted if calibration else overlap.production_min_submitted
+        # mypy: narrowed by the guard above
+        assert min_submitted is not None
+        dataset = _ensure_dataset(
+            client,
+            task=task,
+            calibration=calibration,
+            min_submitted=min_submitted,
+            ws_base=ws_base,
+            dataset_id=settings.dataset_id,
+            task_settings_map=task_settings_map,
         )
-        dataset, ds_created = create_dataset(client, ds_name, ws_base, task_cfg)
-        if ds_created:
-            logger.info("Auto-created dataset %r in workspace %r", ds_name, ws_base)
-
         dataset.records.log(rg_records, on_error=RecordErrorHandling.WARN)
+        ds_name = dataset.name
         dataset_counts[ds_name] = len(rg_records)
         logger.info("Logged %d records to dataset %r", len(rg_records), ds_name)
 
-    return dataset_counts
+    return dataset_counts, calibration_count, production_count

--- a/src/pragmata/core/annotation/setup.py
+++ b/src/pragmata/core/annotation/setup.py
@@ -9,8 +9,8 @@ from dataclasses import dataclass, field
 
 import argilla as rg
 
-from pragmata.core.annotation.argilla_ops import apply_suffix, create_user, create_workspace
-from pragmata.core.annotation.argilla_task_definitions import DATASET_NAMES
+from pragmata.core.annotation.argilla_ops import create_user, create_workspace
+from pragmata.core.annotation.argilla_task_definitions import dataset_name
 from pragmata.core.settings.annotation_settings import AnnotationSettings, UserSpec
 
 logger = logging.getLogger(__name__)
@@ -96,18 +96,22 @@ def teardown_resources(
     Ordering: datasets first (Argilla requires workspace to be empty before deletion).
     Missing resources are silently skipped. User accounts are not touched.
     """
-    for ws_base, tasks in settings.workspace_dataset_map.items():
+    for ws_base, task_overlaps in settings.workspace_dataset_map.items():
         workspace = client.workspaces(ws_base)
         if workspace is None:
             logger.info("Workspace %r not found — skipping", ws_base)
             continue
 
-        for task in tasks:
-            ds_name = apply_suffix(DATASET_NAMES[task], settings.dataset_id)
-            dataset = client.datasets(ds_name, workspace=ws_base)
-            if dataset is not None:
-                dataset.delete()
-                logger.info("Deleted dataset %r from workspace %r", ds_name, ws_base)
+        for task, overlap in task_overlaps.items():
+            purposes_present = [False]  # production always exists
+            if overlap.calibration_min_submitted is not None:
+                purposes_present.append(True)
+            for calibration in purposes_present:
+                ds_name = dataset_name(task, calibration=calibration, dataset_id=settings.dataset_id)
+                dataset = client.datasets(ds_name, workspace=ws_base)
+                if dataset is not None:
+                    dataset.delete()
+                    logger.info("Deleted dataset %r from workspace %r", ds_name, ws_base)
 
         if not settings.dataset_id:
             for user in list(workspace.users):

--- a/src/pragmata/core/paths/annotation_paths.py
+++ b/src/pragmata/core/paths/annotation_paths.py
@@ -36,6 +36,52 @@ def resolve_annotation_paths(*, workspace: WorkspacePaths) -> AnnotationPaths:
 
 
 @dataclass(frozen=True, slots=True)
+class AnnotationImportPaths:
+    """Path bundle for an annotation import scope (one per ``dataset_id``).
+
+    Imports accumulate state across calls into the same logical scope, so the
+    bundle is keyed by ``dataset_id`` (persistent topology scope) rather than
+    a per-call identifier. The partition manifest sidecar tracks calibration
+    vs production assignment for every record imported into this scope.
+
+    Attributes:
+        tool_root: Annotation tool root.
+        import_dir: Per-``dataset_id`` import directory.
+        partition_manifest: Partition manifest sidecar path.
+    """
+
+    tool_root: Path
+    import_dir: Path
+    partition_manifest: Path
+
+    def ensure_dirs(self) -> Self:
+        """Create the import directory scaffold."""
+        self.import_dir.mkdir(parents=True, exist_ok=True)
+        return self
+
+
+def resolve_import_paths(*, workspace: WorkspacePaths, dataset_id: str) -> AnnotationImportPaths:
+    """Build the path bundle for an annotation import scope.
+
+    Args:
+        workspace: Workspace path bundle.
+        dataset_id: Topology scope. Empty string maps to the ``"default"``
+            directory so the layout is uniform across scopes.
+
+    Returns:
+        Path bundle for the import scope.
+    """
+    tool_root = workspace.tool_root("annotation")
+    scope = dataset_id or "default"
+    import_dir = tool_root / "imports" / scope
+    return AnnotationImportPaths(
+        tool_root=tool_root,
+        import_dir=import_dir,
+        partition_manifest=import_dir / "partition.meta.json",
+    )
+
+
+@dataclass(frozen=True, slots=True)
 class AnnotationExportPaths:
     """Path bundle for an annotation export run.
 

--- a/src/pragmata/core/schemas/annotation_export.py
+++ b/src/pragmata/core/schemas/annotation_export.py
@@ -24,6 +24,7 @@ class AnnotationBase(BaseModel):
     annotator_id: str
     task: Task
     language: str | None
+    calibration: bool
     inserted_at: datetime
     created_at: datetime
     record_status: str
@@ -121,6 +122,7 @@ class AnnotationExportMeta(BaseModel):
     include_discarded: bool
     row_counts: dict[Task, NonNegativeInt]
     n_annotators: dict[Task, NonNegativeInt]
+    calibration_enabled: dict[Task, bool]
     constraint_summary: dict[str, NonNegativeInt]
 
     @model_validator(mode="after")
@@ -131,4 +133,6 @@ class AnnotationExportMeta(BaseModel):
             raise ValueError("row_counts keys must match tasks")
         if set(self.n_annotators) != expected:
             raise ValueError("n_annotators keys must match tasks")
+        if set(self.calibration_enabled) != expected:
+            raise ValueError("calibration_enabled keys must match tasks")
         return self

--- a/src/pragmata/core/schemas/annotation_import.py
+++ b/src/pragmata/core/schemas/annotation_import.py
@@ -1,4 +1,6 @@
-"""Boundary schemas for canonical annotation import records."""
+"""Boundary schemas for canonical annotation import records and partition state."""
+
+from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -44,3 +46,45 @@ class QueryResponsePair(BaseModel):
     chunks: list[Chunk] = Field(min_length=1)
     context_set: NonEmptyStr
     language: str | None = None
+
+
+class PartitionManifestEntry(BaseModel):
+    """One record's calibration vs production assignment with import provenance.
+
+    Attributes:
+        calibration: True if assigned to the calibration dataset, else production.
+        import_id: Identifier of the import call that produced this assignment.
+        calibration_fraction_at_import: The fraction in force at that import call.
+        assigned_at: When the assignment was made.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    calibration: bool
+    import_id: str
+    calibration_fraction_at_import: float = Field(ge=0.0, le=1.0)
+    assigned_at: datetime
+
+
+class PartitionManifest(BaseModel):
+    """Persistent record_uuid -> assignment map scoped to one ``dataset_id``.
+
+    Locks calibration vs production assignments across re-imports so growing
+    or repeated batches never reshuffle records between Argilla datasets.
+
+    Attributes:
+        dataset_id: Topology scope this manifest belongs to (empty string ok).
+        created_at: First write timestamp.
+        updated_at: Most recent write timestamp.
+        partition_seed: Hash seed used for new-record assignments. Stored at
+            manifest level - changing seed mid-scope only affects new records.
+        assignments: Map of record_uuid -> PartitionManifestEntry.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    dataset_id: str
+    created_at: datetime
+    updated_at: datetime
+    partition_seed: int
+    assignments: dict[str, PartitionManifestEntry] = Field(default_factory=dict)

--- a/src/pragmata/core/settings/annotation_settings.py
+++ b/src/pragmata/core/settings/annotation_settings.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, NonNegativeInt, PositiveInt
 
 from pragmata.core.schemas.annotation_task import Task
 from pragmata.core.settings.settings_base import ResolveSettings
@@ -18,10 +18,27 @@ class ArgillaSettings(BaseModel):
     api_url: str | None = None
 
 
+class TaskOverlap(BaseModel):
+    """Per-task overlap topology: production and optional calibration thresholds.
+
+    Attributes:
+        production_min_submitted: Argilla ``min_submitted`` for the production
+            dataset (typically 1; >1 enables full overlap on production).
+        calibration_min_submitted: Argilla ``min_submitted`` for the
+            calibration dataset. ``None`` disables calibration for this task.
+            Default 3 covers Krippendorff alpha plus pairwise Cohen kappa.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    production_min_submitted: PositiveInt = 1
+    calibration_min_submitted: PositiveInt | None = 3
+
+
 class AnnotationSettings(ResolveSettings):
     """Configurable runtime settings for annotation (setup, import, export).
 
-    Controls workspace topology and task-distribution thresholds.
+    Controls workspace topology and per-task overlap thresholds.
     Task definitions (Argilla rg.Settings per task) are hardcoded — see
     core/annotation/argilla_task_definitions.py.
     """
@@ -29,14 +46,14 @@ class AnnotationSettings(ResolveSettings):
     argilla: ArgillaSettings = Field(default_factory=ArgillaSettings)
     base_dir: Path = Field(default_factory=Path.cwd)
     dataset_id: str = ""
-    workspace_dataset_map: dict[str, list[Task]] = Field(
+    workspace_dataset_map: dict[str, dict[Task, TaskOverlap]] = Field(
         default_factory=lambda: {
-            "retrieval": [Task.RETRIEVAL],
-            "grounding": [Task.GROUNDING],
-            "generation": [Task.GENERATION],
+            "retrieval": {Task.RETRIEVAL: TaskOverlap()},
+            "grounding": {Task.GROUNDING: TaskOverlap()},
+            "generation": {Task.GENERATION: TaskOverlap()},
         }
     )
-    min_submitted: int = 1
+    calibration_partition_seed: NonNegativeInt = 0
     include_discarded: bool = False
 
 

--- a/tests/integration/test_annotation_calibration.py
+++ b/tests/integration/test_annotation_calibration.py
@@ -1,0 +1,198 @@
+"""Integration tests for the calibration / production split against a live Argilla.
+
+Run with: pytest tests/integration/test_annotation_calibration.py -m "integration and annotation" -v
+Requires: make setup (Argilla stack running on localhost:6900)
+"""
+
+from pathlib import Path
+
+import argilla as rg
+import pytest
+
+from pragmata.api.annotation_import import import_records
+from pragmata.core.annotation.argilla_task_definitions import dataset_name
+from pragmata.core.annotation.setup import setup_workspaces, teardown_resources
+from pragmata.core.schemas.annotation_import import PartitionManifest
+from pragmata.core.schemas.annotation_task import Task
+from pragmata.core.settings.annotation_settings import AnnotationSettings
+
+pytestmark = [pytest.mark.integration, pytest.mark.annotation]
+
+_API_URL = "http://localhost:6900"
+_API_KEY = "argilla.apikey"
+_DATASET_ID = "testcalibration"
+_CREDS: dict[str, str] = {"api_url": _API_URL, "api_key": _API_KEY}
+
+_SETTINGS = AnnotationSettings(dataset_id=_DATASET_ID)
+
+
+def _make_raw(i: int) -> dict:
+    return {
+        "query": f"Question {i}?",
+        "answer": f"Answer {i}.",
+        "chunks": [{"chunk_id": f"c{i}", "doc_id": "d1", "chunk_rank": 1, "text": f"Chunk {i}."}],
+        "context_set": "ctx-001",
+        "language": "en",
+    }
+
+
+@pytest.fixture(scope="module")
+def client() -> rg.Argilla:
+    return rg.Argilla(api_url=_API_URL, api_key=_API_KEY)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def clean_environment(client: rg.Argilla):
+    teardown_resources(client, _SETTINGS)
+    setup_workspaces(client, _SETTINGS)
+    yield
+    teardown_resources(client, _SETTINGS)
+
+
+@pytest.fixture()
+def base_dir(tmp_path: Path) -> Path:
+    """Per-test workspace so each test owns its partition manifest."""
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_default_calibration_fraction_creates_both_datasets(client: rg.Argilla, base_dir: Path) -> None:
+    """Default fraction=0.1 routes ~10% to calibration; both datasets exist."""
+    teardown_resources(client, _SETTINGS)
+    setup_workspaces(client, _SETTINGS)
+
+    records = [_make_raw(i) for i in range(50)]
+    result = import_records(records, dataset_id=_DATASET_ID, base_dir=base_dir, calibration_fraction=0.5, **_CREDS)
+
+    # Both production and calibration datasets exist for retrieval
+    prod_name = dataset_name(Task.RETRIEVAL, calibration=False, dataset_id=_DATASET_ID)
+    cal_name = dataset_name(Task.RETRIEVAL, calibration=True, dataset_id=_DATASET_ID)
+    assert client.datasets(prod_name, workspace="retrieval") is not None
+    assert client.datasets(cal_name, workspace="retrieval") is not None
+
+    # Both populated
+    assert result.calibration_count > 0
+    assert result.production_count > 0
+    assert result.calibration_count + result.production_count == len(records)
+
+
+def test_calibration_fraction_zero_skips_calibration_dataset(client: rg.Argilla, base_dir: Path) -> None:
+    """fraction=0 routes everything to production; calibration dataset is not created."""
+    auto_id = "testcalibrationzero"
+    auto_settings = AnnotationSettings(dataset_id=auto_id)
+    teardown_resources(client, auto_settings)
+    setup_workspaces(client, auto_settings)
+
+    try:
+        result = import_records(
+            [_make_raw(i) for i in range(5)],
+            dataset_id=auto_id,
+            base_dir=base_dir,
+            calibration_fraction=0.0,
+            **_CREDS,
+        )
+
+        prod_name = dataset_name(Task.RETRIEVAL, calibration=False, dataset_id=auto_id)
+        cal_name = dataset_name(Task.RETRIEVAL, calibration=True, dataset_id=auto_id)
+        assert client.datasets(prod_name, workspace="retrieval") is not None
+        assert client.datasets(cal_name, workspace="retrieval") is None
+        assert result.calibration_count == 0
+        assert result.production_count == 5
+    finally:
+        teardown_resources(client, auto_settings)
+
+
+def test_reimport_locks_partition_assignments(client: rg.Argilla, base_dir: Path) -> None:
+    """Re-importing the same batch with a different fraction does not move records."""
+    auto_id = "testreimport"
+    auto_settings = AnnotationSettings(dataset_id=auto_id)
+    teardown_resources(client, auto_settings)
+    setup_workspaces(client, auto_settings)
+
+    try:
+        records = [_make_raw(i) for i in range(20)]
+
+        first = import_records(records, dataset_id=auto_id, base_dir=base_dir, calibration_fraction=0.5, **_CREDS)
+        second = import_records(records, dataset_id=auto_id, base_dir=base_dir, calibration_fraction=0.0, **_CREDS)
+
+        # Same input + locked manifest = identical assignments
+        assert first.calibration_count == second.calibration_count
+        assert first.production_count == second.production_count
+
+        # Manifest sidecar exists and has all 20 entries
+        manifest_path = base_dir / "annotation" / "imports" / auto_id / "partition.meta.json"
+        assert manifest_path.exists()
+        manifest = PartitionManifest.model_validate_json(manifest_path.read_text())
+        assert len(manifest.assignments) == 20
+    finally:
+        teardown_resources(client, auto_settings)
+
+
+def test_growing_batch_partitions_new_records_only(client: rg.Argilla, base_dir: Path) -> None:
+    """Appending new records on a second import partitions only the new ones."""
+    auto_id = "testgrowing"
+    auto_settings = AnnotationSettings(dataset_id=auto_id)
+    teardown_resources(client, auto_settings)
+    setup_workspaces(client, auto_settings)
+
+    try:
+        first_batch = [_make_raw(i) for i in range(10)]
+        first = import_records(first_batch, dataset_id=auto_id, base_dir=base_dir, calibration_fraction=0.5, **_CREDS)
+
+        # Second import: 10 prior + 10 new
+        second_batch = first_batch + [_make_raw(i) for i in range(10, 20)]
+        second = import_records(second_batch, dataset_id=auto_id, base_dir=base_dir, calibration_fraction=0.0, **_CREDS)
+
+        # The first 10 keep their original assignments. The next 10 all go production
+        # because fraction=0 on the second import.
+        manifest_path = base_dir / "annotation" / "imports" / auto_id / "partition.meta.json"
+        manifest = PartitionManifest.model_validate_json(manifest_path.read_text())
+        assert len(manifest.assignments) == 20
+
+        # second.calibration_count must equal first.calibration_count (no new cal records)
+        assert second.calibration_count == first.calibration_count
+        assert second.production_count == 20 - first.calibration_count
+    finally:
+        teardown_resources(client, auto_settings)
+
+
+def test_records_carry_calibration_metadata_to_argilla(client: rg.Argilla, base_dir: Path) -> None:
+    """Imported Argilla records exist in the dataset matching their assignment."""
+    auto_id = "testmetadata"
+    auto_settings = AnnotationSettings(dataset_id=auto_id)
+    teardown_resources(client, auto_settings)
+    setup_workspaces(client, auto_settings)
+
+    try:
+        records = [_make_raw(i) for i in range(10)]
+        import_records(records, dataset_id=auto_id, base_dir=base_dir, calibration_fraction=0.5, **_CREDS)
+
+        manifest_path = base_dir / "annotation" / "imports" / auto_id / "partition.meta.json"
+        manifest = PartitionManifest.model_validate_json(manifest_path.read_text())
+
+        cal_uuids = {rid for rid, entry in manifest.assignments.items() if entry.calibration}
+        prod_uuids = {rid for rid, entry in manifest.assignments.items() if not entry.calibration}
+
+        prod_ds = client.datasets(
+            dataset_name(Task.GROUNDING, calibration=False, dataset_id=auto_id),
+            workspace="grounding",
+        )
+        cal_ds = client.datasets(
+            dataset_name(Task.GROUNDING, calibration=True, dataset_id=auto_id),
+            workspace="grounding",
+        )
+
+        assert prod_ds is not None
+        prod_record_uuids = {r.metadata["record_uuid"] for r in prod_ds.records}
+        assert prod_record_uuids == prod_uuids
+
+        if cal_uuids:
+            assert cal_ds is not None
+            cal_record_uuids = {r.metadata["record_uuid"] for r in cal_ds.records}
+            assert cal_record_uuids == cal_uuids
+    finally:
+        teardown_resources(client, auto_settings)

--- a/tests/integration/test_annotation_import.py
+++ b/tests/integration/test_annotation_import.py
@@ -71,14 +71,19 @@ def test_record_counts_per_dataset(client: rg.Argilla, sample_records: list[dict
     n_records = len(sample_records)
     n_retrieval = sum(len(r["chunks"]) for r in sample_records)  # 3 + 2 = 5
 
-    result = import_records(sample_records, dataset_id=_DATASET_ID, **_CREDS)
+    result = import_records(
+        sample_records,
+        dataset_id=_DATASET_ID,
+        calibration_fraction=0.0,
+        **_CREDS,
+    )
 
     assert result.total_records == n_records
     assert result.errors == []
 
-    ret_ds_name = f"retrieval_{_DATASET_ID}"
-    gnd_ds_name = f"grounding_{_DATASET_ID}"
-    gen_ds_name = f"generation_{_DATASET_ID}"
+    ret_ds_name = f"retrieval_production_{_DATASET_ID}"
+    gnd_ds_name = f"grounding_production_{_DATASET_ID}"
+    gen_ds_name = f"generation_production_{_DATASET_ID}"
 
     assert result.dataset_counts[ret_ds_name] == n_retrieval
     assert result.dataset_counts[gnd_ds_name] == n_records
@@ -87,11 +92,11 @@ def test_record_counts_per_dataset(client: rg.Argilla, sample_records: list[dict
 
 def test_records_exist_in_argilla(client: rg.Argilla, sample_records: list[dict]) -> None:
     """After import, all three datasets contain records."""
-    import_records(sample_records, dataset_id=_DATASET_ID, **_CREDS)
+    import_records(sample_records, dataset_id=_DATASET_ID, calibration_fraction=0.0, **_CREDS)
 
-    ret_ds = client.datasets(f"retrieval_{_DATASET_ID}", workspace="retrieval")
-    gnd_ds = client.datasets(f"grounding_{_DATASET_ID}", workspace="grounding")
-    gen_ds = client.datasets(f"generation_{_DATASET_ID}", workspace="generation")
+    ret_ds = client.datasets(f"retrieval_production_{_DATASET_ID}", workspace="retrieval")
+    gnd_ds = client.datasets(f"grounding_production_{_DATASET_ID}", workspace="grounding")
+    gen_ds = client.datasets(f"generation_production_{_DATASET_ID}", workspace="generation")
 
     assert ret_ds is not None
     assert gnd_ds is not None
@@ -105,15 +110,15 @@ def test_records_exist_in_argilla(client: rg.Argilla, sample_records: list[dict]
 
 def test_record_uuid_linkage(client: rg.Argilla, sample_records: list[dict]) -> None:
     """record_uuid metadata appears in all three datasets and intersects."""
-    import_records(sample_records, dataset_id=_DATASET_ID, **_CREDS)
+    import_records(sample_records, dataset_id=_DATASET_ID, calibration_fraction=0.0, **_CREDS)
 
     def _uuids(ds_name: str, ws_name: str) -> set[str]:
         ds = client.datasets(ds_name, workspace=ws_name)
         return {r.metadata["record_uuid"] for r in ds.records if r.metadata.get("record_uuid")}
 
-    ret_uuids = _uuids(f"retrieval_{_DATASET_ID}", "retrieval")
-    gnd_uuids = _uuids(f"grounding_{_DATASET_ID}", "grounding")
-    gen_uuids = _uuids(f"generation_{_DATASET_ID}", "generation")
+    ret_uuids = _uuids(f"retrieval_production_{_DATASET_ID}", "retrieval")
+    gnd_uuids = _uuids(f"grounding_production_{_DATASET_ID}", "grounding")
+    gen_uuids = _uuids(f"generation_production_{_DATASET_ID}", "generation")
 
     # All three datasets share the same UUIDs
     assert ret_uuids == gnd_uuids == gen_uuids
@@ -127,12 +132,12 @@ def test_idempotent_reimport(client: rg.Argilla, sample_records: list[dict]) -> 
     (derive_record_uuid). Argilla upserts on Record.id, so identical IDs on the second
     import overwrite existing records rather than creating duplicates.
     """
-    import_records(sample_records, dataset_id=_DATASET_ID, **_CREDS)
-    import_records(sample_records, dataset_id=_DATASET_ID, **_CREDS)
+    import_records(sample_records, dataset_id=_DATASET_ID, calibration_fraction=0.0, **_CREDS)
+    import_records(sample_records, dataset_id=_DATASET_ID, calibration_fraction=0.0, **_CREDS)
 
-    ret_ds = client.datasets(f"retrieval_{_DATASET_ID}", workspace="retrieval")
-    gnd_ds = client.datasets(f"grounding_{_DATASET_ID}", workspace="grounding")
-    gen_ds = client.datasets(f"generation_{_DATASET_ID}", workspace="generation")
+    ret_ds = client.datasets(f"retrieval_production_{_DATASET_ID}", workspace="retrieval")
+    gnd_ds = client.datasets(f"grounding_production_{_DATASET_ID}", workspace="grounding")
+    gen_ds = client.datasets(f"generation_production_{_DATASET_ID}", workspace="generation")
 
     n_retrieval = sum(len(r["chunks"]) for r in sample_records)
     n_records = len(sample_records)
@@ -146,7 +151,7 @@ def test_invalid_records_skipped_with_errors(client: rg.Argilla) -> None:
     """Invalid dicts are reported as errors, not sent to Argilla."""
     raw = [{"query": "no answer or chunks"}, _make_raw(1)]
 
-    result = import_records(raw, dataset_id=_DATASET_ID, **_CREDS)
+    result = import_records(raw, dataset_id=_DATASET_ID, calibration_fraction=0.0, **_CREDS)
 
     assert result.total_records == 2
     assert len(result.errors) == 1
@@ -164,15 +169,15 @@ def test_dataset_auto_creation(client: rg.Argilla) -> None:
     teardown_resources(client, auto_settings)
 
     # Import without prior setup_datasets — datasets should be auto-created
-    result = import_records([_make_raw(1)], dataset_id=auto_id, **_CREDS)
+    result = import_records([_make_raw(1)], dataset_id=auto_id, calibration_fraction=0.0, **_CREDS)
 
     assert result.total_records == 1
     assert result.errors == []
 
     # Datasets exist
-    assert client.datasets(f"retrieval_{auto_id}", workspace="retrieval") is not None
-    assert client.datasets(f"grounding_{auto_id}", workspace="grounding") is not None
-    assert client.datasets(f"generation_{auto_id}", workspace="generation") is not None
+    assert client.datasets(f"retrieval_production_{auto_id}", workspace="retrieval") is not None
+    assert client.datasets(f"grounding_production_{auto_id}", workspace="grounding") is not None
+    assert client.datasets(f"generation_production_{auto_id}", workspace="generation") is not None
 
     # Clean up
     teardown_resources(client, auto_settings)

--- a/tests/unit/api/test_annotation.py
+++ b/tests/unit/api/test_annotation.py
@@ -43,6 +43,13 @@ def _autouse_mock_client(mock_client: MagicMock) -> MagicMock:
     return mock_client
 
 
+@pytest.fixture(autouse=True)
+def _isolate_base_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Run every test under a tmp directory so partition manifests etc. write there."""
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
 def _make_raw() -> dict:
     return {
         "query": "What is X?",
@@ -85,17 +92,6 @@ class TestSetup:
 
         assert result.created_workspaces == ["ws1"]
         assert result.created_users == ["alice"]
-
-    @patch("pragmata.api.annotation_setup.provision_users")
-    @patch("pragmata.api.annotation_setup.setup_workspaces")
-    def test_resolves_min_submitted(self, mock_ds: MagicMock, mock_users: MagicMock) -> None:
-        mock_ds.return_value = SetupResult()
-        mock_users.return_value = SetupResult()
-
-        setup(min_submitted=3)
-
-        settings: AnnotationSettings = mock_ds.call_args[0][1]
-        assert settings.min_submitted == 3
 
     @patch("pragmata.api.annotation_setup.provision_users")
     @patch("pragmata.api.annotation_setup.setup_workspaces")
@@ -146,7 +142,7 @@ class TestTeardown:
 class TestImportRecords:
     @patch("pragmata.api.annotation_import.fan_out_records")
     def test_delegates_to_core(self, mock_fan_out: MagicMock, mock_client: MagicMock) -> None:
-        mock_fan_out.return_value = {"ds1": 2}
+        mock_fan_out.return_value = ({"ds1": 2}, 0, 1)
         raw = [_make_raw()]
 
         import_records(raw, dataset_id="test")
@@ -157,7 +153,7 @@ class TestImportRecords:
 
     @patch("pragmata.api.annotation_import.fan_out_records")
     def test_resolves_dataset_id(self, mock_fan_out: MagicMock) -> None:
-        mock_fan_out.return_value = {}
+        mock_fan_out.return_value = ({}, 0, 0)
 
         import_records([], dataset_id="myprefix")
 
@@ -166,19 +162,21 @@ class TestImportRecords:
 
     @patch("pragmata.api.annotation_import.fan_out_records")
     def test_returns_import_result(self, mock_fan_out: MagicMock) -> None:
-        mock_fan_out.return_value = {"ds1": 3, "ds2": 1}
+        mock_fan_out.return_value = ({"ds1": 3, "ds2": 1}, 0, 2)
         raw = [_make_raw(), _make_raw()]
 
-        result = import_records(raw, dataset_id="test")
+        result = import_records(raw, dataset_id="test", calibration_fraction=0.0)
 
         assert isinstance(result, ImportResult)
         assert result.total_records == 2
         assert result.dataset_counts == {"ds1": 3, "ds2": 1}
+        assert result.calibration_count == 0
+        assert result.production_count == 2
         assert result.errors == []
 
     @patch("pragmata.api.annotation_import.fan_out_records")
     def test_empty_records_returns_zero_totals(self, mock_fan_out: MagicMock) -> None:
-        mock_fan_out.return_value = {}
+        mock_fan_out.return_value = ({}, 0, 0)
 
         result = import_records([], dataset_id="test")
 
@@ -188,7 +186,7 @@ class TestImportRecords:
 
     @patch("pragmata.api.annotation_import.fan_out_records")
     def test_validation_errors_reported(self, mock_fan_out: MagicMock) -> None:
-        mock_fan_out.return_value = {"ds1": 1}
+        mock_fan_out.return_value = ({"ds1": 1}, 0, 1)
         raw = [_make_raw(), {"query": "missing required fields"}]
 
         result = import_records(raw, dataset_id="test")
@@ -201,7 +199,7 @@ class TestImportRecords:
 
     @patch("pragmata.api.annotation_import.fan_out_records")
     def test_all_invalid_skips_fan_out(self, mock_fan_out: MagicMock) -> None:
-        mock_fan_out.return_value = {}
+        mock_fan_out.return_value = ({}, 0, 0)
         raw = [{"bad": "data"}, {"also": "bad"}]
 
         result = import_records(raw, dataset_id="test")
@@ -213,7 +211,7 @@ class TestImportRecords:
 
     @patch("pragmata.api.annotation_import.fan_out_records")
     def test_accepts_json_file_path(self, mock_fan_out: MagicMock, tmp_path: Path) -> None:
-        mock_fan_out.return_value = {"ds1": 1}
+        mock_fan_out.return_value = ({"ds1": 1}, 0, 1)
         f = tmp_path / "data.json"
         f.write_text(json.dumps([_make_raw()]))
 
@@ -224,7 +222,7 @@ class TestImportRecords:
 
     @patch("pragmata.api.annotation_import.fan_out_records")
     def test_accepts_path_object(self, mock_fan_out: MagicMock, tmp_path: Path) -> None:
-        mock_fan_out.return_value = {"ds1": 1}
+        mock_fan_out.return_value = ({"ds1": 1}, 0, 1)
         f = tmp_path / "data.json"
         f.write_text(json.dumps([_make_raw()]))
 
@@ -234,7 +232,7 @@ class TestImportRecords:
 
     @patch("pragmata.api.annotation_import.fan_out_records")
     def test_accepts_jsonl_file(self, mock_fan_out: MagicMock, tmp_path: Path) -> None:
-        mock_fan_out.return_value = {"ds1": 1}
+        mock_fan_out.return_value = ({"ds1": 1}, 0, 1)
         f = tmp_path / "data.jsonl"
         f.write_text(json.dumps(_make_raw()) + "\n")
 
@@ -244,7 +242,7 @@ class TestImportRecords:
 
     @patch("pragmata.api.annotation_import.fan_out_records")
     def test_format_override(self, mock_fan_out: MagicMock, tmp_path: Path) -> None:
-        mock_fan_out.return_value = {"ds1": 1}
+        mock_fan_out.return_value = ({"ds1": 1}, 0, 1)
         f = tmp_path / "data.txt"
         f.write_text(json.dumps([_make_raw()]))
 
@@ -264,7 +262,7 @@ class TestImportRecords:
 
     @patch("pragmata.api.annotation_import.fan_out_records")
     def test_accepts_hf_dataset(self, mock_fan_out: MagicMock) -> None:
-        mock_fan_out.return_value = {"ds1": 1}
+        mock_fan_out.return_value = ({"ds1": 1}, 0, 1)
 
         FakeDataset = type("Dataset", (), {"to_list": lambda self: [_make_raw()]})
         fake_ds = FakeDataset()
@@ -278,7 +276,7 @@ class TestImportRecords:
 
     @patch("pragmata.api.annotation_import.fan_out_records")
     def test_accepts_dataframe(self, mock_fan_out: MagicMock) -> None:
-        mock_fan_out.return_value = {"ds1": 1}
+        mock_fan_out.return_value = ({"ds1": 1}, 0, 1)
 
         FakeDataFrame = type("DataFrame", (), {"to_dict": lambda self, orient: [_make_raw()]})
         fake_df = FakeDataFrame()
@@ -289,3 +287,52 @@ class TestImportRecords:
             result = import_records(fake_df, dataset_id="test")
 
         assert result.total_records == 1
+
+
+class TestImportRecordsCalibrationValidation:
+    """Hard-error semantics for calibration_fraction vs topology mismatch."""
+
+    def test_fraction_out_of_range_raises(self) -> None:
+        with pytest.raises(ValueError, match="calibration_fraction"):
+            import_records([_make_raw()], dataset_id="t", calibration_fraction=1.5)
+
+    def test_negative_fraction_raises(self) -> None:
+        with pytest.raises(ValueError, match="calibration_fraction"):
+            import_records([_make_raw()], dataset_id="t", calibration_fraction=-0.1)
+
+    @staticmethod
+    def _no_calibration_config(tmp_path: Path) -> Path:
+        """Write a YAML config that disables calibration on every task."""
+        yaml_text = (
+            "workspace_dataset_map:\n"
+            "  retrieval:\n"
+            "    retrieval:\n"
+            "      production_min_submitted: 1\n"
+            "      calibration_min_submitted: null\n"
+            "  grounding:\n"
+            "    grounding:\n"
+            "      production_min_submitted: 1\n"
+            "      calibration_min_submitted: null\n"
+            "  generation:\n"
+            "    generation:\n"
+            "      production_min_submitted: 1\n"
+            "      calibration_min_submitted: null\n"
+        )
+        path = tmp_path / "config.yaml"
+        path.write_text(yaml_text)
+        return path
+
+    def test_fraction_zero_with_no_calibration_topology_ok(self, tmp_path: Path) -> None:
+        """`calibration_fraction=0` is fine even when topology disables calibration."""
+        config_path = self._no_calibration_config(tmp_path)
+
+        with patch("pragmata.api.annotation_import.fan_out_records") as mock_fan_out:
+            mock_fan_out.return_value = ({"retrieval_production": 1}, 0, 1)
+            result = import_records([_make_raw()], dataset_id="t", calibration_fraction=0.0, config_path=config_path)
+        assert result.calibration_count == 0
+
+    def test_fraction_positive_with_no_calibration_topology_raises(self, tmp_path: Path) -> None:
+        config_path = self._no_calibration_config(tmp_path)
+
+        with pytest.raises(ValueError, match="calibration_fraction"):
+            import_records([_make_raw()], dataset_id="t", calibration_fraction=0.1, config_path=config_path)

--- a/tests/unit/api/test_export_api.py
+++ b/tests/unit/api/test_export_api.py
@@ -295,4 +295,13 @@ class TestExportAnnotations:
 
         assert set(result.files.keys()) == {Task.RETRIEVAL, Task.GROUNDING, Task.GENERATION}
         called_names = {call.args[0] for call in mock_client.datasets.call_args_list}
-        assert called_names == {"retrieval", "grounding", "generation"}
+        # Default topology has calibration enabled, so each task is fetched twice
+        # (production + calibration). All three tasks must appear in both forms.
+        assert called_names == {
+            "retrieval_production",
+            "retrieval_calibration",
+            "grounding_production",
+            "grounding_calibration",
+            "generation_production",
+            "generation_calibration",
+        }

--- a/tests/unit/core/annotation/test_constraints.py
+++ b/tests/unit/core/annotation/test_constraints.py
@@ -21,6 +21,7 @@ _BASE = {
     "record_uuid": "abc123",
     "annotator_id": "user1",
     "language": "en",
+    "calibration": False,
     "inserted_at": _NOW,
     "created_at": _NOW,
     "record_status": "submitted",

--- a/tests/unit/core/annotation/test_dataset_naming.py
+++ b/tests/unit/core/annotation/test_dataset_naming.py
@@ -1,0 +1,37 @@
+"""Unit tests for the always-suffixed Argilla dataset name helper."""
+
+import pytest
+
+from pragmata.core.annotation.argilla_task_definitions import dataset_name
+from pragmata.core.schemas.annotation_task import Task
+
+
+class TestDatasetName:
+    @pytest.mark.parametrize(
+        "task,expected_base",
+        [
+            (Task.RETRIEVAL, "retrieval"),
+            (Task.GROUNDING, "grounding"),
+            (Task.GENERATION, "generation"),
+        ],
+    )
+    def test_production_suffix_no_dataset_id(self, task: Task, expected_base: str) -> None:
+        assert dataset_name(task, calibration=False) == f"{expected_base}_production"
+
+    @pytest.mark.parametrize(
+        "task,expected_base",
+        [
+            (Task.RETRIEVAL, "retrieval"),
+            (Task.GROUNDING, "grounding"),
+            (Task.GENERATION, "generation"),
+        ],
+    )
+    def test_calibration_suffix_no_dataset_id(self, task: Task, expected_base: str) -> None:
+        assert dataset_name(task, calibration=True) == f"{expected_base}_calibration"
+
+    def test_dataset_id_appended(self) -> None:
+        assert dataset_name(Task.RETRIEVAL, calibration=False, dataset_id="run1") == "retrieval_production_run1"
+        assert dataset_name(Task.RETRIEVAL, calibration=True, dataset_id="run1") == "retrieval_calibration_run1"
+
+    def test_empty_dataset_id_no_extra_suffix(self) -> None:
+        assert dataset_name(Task.GENERATION, calibration=True, dataset_id="") == "generation_calibration"

--- a/tests/unit/core/annotation/test_export_fetcher.py
+++ b/tests/unit/core/annotation/test_export_fetcher.py
@@ -15,7 +15,7 @@ from pragmata.core.schemas.annotation_export import (
     RetrievalAnnotation,
 )
 from pragmata.core.schemas.annotation_task import Task
-from pragmata.core.settings.annotation_settings import AnnotationSettings
+from pragmata.core.settings.annotation_settings import AnnotationSettings, TaskOverlap
 
 # ---------------------------------------------------------------------------
 # Mock helpers
@@ -23,7 +23,17 @@ from pragmata.core.settings.annotation_settings import AnnotationSettings
 
 _UID1 = UUID("00000000-0000-0000-0000-000000000001")
 _UID2 = UUID("00000000-0000-0000-0000-000000000002")
-_SETTINGS = AnnotationSettings()
+
+# Tests below use a topology with calibration disabled so that fetch_task
+# iterates a single dataset per task. Calibration-aware fetching is
+# exercised in the integration suite.
+_SETTINGS = AnnotationSettings(
+    workspace_dataset_map={
+        "retrieval": {Task.RETRIEVAL: TaskOverlap(calibration_min_submitted=None)},
+        "grounding": {Task.GROUNDING: TaskOverlap(calibration_min_submitted=None)},
+        "generation": {Task.GENERATION: TaskOverlap(calibration_min_submitted=None)},
+    }
+)
 
 
 def _make_response(question_name: str, value: Any, user_id: UUID, status: str = "submitted") -> MagicMock:

--- a/tests/unit/core/annotation/test_export_runner.py
+++ b/tests/unit/core/annotation/test_export_runner.py
@@ -28,6 +28,7 @@ _BASE = {
     "record_uuid": "abc123",
     "annotator_id": "user1",
     "language": "en",
+    "calibration": False,
     "inserted_at": _NOW,
     "created_at": _NOW,
     "record_status": "submitted",
@@ -296,16 +297,33 @@ class TestExportResult:
 # ---------------------------------------------------------------------------
 
 
+def _set_production_dataset(client: MagicMock, dataset: MagicMock) -> None:
+    """Wire ``client.datasets`` so production names resolve to ``dataset`` and calibration names to None.
+
+    fetch_task iterates production then calibration. Returning None for
+    calibration means tests focus on production behaviour; integration tests
+    cover calibration-aware fetching end-to-end.
+    """
+
+    def _datasets(name: str, workspace: str | None = None):
+        if "_calibration" in name:
+            return None
+        return dataset
+
+    client.datasets.side_effect = _datasets
+
+
 @pytest.fixture()
 def mock_client(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Mock Argilla client with production-only datasets."""
     client = MagicMock()
     user = MagicMock()
     user.id = _UID1
     user.username = "annotator1"
     client.users.list.return_value = [user]
-    dataset = MagicMock()
-    dataset.records.return_value = iter([])
-    client.datasets.return_value = dataset
+    empty_dataset = MagicMock()
+    empty_dataset.records.return_value = iter([])
+    _set_production_dataset(client, empty_dataset)
 
     import pragmata.api.annotation_export as export_module
 
@@ -326,7 +344,7 @@ class TestYesNoConversion:
         )
         dataset = MagicMock()
         dataset.records.return_value = iter([record])
-        mock_client.datasets.return_value = dataset
+        _set_production_dataset(mock_client, dataset)
 
         result = export_annotations(base_dir=tmp_path, export_id="test-run", tasks=[Task.RETRIEVAL])
         rows = list(csv.DictReader(result.files[Task.RETRIEVAL].open()))
@@ -345,7 +363,7 @@ class TestConstraintViolations:
         )
         dataset = MagicMock()
         dataset.records.return_value = iter([record])
-        mock_client.datasets.return_value = dataset
+        _set_production_dataset(mock_client, dataset)
 
         result = export_annotations(base_dir=tmp_path, export_id="test-run", tasks=[Task.RETRIEVAL])
         assert result.constraint_summary
@@ -363,7 +381,7 @@ class TestNotesCoercion:
         )
         dataset = MagicMock()
         dataset.records.return_value = iter([record])
-        mock_client.datasets.return_value = dataset
+        _set_production_dataset(mock_client, dataset)
 
         result = export_annotations(base_dir=tmp_path, export_id="test-run", tasks=[Task.RETRIEVAL])
         rows = list(csv.DictReader(result.files[Task.RETRIEVAL].open()))
@@ -386,7 +404,7 @@ class TestNAnnotators:
         )
         dataset = MagicMock()
         dataset.records.return_value = iter([record])
-        mock_client.datasets.return_value = dataset
+        _set_production_dataset(mock_client, dataset)
 
         result = export_annotations(base_dir=tmp_path, export_id="test-run", tasks=[Task.RETRIEVAL])
         assert result.n_annotators == {Task.RETRIEVAL: 2}
@@ -396,7 +414,7 @@ class TestNAnnotators:
 
         dataset = MagicMock()
         dataset.records.return_value = iter([])
-        mock_client.datasets.return_value = dataset
+        _set_production_dataset(mock_client, dataset)
 
         result = export_annotations(base_dir=tmp_path, export_id="test-run", tasks=[Task.RETRIEVAL])
         assert result.n_annotators == {Task.RETRIEVAL: 0}
@@ -415,7 +433,7 @@ class TestExportMetaSidecar:
         record = _make_record(fields=RETRIEVAL_FIELDS, metadata=BASE_METADATA, responses=_retrieval_responses(_UID1))
         dataset = MagicMock()
         dataset.records.return_value = iter([record])
-        mock_client.datasets.return_value = dataset
+        _set_production_dataset(mock_client, dataset)
 
         result = export_annotations(base_dir=tmp_path, export_id="test-run", tasks=[Task.RETRIEVAL])
 
@@ -434,7 +452,7 @@ class TestExportMetaSidecar:
 
         dataset = MagicMock()
         dataset.records.return_value = iter([])
-        mock_client.datasets.return_value = dataset
+        _set_production_dataset(mock_client, dataset)
 
         result = export_annotations(
             base_dir=tmp_path,
@@ -461,7 +479,7 @@ class TestExportMetaSidecar:
 
         dataset = MagicMock()
         dataset.records.return_value = iter([])
-        mock_client.datasets.return_value = dataset
+        _set_production_dataset(mock_client, dataset)
 
         result = export_annotations(base_dir=tmp_path, export_id="test-run", tasks=[Task.RETRIEVAL])
 

--- a/tests/unit/core/annotation/test_iaa_runner.py
+++ b/tests/unit/core/annotation/test_iaa_runner.py
@@ -18,6 +18,7 @@ from pragmata.core.schemas.iaa_report import IaaReport
 
 _BASE_FIELDS = {
     "language": "en",
+    "calibration": True,
     "inserted_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
     "record_status": "submitted",
     "response_status": "submitted",

--- a/tests/unit/core/annotation/test_partition.py
+++ b/tests/unit/core/annotation/test_partition.py
@@ -1,0 +1,153 @@
+"""Unit tests for record_builder partition logic and manifest IO."""
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from pragmata.core.annotation.record_builder import (
+    _bucket_calibration,
+    assign_partitions,
+    derive_record_uuid,
+    load_partition_manifest,
+    write_partition_manifest,
+)
+from pragmata.core.schemas.annotation_import import (
+    Chunk,
+    PartitionManifest,
+    PartitionManifestEntry,
+    QueryResponsePair,
+)
+
+
+def _make_pair(query: str = "Q?") -> QueryResponsePair:
+    return QueryResponsePair(
+        query=query,
+        answer="A.",
+        chunks=[Chunk(chunk_id=f"c-{query}", doc_id="d", chunk_rank=1, text="t")],
+        context_set="ctx",
+    )
+
+
+class TestBucketCalibration:
+    def test_zero_fraction_always_production(self) -> None:
+        for i in range(20):
+            assert _bucket_calibration(f"uuid-{i}", 0.0, seed=0) is False
+
+    def test_full_fraction_always_calibration(self) -> None:
+        for i in range(20):
+            assert _bucket_calibration(f"uuid-{i}", 1.0, seed=0) is True
+
+    def test_deterministic_across_calls(self) -> None:
+        results = [_bucket_calibration("uuid-x", 0.5, seed=42) for _ in range(10)]
+        assert len(set(results)) == 1
+
+    def test_different_seed_different_bucket(self) -> None:
+        # Probabilistic: different seeds usually flip at least one of N records
+        flips = 0
+        for i in range(50):
+            uuid = f"uuid-{i}"
+            if _bucket_calibration(uuid, 0.5, seed=0) != _bucket_calibration(uuid, 0.5, seed=99):
+                flips += 1
+        assert flips > 0
+
+    def test_fraction_bounded_for_uniform_uuids(self) -> None:
+        # 10% target on 1000 records should be near 100, with wide tolerance for hash variance
+        n_cal = sum(1 for i in range(1000) if _bucket_calibration(f"uuid-{i}", 0.1, seed=7))
+        assert 50 <= n_cal <= 150
+
+
+class TestAssignPartitions:
+    @pytest.fixture
+    def empty_manifest(self) -> PartitionManifest:
+        now = datetime.now(timezone.utc)
+        return PartitionManifest(
+            dataset_id="test",
+            created_at=now,
+            updated_at=now,
+            partition_seed=0,
+            assignments={},
+        )
+
+    def test_new_records_get_assignments(self, empty_manifest: PartitionManifest) -> None:
+        pairs = [_make_pair(f"q{i}") for i in range(10)]
+        result = assign_partitions(pairs, manifest=empty_manifest, fraction=1.0, import_id="imp1")
+
+        assert len(result) == 10
+        assert all(result.values())  # fraction=1.0 -> all calibration
+        assert len(empty_manifest.assignments) == 10
+
+    def test_existing_assignments_respected(self, empty_manifest: PartitionManifest) -> None:
+        # Pre-seed manifest with one record assigned to production
+        pair = _make_pair("q0")
+        rid = derive_record_uuid(pair)
+        empty_manifest.assignments[rid] = PartitionManifestEntry(
+            calibration=False,
+            import_id="prior",
+            calibration_fraction_at_import=0.0,
+            assigned_at=datetime.now(timezone.utc),
+        )
+
+        # Re-import with fraction=1.0 should keep the existing production assignment
+        result = assign_partitions([pair], manifest=empty_manifest, fraction=1.0, import_id="imp2")
+
+        assert result[rid] is False
+        assert empty_manifest.assignments[rid].import_id == "prior"
+
+    def test_new_records_use_current_fraction(self, empty_manifest: PartitionManifest) -> None:
+        pair = _make_pair("q0")
+        rid = derive_record_uuid(pair)
+        assign_partitions([pair], manifest=empty_manifest, fraction=1.0, import_id="imp1")
+
+        entry = empty_manifest.assignments[rid]
+        assert entry.calibration_fraction_at_import == 1.0
+        assert entry.import_id == "imp1"
+
+    def test_mixed_existing_and_new_records(self, empty_manifest: PartitionManifest) -> None:
+        existing = _make_pair("q-existing")
+        existing_rid = derive_record_uuid(existing)
+        empty_manifest.assignments[existing_rid] = PartitionManifestEntry(
+            calibration=True,
+            import_id="prior",
+            calibration_fraction_at_import=0.5,
+            assigned_at=datetime.now(timezone.utc),
+        )
+
+        new_pair = _make_pair("q-new")
+        result = assign_partitions([existing, new_pair], manifest=empty_manifest, fraction=0.0, import_id="imp2")
+
+        assert result[existing_rid] is True  # preserved
+        assert result[derive_record_uuid(new_pair)] is False  # new, fraction=0
+
+
+class TestManifestIO:
+    def test_load_empty_when_missing(self, tmp_path: Path) -> None:
+        path = tmp_path / "partition.meta.json"
+        manifest = load_partition_manifest(path, dataset_id="test", partition_seed=42)
+
+        assert manifest.dataset_id == "test"
+        assert manifest.partition_seed == 42
+        assert manifest.assignments == {}
+
+    def test_round_trip(self, tmp_path: Path) -> None:
+        path = tmp_path / "partition.meta.json"
+        original = load_partition_manifest(path, dataset_id="test", partition_seed=7)
+        original.assignments["uuid-1"] = PartitionManifestEntry(
+            calibration=True,
+            import_id="imp1",
+            calibration_fraction_at_import=0.1,
+            assigned_at=datetime(2026, 4, 22, tzinfo=timezone.utc),
+        )
+
+        write_partition_manifest(path, original)
+        restored = load_partition_manifest(path, dataset_id="test", partition_seed=7)
+
+        assert restored.dataset_id == original.dataset_id
+        assert restored.partition_seed == original.partition_seed
+        assert restored.assignments["uuid-1"] == original.assignments["uuid-1"]
+
+    def test_atomic_write_creates_directory(self, tmp_path: Path) -> None:
+        path = tmp_path / "nested" / "subdir" / "partition.meta.json"
+        manifest = load_partition_manifest(path, dataset_id="x", partition_seed=0)
+        write_partition_manifest(path, manifest)
+        assert path.exists()

--- a/tests/unit/core/schemas/test_annotation_export.py
+++ b/tests/unit/core/schemas/test_annotation_export.py
@@ -26,6 +26,7 @@ def base_fields():
         "record_uuid": "uuid-1",
         "annotator_id": "ann-1",
         "language": "en",
+        "calibration": False,
         "inserted_at": NOW,
         "created_at": NOW,
         "record_status": "submitted",
@@ -321,6 +322,7 @@ def _meta(**overrides) -> AnnotationExportMeta:
         "include_discarded": False,
         "row_counts": {Task.RETRIEVAL: 3},
         "n_annotators": {Task.RETRIEVAL: 2},
+        "calibration_enabled": {Task.RETRIEVAL: True},
         "constraint_summary": {},
     }
     return AnnotationExportMeta(**{**base, **overrides})
@@ -346,6 +348,7 @@ class TestAnnotationExportMeta:
                 include_discarded=False,
                 row_counts={},
                 n_annotators={},
+                calibration_enabled={},
                 constraint_summary={},
                 surprise="bad",  # type: ignore[call-arg]
             )
@@ -371,6 +374,7 @@ class TestAnnotationExportMeta:
             tasks=[Task.RETRIEVAL, Task.GROUNDING],
             row_counts={Task.RETRIEVAL: 3, Task.GROUNDING: 2},
             n_annotators={Task.RETRIEVAL: 2, Task.GROUNDING: 1},
+            calibration_enabled={Task.RETRIEVAL: True, Task.GROUNDING: False},
             constraint_summary={"some_rule": 1},
         )
         restored = AnnotationExportMeta.model_validate(original.model_dump(mode="json"))

--- a/tests/unit/core/settings/test_annotation_settings.py
+++ b/tests/unit/core/settings/test_annotation_settings.py
@@ -4,55 +4,67 @@ import pytest
 from pydantic import ValidationError
 
 from pragmata.core.schemas.annotation_task import Task
-from pragmata.core.settings.annotation_settings import AnnotationSettings, ArgillaSettings, UserSpec
+from pragmata.core.settings.annotation_settings import (
+    AnnotationSettings,
+    ArgillaSettings,
+    TaskOverlap,
+    UserSpec,
+)
 
 
 class TestAnnotationSettingsDefaults:
     def test_workspace_dataset_map_default(self):
         s = AnnotationSettings()
         assert s.workspace_dataset_map == {
-            "retrieval": [Task.RETRIEVAL],
-            "grounding": [Task.GROUNDING],
-            "generation": [Task.GENERATION],
+            "retrieval": {Task.RETRIEVAL: TaskOverlap()},
+            "grounding": {Task.GROUNDING: TaskOverlap()},
+            "generation": {Task.GENERATION: TaskOverlap()},
         }
 
     def test_dataset_id_default(self):
         s = AnnotationSettings()
         assert s.dataset_id == ""
 
-    def test_min_submitted_default(self):
+    def test_calibration_partition_seed_default(self):
         s = AnnotationSettings()
-        assert s.min_submitted == 1
+        assert s.calibration_partition_seed == 0
 
     def test_extra_fields_forbidden(self):
         with pytest.raises(ValidationError):
             AnnotationSettings(nonexistent_field="value")
 
 
+class TestTaskOverlapDefaults:
+    def test_production_default(self):
+        o = TaskOverlap()
+        assert o.production_min_submitted == 1
+
+    def test_calibration_enabled_at_three(self):
+        o = TaskOverlap()
+        assert o.calibration_min_submitted == 3
+
+    def test_calibration_can_be_disabled(self):
+        o = TaskOverlap(calibration_min_submitted=None)
+        assert o.calibration_min_submitted is None
+
+    def test_extra_fields_forbidden(self):
+        with pytest.raises(ValidationError):
+            TaskOverlap(nonexistent_field=1)  # type: ignore[call-arg]
+
+
 class TestAnnotationSettingsResolve:
     def test_resolve_with_no_args_returns_defaults(self):
         s = AnnotationSettings.resolve()
-        assert s.min_submitted == 1
+        assert s.calibration_partition_seed == 0
         assert s.dataset_id == ""
-
-    def test_resolve_overrides_min_submitted(self):
-        s = AnnotationSettings.resolve(overrides={"min_submitted": 3})
-        assert s.min_submitted == 3
 
     def test_resolve_overrides_dataset_id(self):
         s = AnnotationSettings.resolve(overrides={"dataset_id": "run1"})
         assert s.dataset_id == "run1"
 
-    def test_resolve_config_layer(self):
-        s = AnnotationSettings.resolve(config={"min_submitted": 2})
-        assert s.min_submitted == 2
-
-    def test_resolve_overrides_win_over_config(self):
-        s = AnnotationSettings.resolve(
-            config={"min_submitted": 2},
-            overrides={"min_submitted": 5},
-        )
-        assert s.min_submitted == 5
+    def test_resolve_overrides_partition_seed(self):
+        s = AnnotationSettings.resolve(overrides={"calibration_partition_seed": 42})
+        assert s.calibration_partition_seed == 42
 
 
 class TestArgillaSettings:


### PR DESCRIPTION
## Goal

Support partial-overlap annotation: a small calibration subset annotated by all annotators (for inter-annotator agreement) while the bulk runs single-annotated. 

## Problem

Argilla v2's `TaskDistribution(min_submitted=N)` is dataset-wide and frozen once annotation begins ([docs](https://docs.argilla.io/latest/how_to_guides/distribution/), verified in `argilla-server/src/argilla_server/contexts/distribution.py`). There is no per-record overlap, no metadata-based completion threshold, etc. Argilla's own tracker confirms there is no
clean native fix:
- [argilla#3361](https://github.com/argilla-io/argilla/issues/3361) closed in favour of #4067
- [argilla#4067](https://github.com/argilla-io/argilla/issues/4067) is just a docs request to use metadata-based assignment
- [argilla#4792](https://github.com/argilla-io/argilla/pull/4792) closed unmerged; maintainer confirmed full overlap is just default behaviour

Metadata-based assignment only controls UI queue visibility, not completion thresholds, so it cannot solve mixed overlap within one dataset. The only viable workaround is **two datasets per task**: ``task_<task>_calibration``
(``min_submitted=N``) alongside ``task_<task>_production``(``min_submitted=1``).

## Use cases

The design supports these workflows naturally:

1. **Standard pilot (default)**: First import with default `calibration_fraction=0.1`. ~10% of records routed to calibration (`min_submitted=3`), 90% to production (`min_submitted=1`). Run IAA on calibration. Refine guidelines if needed.
2. **Production-only first batch**: First import with `calibration_fraction=0.0`. Only the production dataset is created in Argilla (lazy creation). Calibration dataset does not exist yet but topology supports it.
3. **Add calibration later**: A later import with `calibration_fraction=0.1` on a fresh batch creates the calibration dataset on the fly. Earlier production-only records stay where they are (manifest locks assignments).
4. **Re-calibrate after drift suspicion**: Run a fresh batch with `calibration_fraction=0.1`. New records partition normally; existing manifest entries preserved.
5. **Disable calibration entirely** (rare, opt-out): Set `calibration_min_submitted=None` in topology. All imports go production-only; `calibration_fraction > 0` errors hard at import time.

## Scope

### Settings shape

`workspace_dataset_map` becomes `dict[str, dict[Task, TaskOverlap]]` where `TaskOverlap(production_min_submitted=1, calibration_min_submitted=3)`. Setting `calibration_min_submitted=None` disables calibration for that task. 
Top-level `min_submitted` removed. New `calibration_partition_seed: int = 0`.

`calibration_min_submitted=3` is the canonical robust default - Krippendorff alpha plus pairwise Cohen kappa needs ≥2 annotators per item; 3 gives meaningful pairwise coverage.

### Dataset naming

Always-suffixed: `task_retrieval_production` and `task_retrieval_calibration`, regardless of whether calibration is enabled. The calibration dataset is only created at import time when records partition into it (lazy creation preserved). Future imports can flexibly add a calibration dataset without renaming any existing dataset.

### Import API

`import_records()` gains `calibration_fraction: float = 0.1` per-import kwarg. Records are partitioned deterministically by `record_uuid` hash. A **hard error** is raised if `calibration_fraction > 0` but topology declares
no calibration dataset for any task receiving records - silent rerouting hides user mistakes. `ImportResult` is extended with `calibration_count`,`production_count`, and effective `calibration_fraction`.

### Partition manifest

A persistent `record_uuid → calibration|production` map per `dataset_id` locks assignments across re-imports. Without this, re-importing with a different fraction would shift already-imported records between datasets and create ghost records in Argilla.

The manifest also records the `import_id` and `calibration_fraction_at_import` per entry, providing a full audit trail.
Sidecar lives at `tool_root/imports/{dataset_id|"default"}/partition.meta.json` and mirrors the existing `AnnotationExportMeta` pattern.

>*NB re: Manifest path scope: asymmetry  between import vs export is intentional here:
>
>| Aspect | Import | Export |
>|---|---|---|
>| Target | Argilla (mutable) | CSV (immutable snapshot) |
>| State | Accumulating across calls | Frozen per call |
>| Path scope | `dataset_id` (state collector) | `export_id` (snapshot) |
>
>Imports mutate a persistent target so need a single accumulating manifest per `dataset_id`. Exports are immutable snapshots that benefit from timestamped per-call directories.

### Export

One CSV per task preserved (`retrieval.csv`, etc.). Rows distinguished by a new `calibration: bool` column on every annotation model. Argilla dataset naming and CSV naming serve different audiences (UI vs eval pipelines); different shapes are appropriate. `AnnotationExportMeta` sidecar gains `calibration_enabled: dict[Task, bool]`.

### IAA

`compute_iaa()` filters CSV rows to `calibration=True` by default - IAA is only meaningful on overlapped records. No new kwarg added; the column-based filter is the entire mechanism. Empty-result case returns an empty `IaaReport` with a warning, matching the existing "skip empty CSV" pattern.

## Implementation

Files modified:

- Settings: [annotation_settings.py](src/pragmata/core/settings/annotation_settings.py) - `TaskOverlap` model, nested `workspace_dataset_map`, drop `min_submitted`.
- Schemas: [annotation_import.py](src/pragmata/core/schemas/annotation_import.py) - `PartitionManifest` + `PartitionManifestEntry`. [annotation_export.py](src/pragmata/core/schemas/annotation_export.py) - `calibration: bool` field on annotation models, `calibration_enabled` on meta.
- Paths: [annotation_paths.py](src/pragmata/core/paths/annotation_paths.py) - `AnnotationImportPaths` bundle and `resolve_import_paths()`.
- Core: [argilla_task_definitions.py](src/pragmata/core/annotation/argilla_task_definitions.py) `dataset_name()` helper. [record_builder.py](src/pragmata/core/annotation/record_builder.py) partition logic, manifest IO, `fan_out_records` per-purpose write. [setup.py](src/pragmata/core/annotation/setup.py) per-purpose teardown. [export_fetcher.py](src/pragmata/core/annotation/export_fetcher.py) iterates both datasets, tags rows. [export_runner.py](src/pragmata/core/annotation/export_runner.py) sidecar carries `calibration_enabled`. [iaa_runner.py](src/pragmata/core/annotation/iaa_runner.py) filter rows by `calibration` column.
- API: [annotation_import.py](src/pragmata/api/annotation_import.py) - `calibration_fraction` kwarg, manifest IO, hard-error validation, extended `ImportResult`. [annotation_setup.py](src/pragmata/api/annotation_setup.py) - drop `min_submitted` kwarg.
- CLI: [commands/annotation.py](src/pragmata/cli/commands/annotation.py) - `--calibration-fraction` flag.

## Testing

635 unit tests pass (24 new). New test files:

- [test_partition.py](tests/unit/core/annotation/test_partition.py) - `_bucket_calibration` determinism, fraction bounds, edge cases. `assign_partitions` honours existing manifest entries. Manifest IO round-trip and atomic write.
- [test_dataset_naming.py](tests/unit/core/annotation/test_dataset_naming.py) - always-suffixed naming with/without `dataset_id`.
- [test_annotation.py](tests/unit/api/test_annotation.py) `TestImportRecordsCalibrationValidation` - fraction range validation; hard-error when topology disables calibration but fraction > 0.
- [test_annotation_calibration.py](tests/integration/test_annotation_calibration.py) - Argilla-backed E2E tests for default fraction, fraction=0 lazy skip, re-import locking, growing batches, and Argilla-side dataset placement.

Existing tests updated for the new shape (TaskOverlap, `calibration` field on annotation models, per-purpose dataset names in integration tests).

`mypy src/pragmata` clean. `ruff check` and `ruff format --check` clean.

## References

- [docs/issue-specs/annotation-calibration-overlap.md](docs/issue-specs/annotation-calibration-overlap.md) - original spec
- Design docs: `docs/design/annotation-import-pipeline.md`, `docs/design/annotation-export-pipeline.md`
- ADR-0009 (hardcoded protocol, configurable operations)