### PR TITLE
feat(annotation): discard widget i18n with chrome-locale toggle

### DIFF
--- a/src/pragmata/core/annotation/argilla_task_definitions.py
+++ b/src/pragmata/core/annotation/argilla_task_definitions.py
@@ -18,14 +18,31 @@ dataset creation time.
 """
 
 import functools
+import json
 from importlib.resources import files
 from string import Template
+from typing import Any
 
 import argilla as rg
 
-from pragmata.core.annotation.locales.registry import get_catalog
+from pragmata.core.annotation.locales.loader import DISCARD_WIDGET_KEYS
+from pragmata.core.annotation.locales.registry import CATALOGS, get_catalog
 from pragmata.core.annotation.locales.types import Catalog, CatalogKind
 from pragmata.core.schemas.annotation_task import DiscardReason, Locale, Task
+
+
+class _DiscardTemplate(Template):
+    """``string.Template`` with ``@@`` delimiter; JS body uses ``$nuxt``/``$i18n``.
+
+    The discard_flow.html template body contains literal ``$``-references
+    (``$nuxt``, ``$i18n``, ``$el``); switching the delimiter to ``@@``
+    keeps those intact. When editing discard_flow.html, do not introduce
+    ``@@`` tokens in the JS or HTML body unless you intend them as
+    substitution placeholders.
+    """
+
+    delimiter = "@@"
+
 
 DATASET_NAMES: dict[Task, str] = {
     Task.RETRIEVAL: "retrieval",
@@ -86,6 +103,43 @@ def _discard_questions(task: Task, catalog: Catalog) -> list[rg.LabelQuestion | 
     ]
 
 
+def _discard_i18n_payload_for_locale(loc: Locale, task: Task) -> dict[str, Any]:
+    """Per-locale block of strings the discard widget JS reads at runtime.
+
+    Includes the widget's own chrome strings, the discard-reason option
+    list (value + display text), and the two helper-question titles the
+    widget uses for ``aria-label`` matching when scoping the native
+    Argilla cards it hides.
+    """
+    catalog = CATALOGS[loc]
+    payload: dict[str, Any] = {key: catalog[(task, "widget", f"discard.{key}")] for key in DISCARD_WIDGET_KEYS}
+    payload["discard_reason_title"] = catalog[(task, "question", "discard_reason")]
+    payload["discard_notes_title"] = catalog[(task, "question", "discard_notes")]
+    payload["reason_options"] = [
+        {"value": r.value, "text": catalog[(task, "label", f"discard_reason.{r.value}")]} for r in DiscardReason
+    ]
+    return payload
+
+
+def _render_discard_template(template_text: str, task: Task, dataset_locale: Locale) -> str:
+    """Substitute the all-locales i18n payload into ``discard_flow.html``.
+
+    The widget JS picks the active locale at runtime (Argilla's chrome
+    locale, with a fallback chain). All supported locales are shipped so
+    the switch is instant. ``SUPPORTED_LOCALES`` is ordered with the
+    dataset's creation locale first; this is defensive only -- the JS
+    iterates every locale when matching ``aria-label`` attributes and
+    EN/DE titles do not collide today.
+    """
+    locales_in_order = [dataset_locale] + [loc for loc in sorted(CATALOGS) if loc != dataset_locale]
+    i18n_payload = {loc: _discard_i18n_payload_for_locale(loc, task) for loc in locales_in_order}
+    return _DiscardTemplate(template_text).substitute(
+        I18N_JSON=json.dumps(i18n_payload, ensure_ascii=False),
+        SUPPORTED_LOCALES_JSON=json.dumps(locales_in_order),
+        DEFAULT_LOCALE_JSON=json.dumps(dataset_locale),
+    )
+
+
 @functools.cache
 def build_task_settings(locale: Locale = "en") -> dict[Task, rg.Settings]:
     """Build Argilla Settings for each annotation task, in the given locale.
@@ -104,7 +158,7 @@ def build_task_settings(locale: Locale = "en") -> dict[Task, rg.Settings]:
         return rg.CustomField(
             name="discard_flow",
             title=catalog[(task, "field", "discard_flow")],
-            template=discard_template,
+            template=_render_discard_template(discard_template, task, locale),
             advanced_mode=True,
             required=False,
         )

