### PR TITLE
feat: add eval score path bundle

### DIFF
--- a/src/pragmata/core/paths/eval_paths.py
+++ b/src/pragmata/core/paths/eval_paths.py
@@ -56,7 +56,7 @@ def resolve_eval_score_paths(
         tool_root=tool_root,
         score_dir=score_dir,
         retrieval_scores_json=score_dir / "retrieval_scores.json",
-        grounding_scores_json=score_dir / " grounding_scores.json",
+        grounding_scores_json=score_dir / "grounding_scores.json",
         generation_scores_json=score_dir / "generation_scores.json",
         scores_meta_json=score_dir / "scores_meta.json",
     )

--- a/src/pragmata/core/paths/eval_paths.py
+++ b/src/pragmata/core/paths/eval_paths.py
@@ -14,9 +14,9 @@ class EvalPaths:
     Attributes:
         tool_root: Root directory for the eval tool.
         score_dir: Root directory for a specific eval score run.
-        scores_retrieval_json: Output path for retrieval score metrics.
-        scores_grounding_json: Output path for grounding score metrics.
-        scores_generation_json: Output path for generation score metrics.
+        retrieval_scores_json: Output path for retrieval score metrics.
+        grounding_scores_json: Output path for grounding score metrics.
+        generation_scores_json: Output path for generation score metrics.
         scores_meta_json: Output path for score run metadata.
     """
 
@@ -58,5 +58,5 @@ def resolve_eval_score_paths(
         retrieval_scores_json=score_dir / "retrieval_scores.json",
         grounding_scores_json=score_dir / "grounding_scores.json",
         generation_scores_json=score_dir / "generation_scores.json",
-        scores_meta_json=score_dir / "scores_meta.json",
+        scores_meta_json=score_dir / "scores.meta.json",
     )

--- a/src/pragmata/core/paths/eval_paths.py
+++ b/src/pragmata/core/paths/eval_paths.py
@@ -1,0 +1,62 @@
+"""Path bundles for eval score runs."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Self
+
+from pragmata.core.paths.paths import WorkspacePaths
+
+
+@dataclass(frozen=True, slots=True)
+class EvalPaths:
+    """Path bundle for an eval score run.
+
+    Attributes:
+        tool_root: Root directory for the eval tool.
+        score_dir: Root directory for a specific eval score run.
+        scores_retrieval_json: Output path for retrieval score metrics.
+        scores_grounding_json: Output path for grounding score metrics.
+        scores_generation_json: Output path for generation score metrics.
+        scores_meta_json: Output path for score run metadata.
+    """
+
+    tool_root: Path
+    score_dir: Path
+    retrieval_scores_json: Path
+    grounding_scores_json: Path
+    generation_scores_json: Path
+    scores_meta_json: Path
+
+    def ensure_dirs(
+        self,
+    ) -> Self:
+        """Create the eval score directory scaffold."""
+        self.score_dir.mkdir(parents=True, exist_ok=True)
+        return self
+
+
+def resolve_eval_score_paths(
+    *,
+    workspace: WorkspacePaths,
+    score_id: str,
+) -> EvalPaths:
+    """Build the path bundle for an eval score run.
+
+    Args:
+        workspace: Workspace path bundle.
+        score_id: Unique score run identifier.
+
+    Returns:
+        Path bundle for the eval score run.
+    """
+    tool_root = workspace.tool_root("eval")
+    score_dir = tool_root / "scores" / score_id
+
+    return EvalPaths(
+        tool_root=tool_root,
+        score_dir=score_dir,
+        retrieval_scores_json=score_dir / "retrieval_scores.json",
+        grounding_scores_json=score_dir / " grounding_scores.json",
+        generation_scores_json=score_dir / "generation_scores.json",
+        scores_meta_json=score_dir / "scores_meta.json",
+    )

--- a/tests/unit/core/paths/test_eval_paths.py
+++ b/tests/unit/core/paths/test_eval_paths.py
@@ -33,7 +33,7 @@ def test_resolve_eval_score_paths_returns_expected_bundle(
         retrieval_scores_json=expected_score_dir / "retrieval_scores.json",
         grounding_scores_json=expected_score_dir / "grounding_scores.json",
         generation_scores_json=expected_score_dir / "generation_scores.json",
-        scores_meta_json=expected_score_dir / "scores_meta.json",
+        scores_meta_json=expected_score_dir / "scores.meta.json",
     )
 
 

