### PR TITLE
feat: split querygen model kwargs by planning and realization stage

### DIFF
--- a/src/pragmata/api/querygen.py
+++ b/src/pragmata/api/querygen.py
@@ -67,7 +67,8 @@ def gen_queries(
     check_every_n_seconds: float | Unset = UNSET,
     max_bucket_size: int | Unset = UNSET,
     base_url: str | Unset = UNSET,
-    model_kwargs: dict[str, Any] | Unset = UNSET,
+    planning_model_kwargs: dict[str, Any] | Unset = UNSET,
+    realization_model_kwargs: dict[str, Any] | Unset = UNSET,
     batch_size: PositiveInt | Unset = UNSET,
     near_duplicate_tolerance: float | Unset = UNSET,
     enable_planning_memory: bool | Unset = UNSET,
@@ -128,8 +129,11 @@ def gen_queries(
         max_bucket_size: Maximum burst size for the llm rate limiter. Defaults to 1.
         base_url: Optional custom API endpoint for the provider (e.g., Azure
             OpenAI deployments).
-        model_kwargs: Additional provider-specific keyword arguments passed
-            through to the underlying chat model.
+        planning_model_kwargs: Additional provider-specific keyword arguments passed
+            through to the planning-stage chat model. Also used by the planning-summary
+            updater because it invokes the configured planning model.
+        realization_model_kwargs: Additional provider-specific keyword arguments passed
+            through to the realization-stage chat model.
 
     Returns:
         QueryGenRunResult: Run descriptor containing the resolved settings used
@@ -168,7 +172,8 @@ def gen_queries(
                 "check_every_n_seconds": check_every_n_seconds,
                 "max_bucket_size": max_bucket_size,
                 "base_url": base_url,
-                "model_kwargs": model_kwargs,
+                "planning_model_kwargs": planning_model_kwargs,
+                "realization_model_kwargs": realization_model_kwargs,
             },
             "base_dir": base_dir,
             "run_id": run_id,

--- a/src/pragmata/cli/commands/querygen.py
+++ b/src/pragmata/cli/commands/querygen.py
@@ -60,10 +60,15 @@ def gen_queries_command(
     base_url: str | None = typer.Option(
         None, "--base-url", help="Base URL for the provider endpoint. Accepts a URL string"
     ),
-    model_kwargs: str | None = typer.Option(
+    planning_model_kwargs: str | None = typer.Option(
         None,
-        "--model-kwargs",
-        help="dditional model keyword arguments. Accepts a JSON object.",
+        "--planning-model-kwargs",
+        help="Additional planning-stage model keyword arguments. Accepts a JSON object.",
+    ),
+    realization_model_kwargs: str | None = typer.Option(
+        None,
+        "--realization-model-kwargs",
+        help="Additional realization-stage model keyword arguments. Accepts a JSON object.",
     ),
 ) -> None:
     """Prepare a synthetic query generation run."""
@@ -85,7 +90,8 @@ def gen_queries_command(
         planning_model=UNSET if planning_model is None else planning_model,
         realization_model=UNSET if realization_model is None else realization_model,
         base_url=UNSET if base_url is None else base_url,
-        model_kwargs=parse_cli_value(model_kwargs),
+        planning_model_kwargs=parse_cli_value(planning_model_kwargs),
+        realization_model_kwargs=parse_cli_value(realization_model_kwargs),
     )
 
     typer.echo("Synthetic query generation run prepared.")

--- a/src/pragmata/core/querygen/planning.py
+++ b/src/pragmata/core/querygen/planning.py
@@ -164,7 +164,7 @@ def run_planning_stage(
             check_every_n_seconds=llm_settings.check_every_n_seconds,
             max_bucket_size=llm_settings.max_bucket_size,
             base_url=llm_settings.base_url,
-            model_kwargs=llm_settings.model_kwargs,
+            model_kwargs=llm_settings.planning_model_kwargs,
         )
         llm_output = llm_runnable.invoke(prompt_vars)
     except LlmInitializationError:

--- a/src/pragmata/core/querygen/planning_summary.py
+++ b/src/pragmata/core/querygen/planning_summary.py
@@ -184,7 +184,7 @@ def run_planning_summary(
             check_every_n_seconds=llm_settings.check_every_n_seconds,
             max_bucket_size=llm_settings.max_bucket_size,
             base_url=llm_settings.base_url,
-            model_kwargs=llm_settings.model_kwargs,
+            model_kwargs=llm_settings.planning_model_kwargs,
         )
         llm_output = llm_runnable.invoke(prompt_vars)
     except LlmInitializationError:

--- a/src/pragmata/core/querygen/realization.py
+++ b/src/pragmata/core/querygen/realization.py
@@ -102,7 +102,7 @@ def run_realization_stage(
             check_every_n_seconds=llm_settings.check_every_n_seconds,
             max_bucket_size=llm_settings.max_bucket_size,
             base_url=llm_settings.base_url,
-            model_kwargs=llm_settings.model_kwargs,
+            model_kwargs=llm_settings.realization_model_kwargs,
         )
         llm_output = llm_runnable.invoke(prompt_vars)
     except LlmInitializationError:

--- a/src/pragmata/core/settings/querygen_settings.py
+++ b/src/pragmata/core/settings/querygen_settings.py
@@ -19,7 +19,8 @@ class LlmSettings(BaseModel):
     planning_model: str = "magistral-medium-latest"
     realization_model: str = "mistral-medium-latest"
     base_url: str | None = None
-    model_kwargs: dict[str, Any] = Field(default_factory=dict)
+    planning_model_kwargs: dict[str, Any] = Field(default_factory=dict)
+    realization_model_kwargs: dict[str, Any] = Field(default_factory=dict)
     requests_per_second: float = Field(default=1.0, gt=0)
     check_every_n_seconds: float = Field(default=1.0, gt=0)
     max_bucket_size: int = Field(default=1, ge=1)

--- a/tests/integration/test_querygen.py
+++ b/tests/integration/test_querygen.py
@@ -253,17 +253,20 @@ def happy_path_workflow_stubs(
     planning_summary_contexts: list[str] = []
     planning_summary_calls: list[dict[str, object]] = []
     realization_calls: list[list[str]] = []
+    planning_build_calls: list[dict[str, object]] = []
+    planning_summary_build_calls: list[dict[str, object]] = []
+    realization_build_calls: list[dict[str, object]] = []
 
     def fake_planning_build_llm_runnable(**kwargs: object) -> _PlanningRunnableStub:
-        del kwargs
+        planning_build_calls.append(dict(kwargs))
         return _PlanningRunnableStub(planning_calls, planning_summary_contexts)
 
     def fake_planning_summary_build_llm_runnable(**kwargs: object) -> _PlanningSummaryRunnableStub:
-        del kwargs
+        planning_summary_build_calls.append(dict(kwargs))
         return _PlanningSummaryRunnableStub(planning_summary_calls)
 
     def fake_realization_build_llm_runnable(**kwargs: object) -> _RealizationRunnableStub:
-        del kwargs
+        realization_build_calls.append(dict(kwargs))
         return _RealizationRunnableStub(realization_calls)
 
     monkeypatch.setattr(planning, "build_llm_runnable", fake_planning_build_llm_runnable)
@@ -289,6 +292,9 @@ def happy_path_workflow_stubs(
         "planning_summary_contexts": planning_summary_contexts,
         "planning_summary_calls": planning_summary_calls,
         "realization_calls": realization_calls,
+        "planning_build_calls": planning_build_calls,
+        "planning_summary_build_calls": planning_summary_build_calls,
+        "realization_build_calls": realization_build_calls,
     }
 
 
@@ -298,12 +304,22 @@ def test_gen_queries_executes_staged_workflow_with_recursive_planning_summary_an
 ) -> None:
     base_dir = tmp_path / "workspace"
     run_id = "integration-run-staged-001"
+    planning_model_kwargs = {
+        "temperature": 0.2,
+        "metadata": {"stage": "planning"},
+    }
+    realization_model_kwargs = {
+        "temperature": 0.8,
+        "metadata": {"stage": "realization"},
+    }
 
     result = querygen.gen_queries(
         **_required_querygen_kwargs(base_dir),
         run_id=run_id,
         n_queries=5,
         batch_size=2,
+        planning_model_kwargs=planning_model_kwargs,
+        realization_model_kwargs=realization_model_kwargs,
     )
 
     assert isinstance(result, querygen.QueryGenRunResult)
@@ -322,6 +338,22 @@ def test_gen_queries_executes_staged_workflow_with_recursive_planning_summary_an
         ["c001", "c002"],
         ["c003"],
     ]
+
+    planning_build_calls = happy_path_workflow_stubs["planning_build_calls"]
+    planning_summary_build_calls = happy_path_workflow_stubs["planning_summary_build_calls"]
+    realization_build_calls = happy_path_workflow_stubs["realization_build_calls"]
+
+    assert len(planning_build_calls) == 3
+    assert len(planning_summary_build_calls) == 3
+    assert len(realization_build_calls) == 2
+
+    assert all(call["model_kwargs"] == planning_model_kwargs for call in planning_build_calls)
+    assert all(call["model_kwargs"] == planning_model_kwargs for call in planning_summary_build_calls)
+    assert all(call["model_kwargs"] == realization_model_kwargs for call in realization_build_calls)
+
+    assert all(call["model"] == "magistral-medium-latest" for call in planning_build_calls)
+    assert all(call["model"] == "magistral-medium-latest" for call in planning_summary_build_calls)
+    assert all(call["model"] == "mistral-medium-latest" for call in realization_build_calls)
 
     planning_summary_calls = happy_path_workflow_stubs["planning_summary_calls"]
     assert planning_summary_calls == [

--- a/tests/unit/cli/test_cli_querygen.py
+++ b/tests/unit/cli/test_cli_querygen.py
@@ -45,6 +45,8 @@ def test_querygen_gen_queries_help_available() -> None:
     assert "Prepare a synthetic query generation run." in output
     assert "--domains" in output
     assert "--run-id" in output
+    assert "--planning-model-kwargs" in output
+    assert "--realization-model-kwargs" in output
 
 
 def test_querygen_cli_delegates_to_public_api(monkeypatch) -> None:
@@ -67,8 +69,10 @@ def test_querygen_cli_delegates_to_public_api(monkeypatch) -> None:
             "policy analyst",
             "--run-id",
             "custom-run",
-            "--model-kwargs",
-            '{"temperature": 0.2}',
+            "--planning-model-kwargs",
+            '{"reasoning": {"effort": "medium"}}',
+            "--realization-model-kwargs",
+            '{"reasoning": {"effort": "low"}}',
         ],
     )
 
@@ -76,7 +80,8 @@ def test_querygen_cli_delegates_to_public_api(monkeypatch) -> None:
     assert captured["domains"] == ["public administration"]
     assert captured["roles"] == "policy analyst"
     assert captured["run_id"] == "custom-run"
-    assert captured["model_kwargs"] == {"temperature": 0.2}
+    assert captured["planning_model_kwargs"] == {"reasoning": {"effort": "medium"}}
+    assert captured["realization_model_kwargs"] == {"reasoning": {"effort": "low"}}
 
 
 def test_querygen_cli_maps_omitted_options_to_unset(monkeypatch) -> None:
@@ -108,7 +113,8 @@ def test_querygen_cli_maps_omitted_options_to_unset(monkeypatch) -> None:
         "planning_model",
         "realization_model",
         "base_url",
-        "model_kwargs",
+        "planning_model_kwargs",
+        "realization_model_kwargs",
     }
 
     assert result.exit_code == 0

