### PR TITLE
chore: update Sascha author contact email

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "pragmata"
 version = "0.0.1"
 description = "Evidence-grounded evaluation framework for RAG systems with synthetic query generation, structured annotation, and model-assisted label inference for scalable scoring."
 authors =[
-  { name = "Sascha Göbel", email = "goebel@hertie-school.org" },
+  { name = "Sascha Göbel", email = "sascha.goebel@tuta.com" },
   { name = "Henry Baker", email =  "h.baker@hertie-school.org" },
   { name = "Luis Fernando Ramírez Ruiz" },
 ]


### PR DESCRIPTION
**Summary**

Updates Sascha Göbel’s author contact email in `pyproject.toml` from an institutional address to a non-institutional address.

**Key changes**

- Update Sascha Göbel’s author email metadata
- Leave all co-author metadata unchanged

**Scope**

This is a package metadata-only change.