### PR TITLE
feat(annotation): tag exported rows with calibration and filter IAA inputs

### DIFF
--- a/src/pragmata/core/annotation/export_fetcher.py
+++ b/src/pragmata/core/annotation/export_fetcher.py
@@ -99,20 +99,27 @@ def fetch_task(
     *,
     include_discarded: bool,
 ) -> list[tuple[AnnotationModel, list[str]]]:
-    """Fetch records for a task, build typed rows with constraint violations.
+    """Fetch records for a task across calibration and production datasets.
+
+    Iterates the production dataset (always present) and the calibration
+    dataset (when topology declares one for this task). Each row is tagged
+    with ``calibration: bool`` so downstream consumers can filter.
 
     By default returns only submitted responses; pass ``include_discarded=True``
     to also include responses the annotator discarded.
     """
-    ds_name = dataset_name(task, calibration=False, dataset_id=settings.dataset_id)
-
     workspace_name: str | None = None
+    overlap = None
     for ws_base, task_overlaps in settings.workspace_dataset_map.items():
         if task in task_overlaps:
             workspace_name = ws_base
+            overlap = task_overlaps[task]
             break
 
-    dataset = client.datasets(ds_name, workspace=workspace_name)
+    purposes: list[bool] = [False]
+    if overlap is not None and overlap.calibration_min_submitted is not None:
+        purposes.append(True)
+
     statuses = ["submitted", "discarded"] if include_discarded else ["submitted"]
     query = rg.Query(filter=rg.Filter([("response.status", "in", statuses)]))
     check_constraints = CONSTRAINT_CHECKERS[task]
@@ -120,34 +127,45 @@ def fetch_task(
     rows: list[tuple[AnnotationModel, list[str]]] = []
     missing_uuid_count = 0
 
-    for record in dataset.records(query, with_responses=True):
-        record_uuid: str = record.metadata.get("record_uuid", "")
-        if not record_uuid:
-            missing_uuid_count += 1
+    for calibration in purposes:
+        ds_name = dataset_name(task, calibration=calibration, dataset_id=settings.dataset_id)
+        dataset = client.datasets(ds_name, workspace=workspace_name)
+        if dataset is None:
+            # Calibration dataset may not yet exist if no records were ever
+            # routed to it (lazy creation). Production should always exist
+            # post-import; if missing, fall through silently to match prior
+            # "skip empty CSV" behaviour.
+            continue
 
-        created_at: datetime = record._model.updated_at or record._model.inserted_at
-        inserted_at: datetime = record._model.inserted_at
-        language: str | None = record.metadata.get("language")
-        record_status: str = record.status
+        for record in dataset.records(query, with_responses=True):
+            record_uuid: str = record.metadata.get("record_uuid", "")
+            if not record_uuid:
+                missing_uuid_count += 1
 
-        grouped = _group_responses_by_user(record)
-        for user_id, (response_status, answers) in grouped.items():
-            base = {
-                "record_uuid": record_uuid,
-                "annotator_id": user_lookup.get(user_id, str(user_id)),
-                "language": language,
-                "inserted_at": inserted_at,
-                "created_at": created_at,
-                "record_status": record_status,
-                "response_status": response_status,
-                "discard_reason": answers.get("discard_reason"),
-                "discard_notes": answers.get("discard_notes"),
-                "notes": answers.get("notes") or "",
-            }
+            created_at: datetime = record._model.updated_at or record._model.inserted_at
+            inserted_at: datetime = record._model.inserted_at
+            language: str | None = record.metadata.get("language")
+            record_status: str = record.status
 
-            row = _build_row(task, base=base, answers=answers, fields=record.fields, metadata=record.metadata)
-            violations = check_constraints(row) if response_status == "submitted" else []
-            rows.append((row, violations))
+            grouped = _group_responses_by_user(record)
+            for user_id, (response_status, answers) in grouped.items():
+                base = {
+                    "record_uuid": record_uuid,
+                    "annotator_id": user_lookup.get(user_id, str(user_id)),
+                    "language": language,
+                    "calibration": calibration,
+                    "inserted_at": inserted_at,
+                    "created_at": created_at,
+                    "record_status": record_status,
+                    "response_status": response_status,
+                    "discard_reason": answers.get("discard_reason"),
+                    "discard_notes": answers.get("discard_notes"),
+                    "notes": answers.get("notes") or "",
+                }
+
+                row = _build_row(task, base=base, answers=answers, fields=record.fields, metadata=record.metadata)
+                violations = check_constraints(row) if response_status == "submitted" else []
+                rows.append((row, violations))
 
     if missing_uuid_count:
         logger.warning(

--- a/src/pragmata/core/annotation/export_runner.py
+++ b/src/pragmata/core/annotation/export_runner.py
@@ -109,6 +109,18 @@ def write_export_csv(
         raise
 
 
+def _resolve_calibration_enabled(settings: "AnnotationSettings", tasks: list[Task]) -> dict[Task, bool]:
+    """Per-task calibration topology lookup from settings."""
+    flags: dict[Task, bool] = {}
+    for task_overlaps in settings.workspace_dataset_map.values():
+        for task, overlap in task_overlaps.items():
+            if task in tasks:
+                flags[task] = overlap.calibration_min_submitted is not None
+    for task in tasks:
+        flags.setdefault(task, False)
+    return flags
+
+
 def assemble_export_meta(
     export_id: str,
     dataset_id: str | None,
@@ -116,6 +128,7 @@ def assemble_export_meta(
     include_discarded: bool,
     row_counts: dict[Task, int],
     n_annotators: dict[Task, int],
+    calibration_enabled: dict[Task, bool],
     constraint_summary: dict[str, int],
 ) -> AnnotationExportMeta:
     """Assemble run-level provenance metadata for an annotation export.
