### PR TITLE
ci: add automatic PR labeling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
     open-pull-requests-limit: 5
     versioning-strategy: "lockfile-only"
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "deps"
     labels:
       - "dependencies"
     groups:
@@ -36,7 +36,7 @@ updates:
       default-days: 14
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "chore(ci)"
+      prefix: "deps"
     labels:
       - "dependencies"
     groups:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,41 @@
+feature:
+  - head-branch:
+      - '^feat/'
+      - '^feature/'
+
+fix:
+  - head-branch:
+      - '^fix/'
+      - '^bugfix/'
+
+refactor:
+  - head-branch:
+      - '^refactor/'
+
+tests:
+  - head-branch:
+      - '^test/'
+      - '^tests/'
+
+documentation:
+  - head-branch:
+      - '^docs/'
+      - '^doc/'
+
+ci:
+  - head-branch:
+      - '^ci/'
+
+release:
+  - head-branch:
+      - '^release/'
+
+chore:
+  - head-branch:
+      - '^chore/'
+      - '^build/'
+
+dependencies:
+  - head-branch:
+      - '^deps/'
+      - '^dependabot/'

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,46 @@
+name: Pull Request Labeler
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    name: Label pull request
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Apply type labels
+        uses: actions/labeler@v6
+        with:
+          sync-labels: true
+
+      - name: Apply size label
+        if: github.event.action != 'edited'
+        uses: codelytv/pr-size-labeler@v1
+        with:
+          xs_label: 'size: XS'
+          xs_max_size: '49'
+          s_label: 'size: S'
+          s_max_size: '199'
+          m_label: 'size: M'
+          m_max_size: '499'
+          l_label: 'size: L'
+          l_max_size: '999'
+          xl_label: 'size: XL'
+          fail_if_xl: 'false'
+          files_to_ignore: |
+            uv.lock

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -11,7 +11,6 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  issues: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
@@ -26,7 +25,7 @@ jobs:
       - name: Apply type labels
         uses: actions/labeler@v6
         with:
-          sync-labels: true
+          sync-labels: false
 
       - name: Apply size label
         if: github.event.action != 'edited'


### PR DESCRIPTION
### Summary

Adds lightweight automatic pull request labeling.

This introduces a branch-based PR labeler for common contribution types and a size labeler that classifies pull requests by changed lines of code. The setup is intentionally scoped to low-noise labels and avoids automatic subsystem/topic labeling.

### Key Changes

- Add `.github/labeler.yml` with branch-prefix rules.
- Add `.github/workflows/pr-labeler.yml` to apply PR type and size labels.
- Use size thresholds.
- Exclude `uv.lock` from PR size calculation.
- Update Dependabot PRs to use the `dependencies` label.