--- a/tests/unit/core/paths/test_eval_paths.py
+++ b/tests/unit/core/paths/test_eval_paths.py
@@ -1,0 +1,78 @@
+"""Tests for eval score run path bundle."""
+
+from pathlib import Path
+
+import pytest
+
+from pragmata.core.paths.eval_paths import EvalPaths, resolve_eval_score_paths
+from pragmata.core.paths.paths import WorkspacePaths
+
+
+@pytest.fixture()
+def workspace(tmp_path: Path) -> WorkspacePaths:
+    """Workspace path bundle rooted in a temporary directory."""
+    return WorkspacePaths.from_base_dir(tmp_path)
+
+
+def test_resolve_eval_score_paths_returns_expected_bundle(
+    workspace: WorkspacePaths,
+) -> None:
+    """Resolver returns the expected score run and artifact paths."""
+    score_id = "score-26"
+
+    paths = resolve_eval_score_paths(
+        workspace=workspace,
+        score_id=score_id,
+    )
+    expected_tool_root = workspace.base_dir / "eval"
+    expected_score_dir = workspace.base_dir / "eval" / "scores" / score_id
+
+    assert paths == EvalPaths(
+        tool_root=expected_tool_root,
+        score_dir=expected_score_dir,
+        retrieval_scores_json=expected_score_dir / "retrieval_scores.json",
+        grounding_scores_json=expected_score_dir / "grounding_scores.json",
+        generation_scores_json=expected_score_dir / "generation_scores.json",
+        scores_meta_json=expected_score_dir / "scores_meta.json",
+    )
+
+
+def test_ensure_dirs_creates_score_directory_and_returns_self(
+    workspace: WorkspacePaths,
+) -> None:
+    """ensure_dirs creates the score directory scaffold and returns self."""
+    paths = resolve_eval_score_paths(
+        workspace=workspace,
+        score_id="new-score",
+    )
+
+    assert not paths.score_dir.exists()
+    assert not paths.tool_root.exists()
+
+    returned = paths.ensure_dirs()
+
+    assert returned is paths
+    assert paths.tool_root.is_dir()
+    assert paths.score_dir.is_dir()
+
+
+def test_score_artifact_paths_are_score_id_specific(
+    workspace: WorkspacePaths,
+) -> None:
+    """Score artifact paths depend on the score ID."""
+    first = resolve_eval_score_paths(
+        workspace=workspace,
+        score_id="score-a",
+    )
+    second = resolve_eval_score_paths(
+        workspace=workspace,
+        score_id="score-b",
+    )
+
+    assert first.score_dir != second.score_dir
+    assert first.retrieval_scores_json != second.retrieval_scores_json
+    assert first.grounding_scores_json != second.grounding_scores_json
+    assert first.generation_scores_json != second.generation_scores_json
+    assert first.scores_meta_json != second.scores_meta_json
+
+    assert first.score_dir.parent == second.score_dir.parent == first.tool_root / "scores"


### PR DESCRIPTION
### Summary

Adds the eval path bundle for `pRAGmata`-owned score artifacts.

This intentionally keeps train and prediction artifacts out of `pRAGmata`'s eval path resolver because those are owned by `tlmtc`. `pRAGmata` will pass the eval tool root to `tlmtc` as its `work_dir`, and `tlmtc` will manage its native `train_outputs/` and `prediction_outputs/` structure.

Expected eval workspace layout:

```text
<base_dir>/eval/                      #  `pRAGmata` eval tool root, passed to `tlmtc` as work_dir
├── train_outputs/                    # `tlmtc`-owned
│   └── <run_id>/
│       ├── train_run_meta.json
│       ├── data/
│       ├── logs/
│       ├── model/
│       └── evaluation/
├── prediction_outputs/               # `tlmtc`-owned
│   └── <run_id>/
│       ├── probabilities.csv
│       └── predictions.csv
└── scores/                           #  `pRAGmata`-owned
    └── <score_id>/
        ├── retrieval_scores.json
        ├── grounding_scores.json
        ├── generation_scores.json
        └── scores_meta.json
```

For eval train and predict workflows, the API layer should resolve the `tlmtc` work directory directly via:

```python
WorkspacePaths.from_base_dir(base_dir).tool_root("eval")
```

and pass that path to `tlmtc`.

### Key Changes

- Add `EvalPaths` for eval score run artifacts
- Add `resolve_eval_score_paths(...)`
- Store task-specific score outputs as JSON artifacts
- Add focused unit coverage for score path resolution and directory creation