### PR TITLE
fix: enforce batch-specific querygen structured output cardinality

### DIFF
--- a/src/pragmata/core/querygen/planning.py
+++ b/src/pragmata/core/querygen/planning.py
@@ -3,7 +3,7 @@
 from pragmata.core.querygen.llm import LlmInitializationError, build_llm_runnable
 from pragmata.core.querygen.prompts import SYSTEM_PROMPT_PLANNING, USER_PROMPT_PLANNING
 from pragmata.core.schemas.querygen_input import QueryGenSpec, WeightedValue
-from pragmata.core.schemas.querygen_plan import QueryBlueprint, QueryBlueprintList
+from pragmata.core.schemas.querygen_plan import QueryBlueprint, make_query_blueprint_list_schema
 from pragmata.core.schemas.querygen_summary import PlanningSummaryState
 from pragmata.core.settings.querygen_settings import LlmSettings
 
@@ -152,6 +152,8 @@ def run_planning_stage(
         planning_summary=planning_summary,
     )
 
+    output_schema = make_query_blueprint_list_schema(len(batch_candidate_ids))
+
     try:
         llm_runnable = build_llm_runnable(
             system_text=SYSTEM_PROMPT_PLANNING,
@@ -159,7 +161,7 @@ def run_planning_stage(
             model_provider=llm_settings.model_provider,
             model=llm_settings.planning_model,
             api_key=api_key,
-            output_schema=QueryBlueprintList,
+            output_schema=output_schema,
             requests_per_second=llm_settings.requests_per_second,
             check_every_n_seconds=llm_settings.check_every_n_seconds,
             max_bucket_size=llm_settings.max_bucket_size,

--- a/src/pragmata/core/querygen/realization.py
+++ b/src/pragmata/core/querygen/realization.py
@@ -3,7 +3,7 @@
 from pragmata.core.querygen.llm import LlmInitializationError, build_llm_runnable
 from pragmata.core.querygen.prompts import SYSTEM_PROMPT_REALIZATION, USER_PROMPT_REALIZATION
 from pragmata.core.schemas.querygen_plan import QueryBlueprint
-from pragmata.core.schemas.querygen_realize import RealizedQuery, RealizedQueryList
+from pragmata.core.schemas.querygen_realize import RealizedQuery, make_realized_query_list_schema
 from pragmata.core.settings.querygen_settings import LlmSettings
 
 
@@ -90,6 +90,8 @@ def run_realization_stage(
     """
     prompt_vars = _build_realization_prompt_vars(candidates)
 
+    output_schema = make_realized_query_list_schema(len(candidates))
+
     try:
         llm_runnable = build_llm_runnable(
             system_text=SYSTEM_PROMPT_REALIZATION,
@@ -97,7 +99,7 @@ def run_realization_stage(
             model_provider=llm_settings.model_provider,
             model=llm_settings.realization_model,
             api_key=api_key,
-            output_schema=RealizedQueryList,
+            output_schema=output_schema,
             requests_per_second=llm_settings.requests_per_second,
             check_every_n_seconds=llm_settings.check_every_n_seconds,
             max_bucket_size=llm_settings.max_bucket_size,

--- a/src/pragmata/core/schemas/querygen_plan.py
+++ b/src/pragmata/core/schemas/querygen_plan.py
@@ -1,6 +1,8 @@
 """Structured output contracts for LLM stage 1 query planning."""
 
-from pydantic import BaseModel, ConfigDict, Field
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field, create_model
 
 
 class QueryBlueprint(BaseModel):
@@ -66,4 +68,24 @@ class QueryBlueprintList(BaseModel):
     candidates: list[QueryBlueprint] = Field(
         ...,
         description="List of structured candidate query blueprints.",
+    )
+
+
+def make_query_blueprint_list_schema(
+    expected_length: int,
+) -> type[QueryBlueprintList]:
+    """Build a planning output schema constrained to one exact batch length."""
+    candidate_list_type = Annotated[
+        list[QueryBlueprint],
+        Field(
+            min_length=expected_length,
+            max_length=expected_length,
+            description=f"List of {expected_length} structured candidate query blueprints.",
+        ),
+    ]
+
+    return create_model(
+        f"QueryBlueprintListLen{expected_length}",
+        __base__=QueryBlueprintList,
+        candidates=(candidate_list_type, ...),
     )

--- a/src/pragmata/core/schemas/querygen_realize.py
+++ b/src/pragmata/core/schemas/querygen_realize.py
@@ -1,6 +1,8 @@
 """Structured output contracts for LLM stage 2 query realization."""
 
-from pydantic import BaseModel, ConfigDict, Field
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field, create_model
 
 
 class RealizedQuery(BaseModel):
@@ -18,3 +20,23 @@ class RealizedQueryList(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     queries: list[RealizedQuery] = Field(description="Realized queries aligned one-to-one with the stage 2 candidates.")
+
+
+def make_realized_query_list_schema(
+    expected_length: int,
+) -> type[RealizedQueryList]:
+    """Build a realization output schema constrained to one exact batch length."""
+    realized_query_list_type = Annotated[
+        list[RealizedQuery],
+        Field(
+            min_length=expected_length,
+            max_length=expected_length,
+            description=f"{expected_length} realized queries aligned one-to-one with the stage 2 candidates.",
+        ),
+    ]
+
+    return create_model(
+        f"RealizedQueryListLen{expected_length}",
+        __base__=RealizedQueryList,
+        queries=(realized_query_list_type, ...),
+    )

--- a/tests/unit/core/querygen/test_planning.py
+++ b/tests/unit/core/querygen/test_planning.py
@@ -1,6 +1,6 @@
 """Tests for the synthetic query-generation stage-1 planning executor."""
 
-from unittest.mock import Mock
+from unittest.mock import ANY, Mock
 
 import pytest
 
@@ -282,13 +282,19 @@ def test_run_planning_stage_wires_planning_assets_and_settings_into_llm_builder(
         model_provider=llm_settings.model_provider,
         model=llm_settings.planning_model,
         api_key="test-api-key",
-        output_schema=QueryBlueprintList,
+        output_schema=ANY,
         requests_per_second=llm_settings.requests_per_second,
         check_every_n_seconds=llm_settings.check_every_n_seconds,
         max_bucket_size=llm_settings.max_bucket_size,
         base_url=llm_settings.base_url,
         model_kwargs=llm_settings.planning_model_kwargs,
     )
+
+    output_schema = build_llm_runnable_mock.call_args.kwargs["output_schema"]
+    assert issubclass(output_schema, QueryBlueprintList)
+    assert output_schema is not QueryBlueprintList
+    assert output_schema.__name__ == "QueryBlueprintListLen1"
+
     mock_runnable.invoke.assert_called_once_with(expected_prompt_vars)
 
 

--- a/tests/unit/core/querygen/test_realization.py
+++ b/tests/unit/core/querygen/test_realization.py
@@ -1,6 +1,6 @@
 """Tests for the synthetic query-generation stage-2 realization executor."""
 
-from unittest.mock import Mock
+from unittest.mock import ANY, Mock
 
 import pytest
 
@@ -173,13 +173,19 @@ def test_run_realization_stage_wires_realization_assets_and_settings_into_llm_bu
         model_provider=llm_settings.model_provider,
         model=llm_settings.realization_model,
         api_key="test-api-key",
-        output_schema=RealizedQueryList,
+        output_schema=ANY,
         requests_per_second=llm_settings.requests_per_second,
         check_every_n_seconds=llm_settings.check_every_n_seconds,
         max_bucket_size=llm_settings.max_bucket_size,
         base_url=llm_settings.base_url,
         model_kwargs=llm_settings.realization_model_kwargs,
     )
+
+    output_schema = build_llm_runnable_mock.call_args.kwargs["output_schema"]
+    assert issubclass(output_schema, RealizedQueryList)
+    assert output_schema is not RealizedQueryList
+    assert output_schema.__name__ == "RealizedQueryListLen1"
+
     mock_runnable.invoke.assert_called_once_with(expected_prompt_vars_single)
 
 

--- a/tests/unit/core/schemas/test_querygen_plan.py
+++ b/tests/unit/core/schemas/test_querygen_plan.py
@@ -3,7 +3,7 @@
 import pytest
 from pydantic import ValidationError
 
-from pragmata.core.schemas.querygen_plan import QueryBlueprint, QueryBlueprintList
+from pragmata.core.schemas.querygen_plan import QueryBlueprint, QueryBlueprintList, make_query_blueprint_list_schema
 
 
 @pytest.fixture()
@@ -111,6 +111,22 @@ def test_query_blueprint_list_accepts_valid_candidates(
     assert len(result.candidates) == 2
     assert result.candidates[1].domain == "labour market policy"
     assert result.candidates[1].topic == "minimum wage effects"
+
+
+def test_dynamic_query_blueprint_list_schema_enforces_expected_candidate_count(
+    base_payload: dict[str, object],
+) -> None:
+    """Dynamic wrapper schema enforces the expected candidate count."""
+    schema = make_query_blueprint_list_schema(expected_length=2)
+    second_payload = {**base_payload, "candidate_id": "candidate-002"}
+
+    result = schema.model_validate({"candidates": [base_payload, second_payload]})
+
+    assert isinstance(result, QueryBlueprintList)
+    assert len(result.candidates) == 2
+
+    with pytest.raises(ValidationError):
+        schema.model_validate({"candidates": [base_payload]})
 
 
 def test_query_blueprint_list_rejects_extra_fields() -> None:

--- a/tests/unit/core/schemas/test_querygen_plan.py
+++ b/tests/unit/core/schemas/test_querygen_plan.py
@@ -119,6 +119,7 @@ def test_dynamic_query_blueprint_list_schema_enforces_expected_candidate_count(
     """Dynamic wrapper schema enforces the expected candidate count."""
     schema = make_query_blueprint_list_schema(expected_length=2)
     second_payload = {**base_payload, "candidate_id": "candidate-002"}
+    third_payload = {**base_payload, "candidate_id": "candidate-003"}
 
     result = schema.model_validate({"candidates": [base_payload, second_payload]})
 
@@ -127,6 +128,9 @@ def test_dynamic_query_blueprint_list_schema_enforces_expected_candidate_count(
 
     with pytest.raises(ValidationError):
         schema.model_validate({"candidates": [base_payload]})
+
+    with pytest.raises(ValidationError):
+        schema.model_validate({"candidates": [base_payload, second_payload, third_payload]})
 
 
 def test_query_blueprint_list_rejects_extra_fields() -> None:

--- a/tests/unit/core/schemas/test_querygen_realize.py
+++ b/tests/unit/core/schemas/test_querygen_realize.py
@@ -62,6 +62,10 @@ def test_dynamic_realized_query_list_schema_enforces_expected_query_count(
 ) -> None:
     """Dynamic wrapper schema enforces the expected realized-query count."""
     schema = make_realized_query_list_schema(expected_length=2)
+    extra_query_payload = {
+        "candidate_id": "cand_003",
+        "query": "Where can I check the status of a housing support application?",
+    }
 
     result = schema.model_validate(valid_realized_query_list_payload)
 
@@ -70,6 +74,11 @@ def test_dynamic_realized_query_list_schema_enforces_expected_query_count(
 
     with pytest.raises(ValidationError):
         schema.model_validate({"queries": valid_realized_query_list_payload["queries"][:1]})
+
+    with pytest.raises(ValidationError):
+        schema.model_validate(
+            {"queries": [*valid_realized_query_list_payload["queries"], extra_query_payload]}
+        )
 
 
 def test_realized_query_list_rejects_extra_keys(

--- a/tests/unit/core/schemas/test_querygen_realize.py
+++ b/tests/unit/core/schemas/test_querygen_realize.py
@@ -3,7 +3,7 @@
 import pytest
 from pydantic import ValidationError
 
-from pragmata.core.schemas.querygen_realize import RealizedQuery, RealizedQueryList
+from pragmata.core.schemas.querygen_realize import RealizedQuery, RealizedQueryList, make_realized_query_list_schema
 
 
 @pytest.fixture()
@@ -55,6 +55,21 @@ def test_realized_query_list_accepts_valid_payload(
     assert len(realized_query_list.queries) == 2
     assert realized_query_list.queries[0].candidate_id == "cand_001"
     assert realized_query_list.queries[1].query == "What documents do I need to apply for housing support?"
+
+
+def test_dynamic_realized_query_list_schema_enforces_expected_query_count(
+    valid_realized_query_list_payload: dict[str, list[dict[str, str]]],
+) -> None:
+    """Dynamic wrapper schema enforces the expected realized-query count."""
+    schema = make_realized_query_list_schema(expected_length=2)
+
+    result = schema.model_validate(valid_realized_query_list_payload)
+
+    assert isinstance(result, RealizedQueryList)
+    assert len(result.queries) == 2
+
+    with pytest.raises(ValidationError):
+        schema.model_validate({"queries": valid_realized_query_list_payload["queries"][:1]})
 
 
 def test_realized_query_list_rejects_extra_keys(

--- a/tests/unit/core/schemas/test_querygen_realize.py
+++ b/tests/unit/core/schemas/test_querygen_realize.py
@@ -76,9 +76,7 @@ def test_dynamic_realized_query_list_schema_enforces_expected_query_count(
         schema.model_validate({"queries": valid_realized_query_list_payload["queries"][:1]})
 
     with pytest.raises(ValidationError):
-        schema.model_validate(
-            {"queries": [*valid_realized_query_list_payload["queries"], extra_query_payload]}
-        )
+        schema.model_validate({"queries": [*valid_realized_query_list_payload["queries"], extra_query_payload]})
 
 
 def test_realized_query_list_rejects_extra_keys(


### PR DESCRIPTION
**Summary**

Tightens the structured-output contract for querygen planning and realization. Previously, `QueryBlueprintList` and `RealizedQueryList` validated the shape of returned items, but not the expected number of returned items. This allowed incomplete LLM responses to remain structurally valid and continue through the workflow instead of failing validation and triggering bounded retries.

**Key changes**

- Add a dynamic `QueryBlueprintList` schema factory constrained to the planning batch size
- Add a dynamic `RealizedQueryList` schema factory constrained to the realization batch size
- Wire planning-stage execution to use `len(batch_candidate_ids)` as the expected blueprint count
- Wire realization-stage execution to use `len(candidates)` as the expected realized-query count
- Preserve the existing item schemas and downstream `list[QueryBlueprint]` / `list[RealizedQuery]` contracts

The item schemas remain unchanged, and downstream code still receives plain `list[QueryBlueprint]` and `list[RealizedQuery]`.

## Testing

- Added focused schema tests for dynamic planning and realization output cardinality.
- Updated planning and realization stage tests to assert dynamic schema subclasses are wired into the LLM runnable.
- Unit and integration tests pass.