### PR TITLE
refactor(annotation): introduce TaskOverlap and nested workspace_dataset_map

### DIFF
--- a/src/pragmata/api/annotation_setup.py
+++ b/src/pragmata/api/annotation_setup.py
@@ -20,7 +20,6 @@ def setup(
     *,
     api_url: str | Unset = UNSET,
     api_key: str | Unset = UNSET,
-    min_submitted: int | Unset = UNSET,
     base_dir: str | Path | Unset = UNSET,
     config_path: str | Path | Unset = UNSET,
 ) -> SetupResult:
@@ -31,7 +30,9 @@ def setup(
     workspaces. Existing resources are skipped.
 
     Datasets are not created here — they are auto-created on import,
-    scoped by dataset_id.
+    scoped by dataset_id. Per-task overlap (production and calibration
+    ``min_submitted``) is configured via ``workspace_dataset_map`` in the
+    YAML config or ``AnnotationSettings``.
 
     Settings are resolved from config file and/or keyword overrides. Omitted
     values fall through to config-file defaults, then built-in defaults.
@@ -44,7 +45,6 @@ def setup(
         users: User accounts to provision. Pass None to skip user setup.
         api_url: Argilla server URL.
         api_key: Argilla API key.
-        min_submitted: Minimum annotations required per record.
         base_dir: Workspace base directory. Defaults to cwd.
         config_path: Path to YAML config file for settings resolution.
 
@@ -56,7 +56,6 @@ def setup(
         env={"argilla": {"api_url": os.environ.get("ARGILLA_API_URL")}} if os.environ.get("ARGILLA_API_URL") else None,
         overrides={
             "argilla": {"api_url": api_url},
-            "min_submitted": min_submitted,
             "base_dir": base_dir,
         },
     )

--- a/src/pragmata/api/annotation_setup.py
+++ b/src/pragmata/api/annotation_setup.py
@@ -32,7 +32,7 @@ def setup(
     Datasets are not created here — they are auto-created on import,
     scoped by dataset_id. Per-task overlap (production and calibration
     ``min_submitted``) is configured via ``workspace_dataset_map`` in the
-    YAML config or ``AnnotationSettings``.
+    YAML config.
 
     Settings are resolved from config file and/or keyword overrides. Omitted
     values fall through to config-file defaults, then built-in defaults.

--- a/src/pragmata/cli/commands/annotation.py
+++ b/src/pragmata/cli/commands/annotation.py
@@ -24,9 +24,6 @@ def setup_command(
     api_key: str | None = _api_key_opt,
     base_dir: str | None = _base_dir_opt,
     config: str | None = _config_opt,
-    min_submitted: int | None = typer.Option(
-        None, "--min-submitted", help="Minimum submitted annotations required per record before it is complete."
-    ),
     users_json: str | None = typer.Option(
         None,
         "--users",
@@ -36,7 +33,9 @@ def setup_command(
 ) -> None:
     """Create Argilla workspaces and (optionally) user accounts.
 
-    Datasets are created automatically on import, not here.
+    Datasets are created automatically on import, not here. Per-task overlap
+    (production and calibration ``min_submitted``) is configured via
+    ``workspace_dataset_map`` in the YAML config.
     """
     from pragmata import annotation
 
@@ -44,7 +43,6 @@ def setup_command(
         parse_user_specs(users_json),
         api_url=UNSET if api_url is None else api_url,
         api_key=UNSET if api_key is None else api_key,
-        min_submitted=UNSET if min_submitted is None else min_submitted,
         base_dir=UNSET if base_dir is None else base_dir,
         config_path=UNSET if config is None else config,
     )

--- a/src/pragmata/core/annotation/export_fetcher.py
+++ b/src/pragmata/core/annotation/export_fetcher.py
@@ -108,8 +108,8 @@ def fetch_task(
     dataset_name = apply_suffix(DATASET_NAMES[task], settings.dataset_id)
 
     workspace_name: str | None = None
-    for ws_base, tasks in settings.workspace_dataset_map.items():
-        if task in tasks:
+    for ws_base, task_overlaps in settings.workspace_dataset_map.items():
+        if task in task_overlaps:
             workspace_name = ws_base
             break
 

--- a/src/pragmata/core/annotation/record_builder.py
+++ b/src/pragmata/core/annotation/record_builder.py
@@ -17,7 +17,7 @@ from pragmata.core.annotation.argilla_ops import apply_suffix, create_dataset
 from pragmata.core.annotation.argilla_task_definitions import DATASET_NAMES, build_task_settings
 from pragmata.core.schemas.annotation_import import QueryResponsePair
 from pragmata.core.schemas.annotation_task import Task
-from pragmata.core.settings.annotation_settings import AnnotationSettings
+from pragmata.core.settings.annotation_settings import AnnotationSettings, TaskOverlap
 
 logger = logging.getLogger(__name__)
 
@@ -142,12 +142,14 @@ def build_generation_record(pair: QueryResponsePair, record_uuid: str) -> rg.Rec
     )
 
 
-def _invert_workspace_map(workspace_dataset_map: dict[str, list[Task]]) -> dict[Task, str]:
-    """Invert workspace_dataset_map to task → workspace_base lookup."""
-    task_to_ws: dict[Task, str] = {}
-    for ws_base, tasks in workspace_dataset_map.items():
-        for task in tasks:
-            task_to_ws[task] = ws_base
+def _invert_workspace_map(
+    workspace_dataset_map: dict[str, dict[Task, TaskOverlap]],
+) -> dict[Task, tuple[str, TaskOverlap]]:
+    """Invert workspace_dataset_map to task → (workspace_base, overlap)."""
+    task_to_ws: dict[Task, tuple[str, TaskOverlap]] = {}
+    for ws_base, task_overlaps in workspace_dataset_map.items():
+        for task, overlap in task_overlaps.items():
+            task_to_ws[task] = (ws_base, overlap)
     return task_to_ws
 
 
@@ -184,10 +186,11 @@ def fan_out_records(
     for task, rg_records in batches.items():
         if not rg_records:
             continue
-        ws_base = task_to_ws.get(task)
-        if ws_base is None:
+        binding = task_to_ws.get(task)
+        if binding is None:
             logger.warning("Task %r not in workspace_dataset_map — skipping", task)
             continue
+        ws_base, overlap = binding
 
         ds_name = apply_suffix(DATASET_NAMES[task], settings.dataset_id)
 
@@ -201,7 +204,7 @@ def fan_out_records(
             questions=base_settings.questions,
             metadata=base_settings.metadata,
             guidelines=base_settings.guidelines,
-            distribution=rg.TaskDistribution(min_submitted=settings.min_submitted),
+            distribution=rg.TaskDistribution(min_submitted=overlap.production_min_submitted),
         )
         dataset, ds_created = create_dataset(client, ds_name, ws_base, task_cfg)
         if ds_created:

--- a/src/pragmata/core/annotation/setup.py
+++ b/src/pragmata/core/annotation/setup.py
@@ -96,13 +96,13 @@ def teardown_resources(
     Ordering: datasets first (Argilla requires workspace to be empty before deletion).
     Missing resources are silently skipped. User accounts are not touched.
     """
-    for ws_base, tasks in settings.workspace_dataset_map.items():
+    for ws_base, task_overlaps in settings.workspace_dataset_map.items():
         workspace = client.workspaces(ws_base)
         if workspace is None:
             logger.info("Workspace %r not found — skipping", ws_base)
             continue
 
-        for task in tasks:
+        for task in task_overlaps:
             ds_name = apply_suffix(DATASET_NAMES[task], settings.dataset_id)
             dataset = client.datasets(ds_name, workspace=ws_base)
             if dataset is not None:

--- a/src/pragmata/core/settings/annotation_settings.py
+++ b/src/pragmata/core/settings/annotation_settings.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, NonNegativeInt, PositiveInt
 
 from pragmata.core.schemas.annotation_task import Task
 from pragmata.core.settings.settings_base import ResolveSettings
@@ -18,10 +18,33 @@ class ArgillaSettings(BaseModel):
     api_url: str | None = None
 
 
+class TaskOverlap(BaseModel):
+    """Per-task overlap topology: production and (optional) calibration thresholds.
+
+    Calibration is declared here so future imports can route a subset of
+    records to a separate calibration dataset for IAA. This PR only reads
+    ``production_min_submitted``; calibration support arrives in subsequent
+    PRs.
+
+    Attributes:
+        production_min_submitted: Argilla ``min_submitted`` for the production
+            dataset (typically 1; >1 enables full overlap on production).
+        calibration_min_submitted: Argilla ``min_submitted`` for a future
+            calibration dataset, or ``None`` to disable calibration for this
+            task. Default 3 covers Krippendorff alpha plus pairwise Cohen
+            kappa.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    production_min_submitted: PositiveInt = 1
+    calibration_min_submitted: PositiveInt | None = 3
+
+
 class AnnotationSettings(ResolveSettings):
     """Configurable runtime settings for annotation (setup, import, export).
 
-    Controls workspace topology and task-distribution thresholds.
+    Controls workspace topology and per-task overlap thresholds.
     Task definitions (Argilla rg.Settings per task) are hardcoded — see
     core/annotation/argilla_task_definitions.py.
     """
@@ -29,14 +52,14 @@ class AnnotationSettings(ResolveSettings):
     argilla: ArgillaSettings = Field(default_factory=ArgillaSettings)
     base_dir: Path = Field(default_factory=Path.cwd)
     dataset_id: str = ""
-    workspace_dataset_map: dict[str, list[Task]] = Field(
+    workspace_dataset_map: dict[str, dict[Task, TaskOverlap]] = Field(
         default_factory=lambda: {
-            "retrieval": [Task.RETRIEVAL],
-            "grounding": [Task.GROUNDING],
-            "generation": [Task.GENERATION],
+            "retrieval": {Task.RETRIEVAL: TaskOverlap()},
+            "grounding": {Task.GROUNDING: TaskOverlap()},
+            "generation": {Task.GENERATION: TaskOverlap()},
         }
     )
-    min_submitted: int = 1
+    calibration_partition_seed: NonNegativeInt = 0
     include_discarded: bool = False
 
 

--- a/src/pragmata/core/settings/annotation_settings.py
+++ b/src/pragmata/core/settings/annotation_settings.py
@@ -22,9 +22,7 @@ class TaskOverlap(BaseModel):
     """Per-task overlap topology: production and (optional) calibration thresholds.
 
     Calibration is declared here so future imports can route a subset of
-    records to a separate calibration dataset for IAA. This PR only reads
-    ``production_min_submitted``; calibration support arrives in subsequent
-    PRs.
+    records to a separate calibration dataset for IAA.
 
     Attributes:
         production_min_submitted: Argilla ``min_submitted`` for the production

--- a/tests/unit/api/test_annotation.py
+++ b/tests/unit/api/test_annotation.py
@@ -88,17 +88,6 @@ class TestSetup:
 
     @patch("pragmata.api.annotation_setup.provision_users")
     @patch("pragmata.api.annotation_setup.setup_workspaces")
-    def test_resolves_min_submitted(self, mock_ds: MagicMock, mock_users: MagicMock) -> None:
-        mock_ds.return_value = SetupResult()
-        mock_users.return_value = SetupResult()
-
-        setup(min_submitted=3)
-
-        settings: AnnotationSettings = mock_ds.call_args[0][1]
-        assert settings.min_submitted == 3
-
-    @patch("pragmata.api.annotation_setup.provision_users")
-    @patch("pragmata.api.annotation_setup.setup_workspaces")
     def test_passes_users_to_provision(self, mock_ds: MagicMock, mock_users: MagicMock) -> None:
         mock_ds.return_value = SetupResult()
         mock_users.return_value = SetupResult()

--- a/tests/unit/core/settings/test_annotation_settings.py
+++ b/tests/unit/core/settings/test_annotation_settings.py
@@ -4,55 +4,71 @@ import pytest
 from pydantic import ValidationError
 
 from pragmata.core.schemas.annotation_task import Task
-from pragmata.core.settings.annotation_settings import AnnotationSettings, ArgillaSettings, UserSpec
+from pragmata.core.settings.annotation_settings import (
+    AnnotationSettings,
+    ArgillaSettings,
+    TaskOverlap,
+    UserSpec,
+)
 
 
 class TestAnnotationSettingsDefaults:
     def test_workspace_dataset_map_default(self):
         s = AnnotationSettings()
         assert s.workspace_dataset_map == {
-            "retrieval": [Task.RETRIEVAL],
-            "grounding": [Task.GROUNDING],
-            "generation": [Task.GENERATION],
+            "retrieval": {Task.RETRIEVAL: TaskOverlap()},
+            "grounding": {Task.GROUNDING: TaskOverlap()},
+            "generation": {Task.GENERATION: TaskOverlap()},
         }
 
     def test_dataset_id_default(self):
         s = AnnotationSettings()
         assert s.dataset_id == ""
 
-    def test_min_submitted_default(self):
+    def test_calibration_partition_seed_default(self):
         s = AnnotationSettings()
-        assert s.min_submitted == 1
+        assert s.calibration_partition_seed == 0
 
     def test_extra_fields_forbidden(self):
         with pytest.raises(ValidationError):
             AnnotationSettings(nonexistent_field="value")
 
 
+class TestTaskOverlapDefaults:
+    def test_production_default_one(self):
+        o = TaskOverlap()
+        assert o.production_min_submitted == 1
+
+    def test_calibration_default_three(self):
+        o = TaskOverlap()
+        assert o.calibration_min_submitted == 3
+
+    def test_calibration_can_be_disabled(self):
+        o = TaskOverlap(calibration_min_submitted=None)
+        assert o.calibration_min_submitted is None
+
+    def test_extra_fields_forbidden(self):
+        with pytest.raises(ValidationError):
+            TaskOverlap(nonexistent_field=1)  # type: ignore[call-arg]
+
+    def test_production_must_be_positive(self):
+        with pytest.raises(ValidationError):
+            TaskOverlap(production_min_submitted=0)
+
+
 class TestAnnotationSettingsResolve:
     def test_resolve_with_no_args_returns_defaults(self):
         s = AnnotationSettings.resolve()
-        assert s.min_submitted == 1
+        assert s.calibration_partition_seed == 0
         assert s.dataset_id == ""
-
-    def test_resolve_overrides_min_submitted(self):
-        s = AnnotationSettings.resolve(overrides={"min_submitted": 3})
-        assert s.min_submitted == 3
 
     def test_resolve_overrides_dataset_id(self):
         s = AnnotationSettings.resolve(overrides={"dataset_id": "run1"})
         assert s.dataset_id == "run1"
 
-    def test_resolve_config_layer(self):
-        s = AnnotationSettings.resolve(config={"min_submitted": 2})
-        assert s.min_submitted == 2
-
-    def test_resolve_overrides_win_over_config(self):
-        s = AnnotationSettings.resolve(
-            config={"min_submitted": 2},
-            overrides={"min_submitted": 5},
-        )
-        assert s.min_submitted == 5
+    def test_resolve_overrides_partition_seed(self):
+        s = AnnotationSettings.resolve(overrides={"calibration_partition_seed": 42})
+        assert s.calibration_partition_seed == 42
 
 
 class TestArgillaSettings:


### PR DESCRIPTION
## Goal

Replace the dataset-wide ``min_submitted`` setting with a per-task ``TaskOverlap`` model, opening room for per-task overlap configuration without changing current runtime behaviour.

## What changes

- New `TaskOverlap` Pydantic model: `production_min_submitted: int = 1`, `calibration_min_submitted: int | None = 3`
- `AnnotationSettings.workspace_dataset_map`: `dict[str, list[Task]]` → `dict[str, dict[Task, TaskOverlap]]`
- Top-level `min_submitted: int = 1` removed (now lives on `TaskOverlap`)
- `fan_out_records()` reads `overlap.production_min_submitted` (semantically identical to the old `settings.min_submitted` for default config)
- `--min-submitted` CLI flag removed; `min_submitted` kwarg on `setup()` removed
- Existing tests updated; new tests for `TaskOverlap` defaults and validation

**Breaking change**: Configs that set top-level `min_submitted` need to migrate. 

## Testing

- 610 unit tests pass (new tests added for TaskOverlap)
- `mypy src/pragmata` clean
- `ruff check` and `ruff format --check` clean