--- a/tests/unit/core/querygen/test_planning.py
+++ b/tests/unit/core/querygen/test_planning.py
@@ -105,7 +105,8 @@ def llm_settings() -> LlmSettings:
         check_every_n_seconds=0.2,
         max_bucket_size=3,
         base_url="https://example.invalid/v1",
-        model_kwargs={"temperature": 0.2},
+        planning_model_kwargs={"temperature": 0.2},
+        realization_model_kwargs={"temperature": 0.8},
     )
 
 
@@ -286,7 +287,7 @@ def test_run_planning_stage_wires_planning_assets_and_settings_into_llm_builder(
         check_every_n_seconds=llm_settings.check_every_n_seconds,
         max_bucket_size=llm_settings.max_bucket_size,
         base_url=llm_settings.base_url,
-        model_kwargs=llm_settings.model_kwargs,
+        model_kwargs=llm_settings.planning_model_kwargs,
     )
     mock_runnable.invoke.assert_called_once_with(expected_prompt_vars)
 

--- a/tests/unit/core/querygen/test_planning_summary.py
+++ b/tests/unit/core/querygen/test_planning_summary.py
@@ -106,7 +106,8 @@ def llm_settings() -> LlmSettings:
         check_every_n_seconds=0.2,
         max_bucket_size=3,
         base_url="https://example.invalid/v1",
