### PR TITLE
fix: make dependabot uv updates lockfile-only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     cooldown:
       default-days: 14
     open-pull-requests-limit: 5
-    versioning-strategy: "increase-if-necessary"
+    versioning-strategy: "lockfile-only"
     commit-message:
       prefix: "chore(deps)"
     labels:


### PR DESCRIPTION
**Summary**

Configure Dependabot `uv` updates to use `versioning-strategy: "lockfile-only"`.

**Rationale**

Dependabot currently raises lower bounds in `pyproject.toml` even when the existing constraints already allow the resolved dependency updates. For a library package, those lower bounds are part of the downstream compatibility contract and should not be changed as routine dependency maintenance.

This appears to match the open Dependabot `uv` issue here:

https://github.com/dependabot/dependabot-core/issues/14908

Using `lockfile-only` keeps routine Dependabot updates scoped to `uv.lock`. Any future minimum-version changes in `pyproject.toml` should be made intentionally when the project actually relies on newer dependency behavior.

**Changes**

- Change the `uv` Dependabot block from `increase-if-necessary` to `lockfile-only`