--- a/src/pragmata/core/annotation/discard_flow.html
+++ b/src/pragmata/core/annotation/discard_flow.html
@@ -33,41 +33,47 @@
 <body>
 
 <details class="discard-panel" id="panel">
-  <summary>&#9888; Discard this record</summary>
-  <p style="margin-top:8px;font-size:13px;color:#555">
-    Use this if the record is unsuitable for annotation
-    (e.g. invalid, unclear, or outside your expertise).
-  </p>
+  <summary><span data-i18n="panel_summary"></span></summary>
+  <p data-i18n="panel_help" style="margin-top:8px;font-size:13px;color:#555"></p>
 
-  <label>Reason:
-    <select id="reason">
-      <option value="">&#8212; select &#8212;</option>
-      <option value="invalid_or_unrealistic">Invalid or unrealistic record</option>
-      <option value="unclear">Unclear query/context/answer relationship</option>
-      <option value="outside_reviewer_expertise">Outside my domain expertise</option>
-    </select>
+  <label><span data-i18n="reason_label"></span>
+    <select id="reason"></select>
   </label>
 
-  <label>Optional notes:
-    <textarea id="discard-notes" rows="3"
-      placeholder="Any extra context (optional)"></textarea>
+  <label><span data-i18n="notes_label"></span>
+    <textarea id="discard-notes" rows="3"></textarea>
   </label>
 
   <button class="discard-btn" id="discard-go" disabled>