-        model_kwargs={"temperature": 0.2},
+        planning_model_kwargs={"temperature": 0.2},
+        realization_model_kwargs={"temperature": 0.8},
     )
 
 
@@ -513,7 +514,7 @@ def test_run_planning_summary_wires_summary_prompt_assets_and_settings_into_llm_
         check_every_n_seconds=llm_settings.check_every_n_seconds,
         max_bucket_size=llm_settings.max_bucket_size,
         base_url=llm_settings.base_url,
-        model_kwargs=llm_settings.model_kwargs,
+        model_kwargs=llm_settings.planning_model_kwargs,
     )
     mock_runnable.invoke.assert_called_once_with(expected_prompt_vars)
 

--- a/tests/unit/core/querygen/test_realization.py
+++ b/tests/unit/core/querygen/test_realization.py
@@ -27,7 +27,8 @@ def llm_settings() -> LlmSettings:
         check_every_n_seconds=0.2,
         max_bucket_size=3,
         base_url="https://example.invalid/v1",
-        model_kwargs={"temperature": 0.2},
+        planning_model_kwargs={"temperature": 0.2},
+        realization_model_kwargs={"temperature": 0.8},
     )
 
 
@@ -177,7 +178,7 @@ def test_run_realization_stage_wires_realization_assets_and_settings_into_llm_bu
         check_every_n_seconds=llm_settings.check_every_n_seconds,
         max_bucket_size=llm_settings.max_bucket_size,
         base_url=llm_settings.base_url,
