### PR TITLE
feat(annotation): add PartitionManifest schema, calibration field, import paths

### DIFF
--- a/src/pragmata/core/paths/annotation_paths.py
+++ b/src/pragmata/core/paths/annotation_paths.py
@@ -36,6 +36,52 @@ def resolve_annotation_paths(*, workspace: WorkspacePaths) -> AnnotationPaths:
 
 
 @dataclass(frozen=True, slots=True)
+class AnnotationImportPaths:
+    """Path bundle for an annotation import scope (one per ``dataset_id``).
+
+    Imports accumulate state across calls into the same logical scope, so the
+    bundle is keyed by ``dataset_id`` (persistent topology scope) rather than
+    a per-call identifier. The partition manifest sidecar tracks calibration
+    vs production assignment for every record imported into this scope.
+
+    Attributes:
+        tool_root: Annotation tool root.
+        import_dir: Per-``dataset_id`` import directory.
+        partition_manifest: Partition manifest sidecar path.
+    """
+
+    tool_root: Path
+    import_dir: Path
+    partition_manifest: Path
+
+    def ensure_dirs(self) -> Self:
+        """Create the import directory scaffold."""
+        self.import_dir.mkdir(parents=True, exist_ok=True)
+        return self
+
+
+def resolve_import_paths(*, workspace: WorkspacePaths, dataset_id: str) -> AnnotationImportPaths:
+    """Build the path bundle for an annotation import scope.
+
+    Args:
+        workspace: Workspace path bundle.
+        dataset_id: Topology scope. Empty string maps to the ``"default"``
+            directory so the layout is uniform across scopes.
+
+    Returns:
+        Path bundle for the import scope.
+    """
+    tool_root = workspace.tool_root("annotation")
+    scope = dataset_id or "default"
+    import_dir = tool_root / "imports" / scope
+    return AnnotationImportPaths(
+        tool_root=tool_root,
+        import_dir=import_dir,
+        partition_manifest=import_dir / "partition.meta.json",
+    )
+
+
+@dataclass(frozen=True, slots=True)
 class AnnotationExportPaths:
     """Path bundle for an annotation export run.
 

--- a/src/pragmata/core/paths/annotation_paths.py
+++ b/src/pragmata/core/paths/annotation_paths.py
@@ -45,12 +45,10 @@ class AnnotationImportPaths:
     vs production assignment for every record imported into this scope.
 
     Attributes:
-        tool_root: Annotation tool root.
         import_dir: Per-``dataset_id`` import directory.
         partition_manifest: Partition manifest sidecar path.
     """
 
-    tool_root: Path
     import_dir: Path
     partition_manifest: Path
 
