### PR TITLE
chore: preserve uv dependency bounds in Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
     cooldown:
       default-days: 14
     open-pull-requests-limit: 5
+    versioning-strategy: "increase-if-necessary"
     commit-message:
       prefix: "chore(deps)"
     labels:


### PR DESCRIPTION
**Summary**

Adjust Dependabot's `uv` update strategy so routine dependency updates preserve existing `pyproject.toml` version bounds whenever the current constraints already allow the newer resolved versions.

**Key changes**

- Set `versioning-strategy: "increase-if-necessary"` for the `uv` ecosystem.

**Rationale**

For a distributable Python package, `pyproject.toml` dependency bounds are part of the user-facing compatibility contract, while `uv.lock` captures the repository's reproducible development/test resolution. Routine freshness updates should not raise minimum supported dependency versions unless the existing constraints actually block the update.