-        model_kwargs=llm_settings.model_kwargs,
+        model_kwargs=llm_settings.realization_model_kwargs,
     )
     mock_runnable.invoke.assert_called_once_with(expected_prompt_vars_single)
 

--- a/tests/unit/core/settings/test_querygen_settings.py
+++ b/tests/unit/core/settings/test_querygen_settings.py
@@ -34,7 +34,8 @@ def test_llm_settings_defaults() -> None:
     assert settings.planning_model == "magistral-medium-latest"
     assert settings.realization_model == "mistral-medium-latest"
     assert settings.base_url is None
-    assert settings.model_kwargs == {}
+    assert settings.planning_model_kwargs == {}
+    assert settings.realization_model_kwargs == {}
     assert settings.requests_per_second == 1.0
     assert settings.check_every_n_seconds == 1.0
     assert settings.max_bucket_size == 1
@@ -47,7 +48,8 @@ def test_querygen_run_settings_construction_with_defaults() -> None:
     assert settings.llm.model_provider == "mistralai"
     assert settings.llm.planning_model == "magistral-medium-latest"
     assert settings.llm.realization_model == "mistral-medium-latest"
-    assert settings.llm.model_kwargs == {}
+    assert settings.llm.planning_model_kwargs == {}
+    assert settings.llm.realization_model_kwargs == {}
     assert isinstance(settings.base_dir, Path)
     assert settings.run_id
     assert settings.n_queries == 50