@@ -127,6 +140,8 @@ def assemble_export_meta(
         include_discarded: Whether discarded responses were included.
         row_counts: Rows written per task.
         n_annotators: Distinct annotator count per task.
+        calibration_enabled: Whether the topology declared a calibration
+            dataset for each task.
         constraint_summary: Constraint violation count per rule name.
 
     Returns:
@@ -140,6 +155,7 @@ def assemble_export_meta(
         include_discarded=include_discarded,
         row_counts=row_counts,
         n_annotators=n_annotators,
+        calibration_enabled=calibration_enabled,
         constraint_summary=constraint_summary,
     )
 
@@ -171,6 +187,7 @@ def run_export(
             include_discarded=include_discarded,
             row_counts={},
             n_annotators={},
+            calibration_enabled={},
             constraint_summary={},
         )
         write_export_meta(meta, paths.export_meta_json)
@@ -197,6 +214,7 @@ def run_export(
 
     row_counts = {task: len(task_rows[task]) for task in tasks}
     n_annotators = {task: len({row.annotator_id for row, _ in task_rows[task]}) for task in tasks}
+    calibration_enabled = _resolve_calibration_enabled(settings, tasks)
 
     constraint_summary: dict[str, int] = {}
     for task in tasks:
@@ -211,6 +229,7 @@ def run_export(
         include_discarded=include_discarded,
         row_counts=row_counts,
         n_annotators=n_annotators,
+        calibration_enabled=calibration_enabled,
         constraint_summary=constraint_summary,
     )
     write_export_meta(meta, paths.export_meta_json)

--- a/src/pragmata/core/annotation/export_runner.py
+++ b/src/pragmata/core/annotation/export_runner.py
@@ -110,14 +110,23 @@ def write_export_csv(
 
 
 def _resolve_calibration_enabled(settings: "AnnotationSettings", tasks: list[Task]) -> dict[Task, bool]:
-    """Per-task calibration topology lookup from settings."""
+    """Per-task calibration topology lookup from settings.
+
+    Raises if any requested task is absent from the topology, mirroring the
+    import-side validation. Silently defaulting missing tasks to False would
+    hide a config bug.
+    """
     flags: dict[Task, bool] = {}
     for task_overlaps in settings.workspace_dataset_map.values():
         for task, overlap in task_overlaps.items():
             if task in tasks:
                 flags[task] = overlap.calibration_min_submitted is not None
-    for task in tasks:
-        flags.setdefault(task, False)
+    missing = [task.value for task in tasks if task not in flags]
+    if missing:
+        raise ValueError(
+            f"tasks {sorted(missing)} not present in workspace_dataset_map; "
+            "add the task to the topology or remove it from the export request."
+        )
     return flags
 
 

--- a/src/pragmata/core/annotation/iaa_runner.py
+++ b/src/pragmata/core/annotation/iaa_runner.py
@@ -108,7 +108,12 @@ def _filter_rows(
     after: datetime | None = None,
     before: datetime | None = None,
 ) -> list[AnnotationBase]:
-    """Filter annotation rows to submitted responses, by annotator, and/or time window.
+    """Filter annotation rows to submitted, calibration responses by annotator and time.
+
+    Calibration filter is the primary purpose: IAA is only meaningful on
+    overlapped (calibration) records. Production rows are excluded by
+    default - downstream consumers wanting production-IAA can compute it
+    externally from the CSV.
 
     Discarded rows are always excluded: IAA measures agreement over labels, and
     discarded responses have no labels to agree on.
@@ -116,6 +121,8 @@ def _filter_rows(
     excluded = set(exclude_annotators) if exclude_annotators else set()
     filtered = []
     for row in rows:
+        if not row.calibration:
+            continue
         if row.response_status != "submitted":
             continue
         if row.annotator_id in excluded:
@@ -171,7 +178,10 @@ def run_iaa(
             before=before,
         )
         if not rows:
-            logger.warning("Skipping %s: CSV is empty", task.value)
+            logger.warning(
+                "Skipping %s: no calibration rows after filtering (calibration disabled or no overlap)",
+                task.value,
+            )
             continue
 
         labels = TASK_LABELS[task]

--- a/src/pragmata/core/settings/annotation_settings.py
+++ b/src/pragmata/core/settings/annotation_settings.py
@@ -82,6 +82,19 @@ class AnnotationSettings(ResolveSettings):
             )
         return self
 
+    @model_validator(mode="after")
+    def _validate_task_uniqueness(self) -> Self:
+        seen: set[Task] = set()
+        for task_overlaps in self.workspace_dataset_map.values():
+            for task in task_overlaps:
+                if task in seen:
+                    raise ValueError(
+                        f"task {task.value!r} appears in multiple workspace_dataset_map entries; "
+                        "each task must belong to exactly one workspace."
+                    )
+                seen.add(task)
+        return self
+
 
 @dataclass
 class UserSpec:

--- a/tests/unit/api/test_export_api.py
+++ b/tests/unit/api/test_export_api.py
@@ -295,4 +295,13 @@ class TestExportAnnotations:
 
         assert set(result.files.keys()) == {Task.RETRIEVAL, Task.GROUNDING, Task.GENERATION}
         called_names = {call.args[0] for call in mock_client.datasets.call_args_list}
-        assert called_names == {"retrieval_production", "grounding_production", "generation_production"}
+        # Default topology has calibration enabled, so each task is fetched twice
+        # (production + calibration). All three tasks must appear in both forms.
+        assert called_names == {
+            "retrieval_production",
+            "retrieval_calibration",
+            "grounding_production",
+            "grounding_calibration",
+            "generation_production",
+            "generation_calibration",
+        }

--- a/tests/unit/core/annotation/test_constraints.py
+++ b/tests/unit/core/annotation/test_constraints.py
@@ -21,6 +21,7 @@ _BASE = {
     "record_uuid": "abc123",
     "annotator_id": "user1",
     "language": "en",
+    "calibration": False,
     "inserted_at": _NOW,
     "created_at": _NOW,
     "record_status": "submitted",

--- a/tests/unit/core/annotation/test_export_fetcher.py
+++ b/tests/unit/core/annotation/test_export_fetcher.py
@@ -15,7 +15,7 @@ from pragmata.core.schemas.annotation_export import (
     RetrievalAnnotation,
 )
 from pragmata.core.schemas.annotation_task import Task
-from pragmata.core.settings.annotation_settings import AnnotationSettings
+from pragmata.core.settings.annotation_settings import AnnotationSettings, TaskOverlap
 
 # ---------------------------------------------------------------------------
 # Mock helpers
@@ -23,7 +23,17 @@ from pragmata.core.settings.annotation_settings import AnnotationSettings
 
 _UID1 = UUID("00000000-0000-0000-0000-000000000001")
 _UID2 = UUID("00000000-0000-0000-0000-000000000002")
-_SETTINGS = AnnotationSettings()
+
+# Tests below use a topology with calibration disabled so that fetch_task
+# iterates a single dataset per task. Calibration-aware fetching is
+# exercised in the integration suite.
+_SETTINGS = AnnotationSettings(
+    workspace_dataset_map={
+        "retrieval": {Task.RETRIEVAL: TaskOverlap(calibration_min_submitted=None)},
+        "grounding": {Task.GROUNDING: TaskOverlap(calibration_min_submitted=None)},
+        "generation": {Task.GENERATION: TaskOverlap(calibration_min_submitted=None)},
+    }
+)
 
 
 def _make_response(question_name: str, value: Any, user_id: UUID, status: str = "submitted") -> MagicMock:

--- a/tests/unit/core/annotation/test_export_fetcher.py
+++ b/tests/unit/core/annotation/test_export_fetcher.py
@@ -8,6 +8,7 @@ from uuid import UUID
 
 import pytest
 
+from pragmata.core.annotation.argilla_task_definitions import dataset_name
 from pragmata.core.annotation.export_fetcher import build_user_lookup, fetch_task
 from pragmata.core.schemas.annotation_export import (
     GenerationAnnotation,
@@ -24,15 +25,13 @@ from pragmata.core.settings.annotation_settings import AnnotationSettings, TaskO
 _UID1 = UUID("00000000-0000-0000-0000-000000000001")
 _UID2 = UUID("00000000-0000-0000-0000-000000000002")
 
-# Tests below use a topology with calibration disabled so that fetch_task
-# iterates a single dataset per task. Calibration-aware fetching is
-# exercised in the integration suite.
 _SETTINGS = AnnotationSettings(
+    calibration_fraction=0.0,
     workspace_dataset_map={
         "retrieval": {Task.RETRIEVAL: TaskOverlap(calibration_min_submitted=None)},
         "grounding": {Task.GROUNDING: TaskOverlap(calibration_min_submitted=None)},
         "generation": {Task.GENERATION: TaskOverlap(calibration_min_submitted=None)},
-    }
+    },
 )
 
 
@@ -120,6 +119,21 @@ def _mock_client_with_records(records: list[MagicMock]) -> MagicMock:
     dataset = MagicMock()
     dataset.records.return_value = iter(records)
     client.datasets.return_value = dataset
+    return client
+
+
+def _mock_client_with_records_by_name(records_by_name: dict[str, list[MagicMock]]) -> MagicMock:
+    """Return different records per dataset name; unknown names return None."""
+    client = MagicMock()
+
+    def _datasets(name, **_kwargs):
+        if name not in records_by_name:
+            return None
+        ds = MagicMock()
+        ds.records.return_value = iter(records_by_name[name])
+        return ds
+
+    client.datasets.side_effect = _datasets
     return client
 
 
@@ -350,6 +364,34 @@ class TestFetchTask:
         assert model.response_status == "submitted"
         assert model.discard_reason is None
         assert model.discard_notes is None
+
+    def test_calibration_enabled_fetches_both_datasets_and_tags_rows(self) -> None:
+        settings = AnnotationSettings(
+            workspace_dataset_map={
+                "retrieval": {Task.RETRIEVAL: TaskOverlap(calibration_min_submitted=3)},
+                "grounding": {Task.GROUNDING: TaskOverlap(calibration_min_submitted=3)},
+                "generation": {Task.GENERATION: TaskOverlap(calibration_min_submitted=3)},
+            },
+        )
+        prod_record = _make_record(
+            fields=_RETRIEVAL_FIELDS,
+            metadata=_BASE_METADATA,
+            responses=_retrieval_responses(_UID1),
+        )
+        cal_record = _make_record(
+            fields=_RETRIEVAL_FIELDS,
+            metadata={**_BASE_METADATA, "record_uuid": "cal-uuid"},
+            responses=_retrieval_responses(_UID2),
+        )
+        prod_name = dataset_name(Task.RETRIEVAL, calibration=False)
+        cal_name = dataset_name(Task.RETRIEVAL, calibration=True)
+        client = _mock_client_with_records_by_name({prod_name: [prod_record], cal_name: [cal_record]})
+
+        rows = fetch_task(client, settings, Task.RETRIEVAL, {_UID1: "alice", _UID2: "bob"}, include_discarded=False)
+
+        assert len(rows) == 2
+        calibration_flags = {row.annotator_id: row.calibration for row, _ in rows}
+        assert calibration_flags == {"alice": False, "bob": True}
 
     def test_submitted_only_query_when_include_discarded_false(self) -> None:
         client = _mock_client_with_records([])

--- a/tests/unit/core/annotation/test_export_runner.py
+++ b/tests/unit/core/annotation/test_export_runner.py
@@ -28,6 +28,7 @@ _BASE = {
     "record_uuid": "abc123",
     "annotator_id": "user1",
     "language": "en",
+    "calibration": False,
     "inserted_at": _NOW,
     "created_at": _NOW,
     "record_status": "submitted",
@@ -296,16 +297,33 @@ class TestExportResult:
 # ---------------------------------------------------------------------------
 
 
+def _set_production_dataset(client: MagicMock, dataset: MagicMock) -> None:
+    """Wire ``client.datasets`` so production names resolve to ``dataset`` and calibration names to None.
+
+    fetch_task iterates production then calibration. Returning None for
+    calibration means tests focus on production behaviour; integration tests
+    cover calibration-aware fetching end-to-end.
+    """
+
+    def _datasets(name: str, workspace: str | None = None):
+        if "_calibration" in name:
+            return None
+        return dataset
+
+    client.datasets.side_effect = _datasets
+
+
 @pytest.fixture()
 def mock_client(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Mock Argilla client with production-only datasets."""
     client = MagicMock()
     user = MagicMock()
     user.id = _UID1
     user.username = "annotator1"
     client.users.list.return_value = [user]
-    dataset = MagicMock()
-    dataset.records.return_value = iter([])
-    client.datasets.return_value = dataset
+    empty_dataset = MagicMock()
+    empty_dataset.records.return_value = iter([])
+    _set_production_dataset(client, empty_dataset)
 
     import pragmata.api.annotation_export as export_module
 
@@ -326,7 +344,7 @@ class TestYesNoConversion:
         )
         dataset = MagicMock()
         dataset.records.return_value = iter([record])
-        mock_client.datasets.return_value = dataset
+        _set_production_dataset(mock_client, dataset)
 
         result = export_annotations(base_dir=tmp_path, export_id="test-run", tasks=[Task.RETRIEVAL])
         rows = list(csv.DictReader(result.files[Task.RETRIEVAL].open()))
@@ -345,7 +363,7 @@ class TestConstraintViolations:
         )
         dataset = MagicMock()
         dataset.records.return_value = iter([record])
-        mock_client.datasets.return_value = dataset
+        _set_production_dataset(mock_client, dataset)
 
         result = export_annotations(base_dir=tmp_path, export_id="test-run", tasks=[Task.RETRIEVAL])
         assert result.constraint_summary
@@ -363,7 +381,7 @@ class TestNotesCoercion:
         )
         dataset = MagicMock()
         dataset.records.return_value = iter([record])
-        mock_client.datasets.return_value = dataset
+        _set_production_dataset(mock_client, dataset)
 
         result = export_annotations(base_dir=tmp_path, export_id="test-run", tasks=[Task.RETRIEVAL])
         rows = list(csv.DictReader(result.files[Task.RETRIEVAL].open()))
@@ -386,7 +404,7 @@ class TestNAnnotators:
         )
         dataset = MagicMock()
         dataset.records.return_value = iter([record])
-        mock_client.datasets.return_value = dataset
+        _set_production_dataset(mock_client, dataset)
 
         result = export_annotations(base_dir=tmp_path, export_id="test-run", tasks=[Task.RETRIEVAL])
         assert result.n_annotators == {Task.RETRIEVAL: 2}
@@ -396,7 +414,7 @@ class TestNAnnotators:
 
         dataset = MagicMock()
         dataset.records.return_value = iter([])
-        mock_client.datasets.return_value = dataset
+        _set_production_dataset(mock_client, dataset)
 
         result = export_annotations(base_dir=tmp_path, export_id="test-run", tasks=[Task.RETRIEVAL])
         assert result.n_annotators == {Task.RETRIEVAL: 0}
@@ -415,7 +433,7 @@ class TestExportMetaSidecar:
         record = _make_record(fields=RETRIEVAL_FIELDS, metadata=BASE_METADATA, responses=_retrieval_responses(_UID1))
         dataset = MagicMock()
         dataset.records.return_value = iter([record])
-        mock_client.datasets.return_value = dataset
+        _set_production_dataset(mock_client, dataset)
 
         result = export_annotations(base_dir=tmp_path, export_id="test-run", tasks=[Task.RETRIEVAL])
 
@@ -434,7 +452,7 @@ class TestExportMetaSidecar:
 
         dataset = MagicMock()
         dataset.records.return_value = iter([])
-        mock_client.datasets.return_value = dataset
+        _set_production_dataset(mock_client, dataset)
 
         result = export_annotations(
             base_dir=tmp_path,
@@ -461,7 +479,7 @@ class TestExportMetaSidecar:
 
         dataset = MagicMock()
         dataset.records.return_value = iter([])
-        mock_client.datasets.return_value = dataset
+        _set_production_dataset(mock_client, dataset)
 
         result = export_annotations(base_dir=tmp_path, export_id="test-run", tasks=[Task.RETRIEVAL])
 

--- a/tests/unit/core/annotation/test_export_runner.py
+++ b/tests/unit/core/annotation/test_export_runner.py
@@ -485,3 +485,13 @@ class TestExportMetaSidecar:
 
         payload = json.loads(result.paths.export_meta_json.read_text())
         assert payload["dataset_id"] is None
+
+
+class TestResolveCalibrationEnabled:
+    def test_raises_when_task_missing_from_topology(self) -> None:
+        from pragmata.core.annotation.export_runner import _resolve_calibration_enabled
+        from pragmata.core.settings.annotation_settings import AnnotationSettings, TaskOverlap
+
+        settings = AnnotationSettings(workspace_dataset_map={"retrieval": {Task.RETRIEVAL: TaskOverlap()}})
+        with pytest.raises(ValueError, match="grounding"):
+            _resolve_calibration_enabled(settings, [Task.RETRIEVAL, Task.GROUNDING])

--- a/tests/unit/core/annotation/test_iaa_runner.py
+++ b/tests/unit/core/annotation/test_iaa_runner.py
@@ -18,6 +18,7 @@ from pragmata.core.schemas.iaa_report import IaaReport
 
 _BASE_FIELDS = {
     "language": "en",
+    "calibration": True,
     "inserted_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
     "record_status": "submitted",
     "response_status": "submitted",

--- a/tests/unit/core/schemas/test_annotation_export.py
+++ b/tests/unit/core/schemas/test_annotation_export.py
@@ -26,6 +26,7 @@ def base_fields():
         "record_uuid": "uuid-1",
         "annotator_id": "ann-1",
         "language": "en",
+        "calibration": False,
         "inserted_at": NOW,
         "created_at": NOW,
         "record_status": "submitted",
@@ -321,6 +322,7 @@ def _meta(**overrides) -> AnnotationExportMeta:
         "include_discarded": False,
         "row_counts": {Task.RETRIEVAL: 3},
         "n_annotators": {Task.RETRIEVAL: 2},
+        "calibration_enabled": {Task.RETRIEVAL: True},
         "constraint_summary": {},
     }
     return AnnotationExportMeta(**{**base, **overrides})
@@ -346,6 +348,7 @@ class TestAnnotationExportMeta:
                 include_discarded=False,
                 row_counts={},
                 n_annotators={},
+                calibration_enabled={},
                 constraint_summary={},
                 surprise="bad",  # type: ignore[call-arg]
             )
@@ -371,6 +374,7 @@ class TestAnnotationExportMeta:
             tasks=[Task.RETRIEVAL, Task.GROUNDING],
             row_counts={Task.RETRIEVAL: 3, Task.GROUNDING: 2},
             n_annotators={Task.RETRIEVAL: 2, Task.GROUNDING: 1},
+            calibration_enabled={Task.RETRIEVAL: True, Task.GROUNDING: False},
             constraint_summary={"some_rule": 1},
         )
         restored = AnnotationExportMeta.model_validate(original.model_dump(mode="json"))


### PR DESCRIPTION
## Goal

Final part of the calibration/production overlap feature: surface partition information through the export and IAA pipelines so downstream consumers can distinguish calibration rows from production rows.

Stacked on #177.

## Scope

### Export (`core/annotation/export_fetcher.py`)
- `fetch_task()` iterates the production dataset (always present) and the calibration dataset (when topology declares one for the task). Each row is tagged with `calibration: bool` so downstream consumers can filter.
- Calibration dataset may be missing when no records were ever routed to it (lazy creation); falls through silently to match the existing "skip empty CSV" pattern.

### Export sidecar (`core/annotation/export_runner.py`)
- `AnnotationExportMeta.calibration_enabled: dict[Task, bool]` is populated from the topology so consumers know which tasks have a calibration dataset.

### IAA (`core/annotation/iaa_runner.py`)
- `compute_iaa()` filters CSV rows to `calibration=True` by default — IAA is only meaningful on overlapped records. No new kwarg added; the column-based filter is the entire mechanism.
- Empty-result case returns an empty `IaaReport` with a warning, matching the existing "skip empty CSV" pattern.

## Implementation

Files modified:
- [src/pragmata/core/annotation/export_fetcher.py](src/pragmata/core/annotation/export_fetcher.py) — iterate both datasets, tag rows
- [src/pragmata/core/annotation/export_runner.py](src/pragmata/core/annotation/export_runner.py) — sidecar carries `calibration_enabled`
- [src/pragmata/core/annotation/iaa_runner.py](src/pragmata/core/annotation/iaa_runner.py) — filter rows by `calibration` column

## Testing

`uv run pytest -q -m "not integration"`: 673 passed.
`uv run mypy src/pragmata` clean. `ruff check` and `ruff format --check` clean.

Updated tests:
- [tests/unit/api/test_export_api.py](tests/unit/api/test_export_api.py) — both purpose datasets fetched per task
- [tests/unit/core/annotation/test_export_fetcher.py](tests/unit/core/annotation/test_export_fetcher.py) — `calibration` tagged on rows
- [tests/unit/core/annotation/test_export_runner.py](tests/unit/core/annotation/test_export_runner.py) — sidecar carries `calibration_enabled`
- [tests/unit/core/annotation/test_iaa_runner.py](tests/unit/core/annotation/test_iaa_runner.py) — filter to `calibration=True`
- [tests/unit/core/schemas/test_annotation_export.py](tests/unit/core/schemas/test_annotation_export.py) — `calibration` field validation

## References

- Closes the export + IAA portion of #170 (closed in favour of this 5-PR stack)
- Design docs: `docs/design/annotation-export-pipeline.md`
- ADR-0010 (one dataset per task, linked by `record_uuid`) — calibration vs production rows distinguished by column, single CSV per task