-    Discard
+    <span data-i18n="button_label"></span>
   </button>
 </details>
 
 <script>
 (function() {
+  // --- Locale + i18n payload (substituted at dataset creation time) ---
+  // Shape:
+  //   I18N = {
+  //     "en": {
+  //       "panel_summary": "...", "panel_help": "...",
+  //       "reason_label": "...", "reason_placeholder": "...",
+  //       "notes_label": "...", "notes_placeholder": "...",
+  //       "button_label": "...",
+  //       "discard_reason_title": "Discard reason",     // for aria-label probe
+  //       "discard_notes_title":  "Discard notes (optional)",
+  //       "reason_options": [{value, text}, ...]
+  //     },
+  //     "de": { ... },
+  //     ...
+  //   }
+  // SUPPORTED_LOCALES is the list of keys above, ordered with the
+  // dataset's creation locale first (so aria-label probing prefers it).
+  var I18N = @@I18N_JSON;
+  var SUPPORTED_LOCALES = @@SUPPORTED_LOCALES_JSON;
+  var DEFAULT_LOCALE = @@DEFAULT_LOCALE_JSON;
+
   var pdoc = window.parent.document;
-  // Argilla-internal selectors — will need to re-verify on Argilla upgrade.
-  var CARD_TITLE_SEL = '.title-area';
-  var CARD_SEL = '.wrapper';
   var NATIVE_DISCARD_SEL = '.button--discard';
-  var REASON_TITLE = 'Discard reason';
-  var NOTES_TITLE = 'Discard notes (optional)';
-  var HIDDEN_TITLES = [REASON_TITLE, NOTES_TITLE];
   // Delay after writing hidden question values before firing native discard,
   // so Vue has a tick to register the input/change events.
   var DISCARD_SUBMIT_DELAY_MS = 80;
@@ -79,26 +85,85 @@
     pdoc.head.appendChild(s);
   }
 
-  function cardFor(title) {
-    var areas = pdoc.querySelectorAll(CARD_TITLE_SEL);
-    for (var i = 0; i < areas.length; i++) {
-      if ((areas[i].innerText || '').trim() === title) return areas[i].closest(CARD_SEL);
+  // --- Active locale detection --------------------------------------
+  // Order of preference:
+  //   1. window.parent.$nuxt.$i18n.locale  (Argilla's nuxt-i18n state)
+  //   2. <html lang> attribute on the parent page
+  //   3. DEFAULT_LOCALE (the dataset's creation locale)
+  function currentLocale() {
+    try {
+      var nuxtLocale = window.parent.$nuxt && window.parent.$nuxt.$i18n && window.parent.$nuxt.$i18n.locale;
+      if (nuxtLocale && I18N[nuxtLocale]) return nuxtLocale;
+    } catch (e) {}
+    try {
+      var htmlLang = (pdoc.documentElement.getAttribute('lang') || '').toLowerCase().split('-')[0];
+      if (htmlLang && I18N[htmlLang]) return htmlLang;
+    } catch (e) {}
+    return DEFAULT_LOCALE;
+  }
+
+  function strings() { return I18N[currentLocale()] || I18N[DEFAULT_LOCALE]; }
+
+  // --- Render ------------------------------------------------------
+  function applyText() {
+    var s = strings();
+    var nodes = document.querySelectorAll('[data-i18n]');
+    for (var i = 0; i < nodes.length; i++) {
+      var key = nodes[i].getAttribute('data-i18n');
+      if (s[key] != null) nodes[i].textContent = s[key];
+    }
+
+    var sel = document.getElementById('reason');
+    var prev = sel.value;
+    sel.innerHTML = '';
+    var placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = s.reason_placeholder;
+    sel.appendChild(placeholder);
+    for (var j = 0; j < s.reason_options.length; j++) {
+      var opt = document.createElement('option');
+      opt.value = s.reason_options[j].value;
+      opt.textContent = s.reason_options[j].text;
+      sel.appendChild(opt);
+    }
+    if (prev) sel.value = prev;
+
+    document.getElementById('discard-notes').setAttribute('placeholder', s.notes_placeholder);
+  }
+
+  // --- Argilla card discovery (aria-label probing) -----------------
+  // Find a hidden helper question's card by trying every supported
+  // locale's title for it. This works even when the user has toggled
+  // Argilla's chrome to a different language than the dataset was
+  // created in — Argilla stamps the aria-label from the title stored
+  // on the dataset, which is fixed at creation.
+  function cardByQuestion(questionTitleKey) {
+    for (var i = 0; i < SUPPORTED_LOCALES.length; i++) {
+      var title = (I18N[SUPPORTED_LOCALES[i]] || {})[questionTitleKey];
+      if (!title) continue;
+      var titleArea = pdoc.querySelector('[aria-label="' + title.replace(/"/g, '\\"') + '"]');
+      if (titleArea) {
+        var card = titleArea.closest('.wrapper');
+        if (card) return card;
+      }
     }
     return null;
   }
 
   function hideStaleQuestions() {
-    HIDDEN_TITLES.forEach(function(title) {
-      var card = cardFor(title);
+    var keys = ['discard_reason_title', 'discard_notes_title'];
+    for (var i = 0; i < keys.length; i++) {
+      var card = cardByQuestion(keys[i]);
       if (card && card.style.display !== 'none') card.style.display = 'none';
-    });
+    }
   }
 
+  // --- Sizing -----------------------------------------------------
   function resizeSelf() {
     try {
       var frame = window.frameElement;
       if (!frame) return;
-      // scrollHeight is clamped to >=  iframe viewport, so shrink to
+      // scrollHeight is clamped to >= iframe viewport, so shrink to
       // 0 first then remeasure — otherwise the iframe grows but can't
       // shrink back on collapse.
       frame.style.height = '0px';
@@ -121,6 +186,7 @@
     } catch (e) {}
   }
 
+  // --- Wire up -----------------------------------------------------
   var panel = document.getElementById('panel');
   var reasonSel = document.getElementById('reason');
   var notesTa = document.getElementById('discard-notes');
@@ -136,8 +202,8 @@
     var notes = notesTa.value;
     if (!reason) return;
 
-    var reasonCard = cardFor(REASON_TITLE);
-    var notesCard = cardFor(NOTES_TITLE);
+    var reasonCard = cardByQuestion('discard_reason_title');
+    var notesCard = cardByQuestion('discard_notes_title');
     if (reasonCard) reasonCard.style.display = '';
     if (notesCard) notesCard.style.display = '';
 
@@ -174,6 +240,7 @@
   });
 
   function applyHiding() { hideStaleQuestions(); hideFieldTitle(); }
+  function rerender() { applyText(); resizeSelf(); }
 
   // Coalesce mutation bursts to one apply per paint frame — Argilla's Vue
   // app fires many mutations per render, and applyHiding is now idempotent.
@@ -184,7 +251,15 @@
     requestAnimationFrame(function () { pendingApply = false; applyHiding(); });
   }
 
-  resizeSelf();
+  // Live-react to Argilla's chrome locale toggle.
+  try {
+    var i18n = window.parent.$nuxt && window.parent.$nuxt.$i18n;
+    if (i18n && typeof i18n.onLanguageSwitched === 'function') {
+      i18n.onLanguageSwitched(rerender);
+    }
+  } catch (e) {}
+
+  rerender();
   applyHiding();
   try {
     new MutationObserver(scheduleApply).observe(pdoc.body, { childList: true, subtree: true });

--- a/src/pragmata/core/annotation/locales/en.yaml
+++ b/src/pragmata/core/annotation/locales/en.yaml
@@ -24,36 +24,37 @@ fields:
 questions:
   retrieval:
     topically_relevant: >-
-      Does this passage contain information that is substantively relevant to
+      Does this chunk contain information that is substantively relevant to
       the query?
     evidence_sufficient: >-
-      Does this passage provide sufficient evidence to support answering the
+      Does this chunk provide sufficient evidence to support answering the
       query?
     misleading: >-
-      Could this passage plausibly lead to an incorrect or distorted answer?
+      Could this chunk plausibly lead to an incorrect or distorted answer?
     notes: Notes (optional)
     discard_reason: Discard reason
     discard_notes: Discard notes (optional)
   grounding:
     support_present: >-
-      Is at least one claim in the answer supported by the provided context?
+      Is at least one claim in the answer supported by the context set?
     unsupported_claim_present: >-
-      Does the answer contain claims not supported by the provided context?
+      Does the answer contain claims not supported by the context set?
     contradicted_claim_present: >-
-      Does the provided context contradict any claim in the answer?
+      Does the context set contradict any claim in the answer?
     source_cited: Does the answer contain a citation marker?
     fabricated_source: >-
-      Does the answer cite a source not present in the retrieved context?
+      Does the answer cite a source not present in the context set?
     notes: Notes (optional)
     discard_reason: Discard reason
     discard_notes: Discard notes (optional)
   generation:
-    proper_action: Did the system choose the appropriate action for this query?
-    response_on_topic: Does the response substantively address the user's query?
+    proper_action: >-
+      Does the answer reflect the appropriate response type for the query?
+    response_on_topic: Does the answer substantively address the user's query?
     helpful: >-
-      Would this response enable a typical user to make progress on their task?
-    incomplete: Does the response fail to cover required parts of the query?
-    unsafe_content: Does the response contain unsafe or policy-violating content?
+      Does this answer enable a typical user to make progress on their task?
+    incomplete: Does the answer fail to cover required parts of the query?
+    unsafe_content: Does the answer contain unsafe or harmful content?
     notes: Notes (optional)
     discard_reason: Discard reason
     discard_notes: Discard notes (optional)

--- a/src/pragmata/core/annotation/locales/en.yaml
+++ b/src/pragmata/core/annotation/locales/en.yaml
@@ -24,37 +24,36 @@ fields:
 questions:
   retrieval:
     topically_relevant: >-
-      Does this chunk contain information that is substantively relevant to
+      Does this passage contain information that is substantively relevant to
       the query?
     evidence_sufficient: >-
-      Does this chunk provide sufficient evidence to support answering the
+      Does this passage provide sufficient evidence to support answering the
       query?
     misleading: >-
-      Could this chunk plausibly lead to an incorrect or distorted answer?
+      Could this passage plausibly lead to an incorrect or distorted answer?
     notes: Notes (optional)
     discard_reason: Discard reason
     discard_notes: Discard notes (optional)
   grounding:
     support_present: >-
-      Is at least one claim in the answer supported by the context set?
+      Is at least one claim in the answer supported by the provided context?
     unsupported_claim_present: >-
-      Does the answer contain claims not supported by the context set?
+      Does the answer contain claims not supported by the provided context?
     contradicted_claim_present: >-
-      Does the context set contradict any claim in the answer?
+      Does the provided context contradict any claim in the answer?
     source_cited: Does the answer contain a citation marker?
     fabricated_source: >-
-      Does the answer cite a source not present in the context set?
+      Does the answer cite a source not present in the retrieved context?
     notes: Notes (optional)
     discard_reason: Discard reason
     discard_notes: Discard notes (optional)
   generation:
-    proper_action: >-
-      Does the answer reflect the appropriate response type for the query?
-    response_on_topic: Does the answer substantively address the user's query?
+    proper_action: Did the system choose the appropriate action for this query?
+    response_on_topic: Does the response substantively address the user's query?
     helpful: >-
-      Does this answer enable a typical user to make progress on their task?
-    incomplete: Does the answer fail to cover required parts of the query?
-    unsafe_content: Does the answer contain unsafe or harmful content?
+      Would this response enable a typical user to make progress on their task?
+    incomplete: Does the response fail to cover required parts of the query?
+    unsafe_content: Does the response contain unsafe or policy-violating content?
     notes: Notes (optional)
     discard_reason: Discard reason
     discard_notes: Discard notes (optional)
@@ -71,3 +70,14 @@ labels:
     invalid_or_unrealistic: Invalid or unrealistic record
     unclear: Unclear query/context/answer relationship
     outside_reviewer_expertise: Outside reviewer expertise
+
+widget:
+  panel_summary: Discard this record
+  panel_help: >-
+    Use this if the record is unsuitable for annotation (e.g. invalid,
+    unclear, or outside your expertise).
+  reason_label: "Reason:"
+  reason_placeholder: "— select —"
+  notes_label: "Optional notes:"
+  notes_placeholder: Any extra context (optional)
+  button_label: Discard

--- a/src/pragmata/core/annotation/locales/loader.py
+++ b/src/pragmata/core/annotation/locales/loader.py
@@ -40,9 +40,11 @@ DISCARD_WIDGET_KEYS: tuple[str, ...] = (
 def load_catalog(path: Path) -> Catalog:
     """Build a Catalog from a YAML translation file.
 
-    Raises ``KeyError`` if a required top-level section, task, field, question,
-    or label value is missing — fail-loud is intentional so a typo in a locale
-    file surfaces at import time, not at first widget render.
+    Fails loud on any malformed locale file: ``KeyError`` for missing
+    keys, ``ValueError`` for unknown task or discard-reason values, plus
+    any error raised by the underlying YAML parser. This is intentional
+    so a typo in a locale file surfaces at import time rather than at
+    first widget render.
     """
     data = load_config_file(path)
     catalog: Catalog = {}

--- a/src/pragmata/core/annotation/locales/loader.py
+++ b/src/pragmata/core/annotation/locales/loader.py
@@ -26,15 +26,23 @@ _YES_NO_QUESTIONS_BY_TASK: dict[Task, list[str]] = {
     Task.GENERATION: ["proper_action", "response_on_topic", "helpful", "incomplete", "unsafe_content"],
 }
 
+DISCARD_WIDGET_KEYS: tuple[str, ...] = (
+    "panel_summary",
+    "panel_help",
+    "reason_label",
+    "reason_placeholder",
+    "notes_label",
+    "notes_placeholder",
+    "button_label",
+)
+
 
 def load_catalog(path: Path) -> Catalog:
     """Build a Catalog from a YAML translation file.
 
-    Fails loud on any malformed locale file: ``KeyError`` for missing
-    keys, ``ValueError`` for unknown task or discard-reason values, plus
-    any error raised by the underlying YAML parser. This is intentional
-    so a typo in a locale file surfaces at import time rather than at
-    first widget render.
+    Raises ``KeyError`` if a required top-level section, task, field, question,
+    or label value is missing — fail-loud is intentional so a typo in a locale
+    file surfaces at import time, not at first widget render.
     """
     data = load_config_file(path)
     catalog: Catalog = {}
@@ -51,11 +59,14 @@ def load_catalog(path: Path) -> Catalog:
     labels = data["labels"]
     yes_display, no_display = labels["yes_display"], labels["no_display"]
     discard_reasons: dict[str, str] = labels["discard_reasons"]
+    widget: dict[str, str] = data["widget"]
     for task, question_names in _YES_NO_QUESTIONS_BY_TASK.items():
         for question in question_names:
             catalog[(task, "label", f"{question}.yes")] = yes_display
             catalog[(task, "label", f"{question}.no")] = no_display
         for reason in DiscardReason:
             catalog[(task, "label", f"discard_reason.{reason.value}")] = discard_reasons[reason.value]
+        for key in DISCARD_WIDGET_KEYS:
+            catalog[(task, "widget", f"discard.{key}")] = widget[key]
 
     return catalog

--- a/tests/unit/core/annotation/test_argilla_task_definitions.py
+++ b/tests/unit/core/annotation/test_argilla_task_definitions.py
@@ -229,45 +229,23 @@ class TestDatasetNames:
         assert DATASET_NAMES[Task.GENERATION] == "generation"
 
 
-class TestDiscardFlowHtmlEnumSync:
-    """Guard against drift between DiscardReason enum and discard_flow.html options."""
+class TestDiscardFlowI18nPayload:
+    """Guard against drift between DiscardReason enum and the discard widget payload.
 
-    def test_html_option_values_match_enum(self):
-        import re
-        from importlib.resources import files
-
-        html = files("pragmata.core.annotation").joinpath("discard_flow.html").read_text(encoding="utf-8")
-        option_values = set(re.findall(r'<option value="([^"]+)"', html))
-        option_values.discard("")  # ignore placeholder "-- select --" option
-        assert option_values == {r.value for r in DiscardReason}
-
-
-class TestYesNoCatalogSync:
-    """Guard the yes/no question set against drift between the two encodings.
-
-    The set lives in two places: ``rg.LabelQuestion`` definitions in
-    ``argilla_task_definitions`` and ``_YES_NO_QUESTIONS_BY_TASK`` in
-    ``loader.py`` (which drives ``.yes`` / ``.no`` catalog keys). Both sides
-    must enumerate the same yes/no question set per task; otherwise label
-    lookup silently breaks at dataset creation.
+    Option values are now injected via the i18n JSON baked into the rendered
+    ``discard_flow.html`` template at build time, not hardcoded in the HTML.
     """
 
-    @pytest.mark.parametrize(
-        ("task", "settings"),
-        [
-            (Task.RETRIEVAL, _RETRIEVAL),
-            (Task.GROUNDING, _GROUNDING),
-            (Task.GENERATION, _GENERATION),
-        ],
-        ids=["retrieval", "grounding", "generation"],
-    )
-    def test_yes_no_questions_match_loader_map(self, task, settings):
-        from pragmata.core.annotation.locales.loader import _YES_NO_QUESTIONS_BY_TASK
-
-        yes_no_question_names = {
-            q.name for q in settings.questions if isinstance(q, rg.LabelQuestion) and set(q.labels) == {"yes", "no"}
-        }
-        assert yes_no_question_names == set(_YES_NO_QUESTIONS_BY_TASK[task])
+    def test_rendered_template_contains_all_enum_values(self):
+        # Option values are injected via the i18n JSON payload at build time,
+        # not hardcoded in the HTML. Assert each DiscardReason.value appears
+        # in the rendered output of the discard CustomField.
+        discard_field = next(f for f in _RETRIEVAL.fields if f.name == "discard_flow")
+        rendered = discard_field.template
+        for reason in DiscardReason:
+            assert f'"value": "{reason.value}"' in rendered, (
+                f"DiscardReason.{reason.name} value {reason.value!r} missing from rendered widget"
+            )
 
 
 class TestCatalogDrivesRenderedOutput:
@@ -284,8 +262,13 @@ class TestCatalogDrivesRenderedOutput:
         stub = dict(CATALOGS["en"])
         stub[(Task.RETRIEVAL, "field", "query")] = sentinel
         monkeypatch.setitem(CATALOGS, "en", stub)
-
-        rendered = build_task_settings("en")[Task.RETRIEVAL]
-        query_field = _get_field(rendered, "query")
-        assert query_field is not None
-        assert query_field.title == sentinel
+        # build_task_settings is @functools.cache'd; clear so the swap takes effect
+        # and again on the way out so later tests see the unmodified catalog.
+        build_task_settings.cache_clear()
+        try:
+            rendered = build_task_settings("en")[Task.RETRIEVAL]
+            query_field = _get_field(rendered, "query")
+            assert query_field is not None
+            assert query_field.title == sentinel
+        finally:
+            build_task_settings.cache_clear()

--- a/tests/unit/core/annotation/test_argilla_task_definitions.py
+++ b/tests/unit/core/annotation/test_argilla_task_definitions.py
@@ -248,6 +248,34 @@ class TestDiscardFlowI18nPayload:
             )
 
 
+class TestYesNoCatalogSync:
+    """Guard the yes/no question set against drift between the two encodings.
+
+    The set lives in two places: ``rg.LabelQuestion`` definitions in
+    ``argilla_task_definitions`` and ``_YES_NO_QUESTIONS_BY_TASK`` in
+    ``loader.py`` (which drives ``.yes`` / ``.no`` catalog keys). Both sides
+    must enumerate the same yes/no question set per task; otherwise label
+    lookup silently breaks at dataset creation.
+    """
+
+    @pytest.mark.parametrize(
+        ("task", "settings"),
+        [
+            (Task.RETRIEVAL, _RETRIEVAL),
+            (Task.GROUNDING, _GROUNDING),
+            (Task.GENERATION, _GENERATION),
+        ],
+        ids=["retrieval", "grounding", "generation"],
+    )
+    def test_yes_no_questions_match_loader_map(self, task, settings):
+        from pragmata.core.annotation.locales.loader import _YES_NO_QUESTIONS_BY_TASK
+
+        yes_no_question_names = {
+            q.name for q in settings.questions if isinstance(q, rg.LabelQuestion) and set(q.labels) == {"yes", "no"}
+        }
+        assert yes_no_question_names == set(_YES_NO_QUESTIONS_BY_TASK[task])
+
+
 class TestCatalogDrivesRenderedOutput:
     """The catalog is the source of truth for user-visible strings.
 


### PR DESCRIPTION
**Stack (6 PRs):** #206 > #196 > #207 > #219 > #208 > #209

**Chain goal:** Adds locale-aware Argilla datasets (EN/DE) on top of a deployment/workspace/task settings inheritance hierarchy, with live widget locale switching and CLI flags for per-import overrides.

**This PR (3/6):** Discard widget i18n - template machinery + EN widget chrome strings so the widget renders a locale-aware JSON payload at dataset-creation time and switches at runtime via Argilla's chrome-locale toggle.

---

## Scope

- `discard_flow.html`: i18n JSON payload + supported-locales array injected at render time using `string.Template` with `@@` delimiter (avoids `$nuxt` / `$i18n` collisions in the JS body); JS picks active locale via `window.parent.$nuxt.$i18n.onLanguageSwitched` with a chrome > `<html lang>` > dataset-creation > EN fallback chain.
- `_render_discard_template` / `_discard_i18n_payload_for_locale` in `argilla_task_definitions.py` do the substitution per `(task, dataset_locale)`. Widget payload assembly uses a comprehension over `DISCARD_WIDGET_KEYS` for the chrome strings. `_DiscardTemplate` docstring spells out the `@@`-delimiter rationale and warns future contributors not to introduce `@@` tokens in the JS body unless they are intended as substitution placeholders.
- `locales/en.yaml`: adds widget chrome strings (panel summary, button label, etc.) under a `widget` kind, keyed for fan-out into per-task widget payloads.
- `locales/loader.py`: widget-key helper supporting payload assembly.
- The existing HTML-option enum-sync test is rewritten against the rendered i18n payload (`TestDiscardFlowI18nPayload`).

## Stable across locales (exports depend on this)

- Field and question `name=` identifiers
- Label values: `yes`, `no`, `DiscardReason.*.value`

## Test plan

- [x] `uv run python -m pytest tests/unit` (724 passed)
- [x] `uv run mypy src/pragmata` clean
- [x] `uv run ruff check src/pragmata tests` clean
- [x] `uv run ruff format --check src/pragmata tests` clean
- [x] `tests/unit/core/annotation/test_argilla_task_definitions.py::TestDiscardFlowI18nPayload`: rendered widget contains every `DiscardReason` value
- [x] Manual: chrome locale toggle in Argilla flips widget strings live; non-widget strings remain frozen at dataset creation