@@ -63,9 +65,12 @@ def test_querygen_run_settings_resolve_deep_merges_nested_llm_settings() -> None
             "spec": _valid_spec_payload(),
             "llm": {
                 "model_provider": "mistralai",
-                "model_kwargs": {
+                "planning_model_kwargs": {
                     "temperature": 0.2,
                     "top_p": 0.9,
+                },
+                "realization_model_kwargs": {
+                    "temperature": 0.4,
                 },
             },
             "n_queries": 20,
@@ -73,7 +78,7 @@ def test_querygen_run_settings_resolve_deep_merges_nested_llm_settings() -> None
         overrides={
             "llm": {
                 "planning_model": "magistral-small-latest",
-                "model_kwargs": {
+                "planning_model_kwargs": {
                     "temperature": 0.7,
                 },
             }
@@ -84,9 +89,12 @@ def test_querygen_run_settings_resolve_deep_merges_nested_llm_settings() -> None
     assert resolved.llm.model_provider == "mistralai"
     assert resolved.llm.planning_model == "magistral-small-latest"
     assert resolved.llm.realization_model == "mistral-medium-latest"
-    assert resolved.llm.model_kwargs == {
+    assert resolved.llm.planning_model_kwargs == {
         "temperature": 0.7,
         "top_p": 0.9,
+    }
+    assert resolved.llm.realization_model_kwargs == {
+        "temperature": 0.4,
     }
 
 
@@ -96,32 +104,47 @@ def test_querygen_run_settings_model_kwargs_merge_semantics() -> None:
         config={
             "spec": _valid_spec_payload(),
             "llm": {
-                "model_kwargs": {
+                "planning_model_kwargs": {
                     "temperature": 0.2,
                     "top_p": 0.9,
-                }
+                },
+                "realization_model_kwargs": {
+                    "temperature": 0.4,
+                    "max_tokens": 500,
+                },
             },
         },
         env={
             "llm": {
-                "model_kwargs": {
+                "planning_model_kwargs": {
                     "max_tokens": 300,
-                }
+                },
+                "realization_model_kwargs": {
+                    "temperature": 0.6,
+                },
             },
         },
         overrides={
             "llm": {
-                "model_kwargs": {
+                "planning_model_kwargs": {
                     "temperature": 0.7,
-                }
+                },
+                "realization_model_kwargs": {
+                    "top_p": 0.8,
+                },
             }
         },
     )
 
-    assert resolved.llm.model_kwargs == {
+    assert resolved.llm.planning_model_kwargs == {
         "temperature": 0.7,
         "top_p": 0.9,
         "max_tokens": 300,
+    }
+    assert resolved.llm.realization_model_kwargs == {
+        "temperature": 0.6,
+        "max_tokens": 500,
+        "top_p": 0.8,
     }
 
 


### PR DESCRIPTION
**Summary**

Replaces the shared querygen `model_kwargs` setting with stage-specific `planning_model_kwargs` and `realization_model_kwargs`. The change allows callers to pass provider-specific model options independently to the planning and realization models.

**Key changes**

- Replace `model_kwargs` with:
  - `planning_model_kwargs`
  - `realization_model_kwargs`
- Wire planning-stage execution to `planning_model_kwargs`
- Wire planning-summary execution to `planning_model_kwargs`
- Wire realization-stage execution to `realization_model_kwargs`
- Update the Python API and CLI surfaces
- Update unit and integration tests for the new settings/API/CLI contract

**Rationale**

The previous shared `model_kwargs` setting applied the same provider-specific options to both querygen stages. That became too coarse once planning and realization started using different model roles and, in practice, potentially different model families or reasoning settings.

Splitting this into `planning_model_kwargs` and `realization_model_kwargs` keeps provider-specific tuning stage-local: planning can receive options appropriate for structured blueprint generation and planning-summary updates, while realization can receive options appropriate for natural-language query writing.

**Compatibility**

This is a breaking pre-release API/CLI change:

- `model_kwargs` is removed
- `--model-kwargs` is removed
- config files must use `planning_model_kwargs` and/or `realization_model_kwargs` under `llm`