@@ -71,11 +69,9 @@ def resolve_import_paths(*, workspace: WorkspacePaths, dataset_id: str) -> Annot
     Returns:
         Path bundle for the import scope.
     """
-    tool_root = workspace.tool_root("annotation")
     scope = dataset_id or "default"
-    import_dir = tool_root / "imports" / scope
+    import_dir = workspace.tool_root("annotation") / "imports" / scope
     return AnnotationImportPaths(
-        tool_root=tool_root,
         import_dir=import_dir,
         partition_manifest=import_dir / "partition.meta.json",
     )

--- a/src/pragmata/core/schemas/annotation_export.py
+++ b/src/pragmata/core/schemas/annotation_export.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, NonNegativeInt, model_validator
+from pydantic import BaseModel, ConfigDict, Field, NonNegativeInt, model_validator
 
 from pragmata.core.schemas.annotation_task import DiscardReason, Task
 
@@ -24,6 +24,7 @@ class AnnotationBase(BaseModel):
     annotator_id: str
     task: Task
     language: str | None
+    calibration: bool = False
     inserted_at: datetime
     created_at: datetime
     record_status: str
@@ -121,14 +122,21 @@ class AnnotationExportMeta(BaseModel):
     include_discarded: bool
     row_counts: dict[Task, NonNegativeInt]
     n_annotators: dict[Task, NonNegativeInt]
+    calibration_enabled: dict[Task, bool] = Field(default_factory=dict)
     constraint_summary: dict[str, NonNegativeInt]
 
     @model_validator(mode="after")
     def validate_keys_match_tasks(self) -> "AnnotationExportMeta":
-        """Enforce per-task dicts cover exactly the exported tasks."""
+        """Enforce per-task dicts cover exactly the exported tasks.
+
+        ``calibration_enabled`` is optional: when absent (empty), no check is
+        performed; when populated, its keys must match ``tasks``.
+        """
         expected = set(self.tasks)
         if set(self.row_counts) != expected:
             raise ValueError("row_counts keys must match tasks")
         if set(self.n_annotators) != expected:
             raise ValueError("n_annotators keys must match tasks")
+        if self.calibration_enabled and set(self.calibration_enabled) != expected:
+            raise ValueError("calibration_enabled keys must match tasks")
         return self

--- a/src/pragmata/core/schemas/annotation_import.py
+++ b/src/pragmata/core/schemas/annotation_import.py
@@ -1,4 +1,6 @@
-"""Boundary schemas for canonical annotation import records."""
+"""Boundary schemas for canonical annotation import records and partition state."""
+
+from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -44,3 +46,45 @@ class QueryResponsePair(BaseModel):
     chunks: list[Chunk] = Field(min_length=1)
     context_set: NonEmptyStr
     language: str | None = None
+
+
+class PartitionManifestEntry(BaseModel):
+    """One record's calibration vs production assignment with import provenance.
+
+    Attributes:
+        calibration: True if assigned to the calibration dataset, else production.
+        import_id: Identifier of the import call that produced this assignment.
+        calibration_fraction_at_import: The fraction in force at that import call.
+        assigned_at: When the assignment was made.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    calibration: bool
+    import_id: str
+    calibration_fraction_at_import: float = Field(ge=0.0, le=1.0)
+    assigned_at: datetime
+
+
+class PartitionManifest(BaseModel):
+    """Persistent record_uuid -> assignment map scoped to one ``dataset_id``.
+
+    Locks calibration vs production assignments across re-imports so growing
+    or repeated batches never reshuffle records between Argilla datasets.
+
+    Attributes:
+        dataset_id: Topology scope this manifest belongs to (empty string ok).
+        created_at: First write timestamp.
+        updated_at: Most recent write timestamp.
+        partition_seed: Hash seed used for new-record assignments. Stored at
+            manifest level - changing seed mid-scope only affects new records.
+        assignments: Map of record_uuid -> PartitionManifestEntry.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    dataset_id: str
+    created_at: datetime
+    updated_at: datetime
+    partition_seed: int
+    assignments: dict[str, PartitionManifestEntry] = Field(default_factory=dict)

--- a/src/pragmata/core/schemas/annotation_import.py
+++ b/src/pragmata/core/schemas/annotation_import.py
@@ -1,10 +1,11 @@
 """Boundary schemas for canonical annotation import records and partition state."""
 
 from datetime import datetime
+from typing import Self
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from pragmata.core.types import NonEmptyStr
+from pragmata.core.types import NonEmptyStr, SafePathSegment
 
 
 class Chunk(BaseModel):
@@ -61,7 +62,7 @@ class PartitionManifestEntry(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
     calibration: bool
-    import_id: str
+    import_id: NonEmptyStr
     calibration_fraction_at_import: float = Field(ge=0.0, le=1.0)
     assigned_at: datetime
 
@@ -83,8 +84,14 @@ class PartitionManifest(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    dataset_id: str
+    dataset_id: SafePathSegment
     created_at: datetime
     updated_at: datetime
     partition_seed: int
     assignments: dict[str, PartitionManifestEntry] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _check_timestamps(self) -> Self:
+        if self.updated_at < self.created_at:
+            raise ValueError("updated_at must be >= created_at")
+        return self

--- a/src/pragmata/core/settings/annotation_settings.py
+++ b/src/pragmata/core/settings/annotation_settings.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field, NonNegativeInt, PositiveInt
 
 from pragmata.core.schemas.annotation_task import Task
 from pragmata.core.settings.settings_base import ResolveSettings
+from pragmata.core.types import SafePathSegment
 
 
 class ArgillaSettings(BaseModel):
@@ -49,7 +50,7 @@ class AnnotationSettings(ResolveSettings):
 
     argilla: ArgillaSettings = Field(default_factory=ArgillaSettings)
     base_dir: Path = Field(default_factory=Path.cwd)
-    dataset_id: str = ""
+    dataset_id: SafePathSegment = ""
     workspace_dataset_map: dict[str, dict[Task, TaskOverlap]] = Field(
         default_factory=lambda: {
             "retrieval": {Task.RETRIEVAL: TaskOverlap()},

--- a/src/pragmata/core/types.py
+++ b/src/pragmata/core/types.py
@@ -2,12 +2,27 @@
 
 from typing import Annotated, Protocol, TypeVar
 
-from pydantic import BaseModel, StringConstraints
+from pydantic import AfterValidator, BaseModel, StringConstraints
 
 NonEmptyStr = Annotated[
     str,
     StringConstraints(strip_whitespace=True, min_length=1),
 ]
+
+
+def _validate_safe_path_segment(value: str) -> str:
+    if value == "":
+        return value
+    if value != value.strip():
+        raise ValueError("must not have surrounding whitespace")
+    if "/" in value or "\\" in value:
+        raise ValueError("must not contain path separators")
+    if ".." in value:
+        raise ValueError("must not contain '..'")
+    return value
+
+
+SafePathSegment = Annotated[str, AfterValidator(_validate_safe_path_segment)]
 
 M = TypeVar("M", bound=BaseModel)
 

--- a/tests/unit/core/paths/test_annotation_paths.py
+++ b/tests/unit/core/paths/test_annotation_paths.py
@@ -4,7 +4,11 @@ from pathlib import Path
 
 import pytest
 
-from pragmata.core.paths.annotation_paths import resolve_annotation_paths, resolve_export_paths
+from pragmata.core.paths.annotation_paths import (
+    resolve_annotation_paths,
+    resolve_export_paths,
+    resolve_import_paths,
+)
 from pragmata.core.paths.paths import WorkspacePaths
 
 
@@ -71,3 +75,43 @@ class TestAnnotationExportPaths:
         paths = resolve_export_paths(workspace=workspace, export_id="run1")
         with pytest.raises((AttributeError, TypeError)):
             paths.export_dir = tmp_path  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# AnnotationImportPaths
+# ---------------------------------------------------------------------------
+
+
+class TestAnnotationImportPaths:
+    def test_import_dir_under_imports_scope(self, workspace: WorkspacePaths) -> None:
+        paths = resolve_import_paths(workspace=workspace, dataset_id="run1")
+        expected = workspace.tool_root("annotation") / "imports" / "run1"
+        assert paths.import_dir == expected
+
+    def test_empty_dataset_id_maps_to_default_scope(self, workspace: WorkspacePaths) -> None:
+        paths = resolve_import_paths(workspace=workspace, dataset_id="")
+        expected = workspace.tool_root("annotation") / "imports" / "default"
+        assert paths.import_dir == expected
+
+    def test_partition_manifest_under_import_dir(self, workspace: WorkspacePaths) -> None:
+        paths = resolve_import_paths(workspace=workspace, dataset_id="run1")
+        assert paths.partition_manifest == paths.import_dir / "partition.meta.json"
+
+    def test_tool_root_matches_annotation_tool_root(self, workspace: WorkspacePaths) -> None:
+        paths = resolve_import_paths(workspace=workspace, dataset_id="run1")
+        assert paths.tool_root == workspace.tool_root("annotation")
+
+    def test_ensure_dirs_creates_import_dir(self, workspace: WorkspacePaths) -> None:
+        paths = resolve_import_paths(workspace=workspace, dataset_id="run1")
+        assert not paths.import_dir.exists()
+        paths.ensure_dirs()
+        assert paths.import_dir.exists()
+
+    def test_ensure_dirs_returns_self(self, workspace: WorkspacePaths) -> None:
+        paths = resolve_import_paths(workspace=workspace, dataset_id="run1")
+        assert paths.ensure_dirs() is paths
+
+    def test_frozen(self, workspace: WorkspacePaths, tmp_path: Path) -> None:
+        paths = resolve_import_paths(workspace=workspace, dataset_id="run1")
+        with pytest.raises((AttributeError, TypeError)):
+            paths.import_dir = tmp_path  # type: ignore[misc]

--- a/tests/unit/core/paths/test_annotation_paths.py
+++ b/tests/unit/core/paths/test_annotation_paths.py
@@ -97,10 +97,6 @@ class TestAnnotationImportPaths:
         paths = resolve_import_paths(workspace=workspace, dataset_id="run1")
         assert paths.partition_manifest == paths.import_dir / "partition.meta.json"
 
-    def test_tool_root_matches_annotation_tool_root(self, workspace: WorkspacePaths) -> None:
-        paths = resolve_import_paths(workspace=workspace, dataset_id="run1")
-        assert paths.tool_root == workspace.tool_root("annotation")
-
     def test_ensure_dirs_creates_import_dir(self, workspace: WorkspacePaths) -> None:
         paths = resolve_import_paths(workspace=workspace, dataset_id="run1")
         assert not paths.import_dir.exists()

--- a/tests/unit/core/schemas/test_annotation_import.py
+++ b/tests/unit/core/schemas/test_annotation_import.py
@@ -1,9 +1,16 @@
 """Tests for annotation import schemas."""
 
+from datetime import datetime, timezone
+
 import pytest
 from pydantic import ValidationError
 
-from pragmata.core.schemas.annotation_import import Chunk, QueryResponsePair
+from pragmata.core.schemas.annotation_import import (
+    Chunk,
+    PartitionManifest,
+    PartitionManifestEntry,
+    QueryResponsePair,
+)
 
 
 @pytest.fixture()
@@ -116,3 +123,80 @@ def test_extra_field_on_chunk_rejected(valid_chunk):
     valid_chunk["unknown"] = "x"
     with pytest.raises(ValidationError):
         Chunk(**valid_chunk)
+
+
+# ---------------------------------------------------------------------------
+# PartitionManifestEntry / PartitionManifest
+# ---------------------------------------------------------------------------
+
+
+_ENTRY_NOW = datetime(2026, 4, 30, 12, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture()
+def valid_entry_kwargs():
+    return {
+        "calibration": True,
+        "import_id": "imp1",
+        "calibration_fraction_at_import": 0.1,
+        "assigned_at": _ENTRY_NOW,
+    }
+
+
+@pytest.fixture()
+def valid_manifest_kwargs():
+    return {
+        "dataset_id": "run1",
+        "created_at": _ENTRY_NOW,
+        "updated_at": _ENTRY_NOW,
+        "partition_seed": 0,
+    }
+
+
+class TestPartitionManifestEntry:
+    def test_constructs(self, valid_entry_kwargs):
+        entry = PartitionManifestEntry(**valid_entry_kwargs)
+        assert entry.calibration is True
+        assert entry.import_id == "imp1"
+        assert entry.calibration_fraction_at_import == 0.1
+
+    def test_fraction_above_one_rejected(self, valid_entry_kwargs):
+        valid_entry_kwargs["calibration_fraction_at_import"] = 1.5
+        with pytest.raises(ValidationError):
+            PartitionManifestEntry(**valid_entry_kwargs)
+
+    def test_fraction_negative_rejected(self, valid_entry_kwargs):
+        valid_entry_kwargs["calibration_fraction_at_import"] = -0.1
+        with pytest.raises(ValidationError):
+            PartitionManifestEntry(**valid_entry_kwargs)
+
+    def test_extra_fields_rejected(self, valid_entry_kwargs):
+        valid_entry_kwargs["unknown"] = "x"
+        with pytest.raises(ValidationError):
+            PartitionManifestEntry(**valid_entry_kwargs)
+
+    def test_frozen(self, valid_entry_kwargs):
+        entry = PartitionManifestEntry(**valid_entry_kwargs)
+        with pytest.raises(ValidationError):
+            entry.calibration = False  # type: ignore[misc]
+
+
+class TestPartitionManifest:
+    def test_empty_assignments_default(self, valid_manifest_kwargs):
+        manifest = PartitionManifest(**valid_manifest_kwargs)
+        assert manifest.assignments == {}
+
+    def test_assignments_round_trip(self, valid_manifest_kwargs, valid_entry_kwargs):
+        entry = PartitionManifestEntry(**valid_entry_kwargs)
+        manifest = PartitionManifest(**valid_manifest_kwargs, assignments={"uuid-1": entry})
+        restored = PartitionManifest.model_validate_json(manifest.model_dump_json())
+        assert restored == manifest
+
+    def test_extra_fields_rejected(self, valid_manifest_kwargs):
+        with pytest.raises(ValidationError):
+            PartitionManifest(**valid_manifest_kwargs, surprise="bad")  # type: ignore[call-arg]
+
+    def test_dataset_id_can_be_empty_string(self, valid_manifest_kwargs):
+        valid_manifest_kwargs["dataset_id"] = ""
+        manifest = PartitionManifest(**valid_manifest_kwargs)
+        assert manifest.dataset_id == ""

--- a/tests/unit/core/schemas/test_annotation_import.py
+++ b/tests/unit/core/schemas/test_annotation_import.py
@@ -175,6 +175,11 @@ class TestPartitionManifestEntry:
         with pytest.raises(ValidationError):
             PartitionManifestEntry(**valid_entry_kwargs)
 
+    def test_empty_import_id_rejected(self, valid_entry_kwargs):
+        valid_entry_kwargs["import_id"] = ""
+        with pytest.raises(ValidationError):
+            PartitionManifestEntry(**valid_entry_kwargs)
+
     def test_frozen(self, valid_entry_kwargs):
         entry = PartitionManifestEntry(**valid_entry_kwargs)
         with pytest.raises(ValidationError):
@@ -200,3 +205,14 @@ class TestPartitionManifest:
         valid_manifest_kwargs["dataset_id"] = ""
         manifest = PartitionManifest(**valid_manifest_kwargs)
         assert manifest.dataset_id == ""
+
+    @pytest.mark.parametrize("bad", ["a/b", "..", "foo..bar", " run", "run\\sub"])
+    def test_unsafe_dataset_id_rejected(self, valid_manifest_kwargs, bad):
+        valid_manifest_kwargs["dataset_id"] = bad
+        with pytest.raises(ValidationError):
+            PartitionManifest(**valid_manifest_kwargs)
+
+    def test_updated_before_created_rejected(self, valid_manifest_kwargs):
+        valid_manifest_kwargs["updated_at"] = _ENTRY_NOW.replace(year=2025)
+        with pytest.raises(ValidationError):
+            PartitionManifest(**valid_manifest_kwargs)

--- a/tests/unit/core/settings/test_annotation_settings.py
+++ b/tests/unit/core/settings/test_annotation_settings.py
@@ -70,6 +70,11 @@ class TestAnnotationSettingsResolve:
         s = AnnotationSettings.resolve(overrides={"calibration_partition_seed": 42})
         assert s.calibration_partition_seed == 42
 
+    @pytest.mark.parametrize("bad", ["a/b", "..", "foo..bar", " run", "run\\sub"])
+    def test_unsafe_dataset_id_rejected(self, bad):
+        with pytest.raises(ValidationError):
+            AnnotationSettings(dataset_id=bad)
+
 
 class TestArgillaSettings:
     def test_defaults_to_none_api_url(self):


### PR DESCRIPTION
## Goal

Add the schemas and path bundle that partial-overlap calibration support depends on. 

## What changes

### Schemas

- New `PartitionManifestEntry` and `PartitionManifest` in `core/schemas/annotation_import.py`. The manifest is a persistent record_uuid → assignment map keyed by `dataset_id`. Each entry records the assignment (calibration vs production), the import that produced it, the fraction in force at that import, and a timestamp.
- `calibration: bool = False` field on `AnnotationBase` in `core/schemas/annotation_export.py`. Defaulted so existing construction sites continue to validate without modification.
- `calibration_enabled: dict[Task, bool]` field on `AnnotationExportMeta` (defaulted empty). The validator only checks key membership when the dict is non-empty, so current sidecars remain valid.

### Paths

- New `AnnotationImportPaths` bundle and `resolve_import_paths(workspace, dataset_id)` in `core/paths/annotation_paths.py`. The bundle is keyed by `dataset_id` (persistent topology scope, with empty-string mapping to a `default` directory) because imports accumulate state across calls into the same scope. The bundle exposes a `partition.meta.json` sidecar path.

## Why

These schemas and paths model the calibration vs production assignment that downstream IAA metrics based on partial overlap will need. 

## Testing

- 634 unit tests pass (16 new for `PartitionManifest`, `PartitionManifestEntry`, and `AnnotationImportPaths`)
- `mypy src/pragmata` clean
- `ruff check` and `ruff format --check` clean