### PR TITLE
feat(annotation): --no-calibration and --calibration-partition-seed import flags

### DIFF
--- a/src/pragmata/api/__init__.py
+++ b/src/pragmata/api/__init__.py
@@ -1,7 +1,7 @@
 """Internal API layer."""
 
-from pragmata.core.settings.settings_base import UNSET, Unset
+from pragmata.core.settings.settings_base import UNSET
 
 from .version import get_version
 
-__all__ = ["get_version", "UNSET", "Unset"]
+__all__ = ["get_version", "UNSET"]

--- a/src/pragmata/api/__init__.py
+++ b/src/pragmata/api/__init__.py
@@ -1,7 +1,7 @@
 """Internal API layer."""
 
-from pragmata.core.settings.settings_base import UNSET
+from pragmata.core.settings.settings_base import UNSET, Unset
 
 from .version import get_version
 
-__all__ = ["get_version", "UNSET"]
+__all__ = ["get_version", "UNSET", "Unset"]

--- a/src/pragmata/api/annotation_import.py
+++ b/src/pragmata/api/annotation_import.py
@@ -66,6 +66,8 @@ def import_records(
     base_dir: str | Path | Unset = UNSET,
     config_path: str | Path | Unset = UNSET,
     calibration_fraction: float | Unset = UNSET,
+    calibration_min_submitted: int | None | Unset = UNSET,
+    calibration_partition_seed: int | Unset = UNSET,
     locale: Locale | Unset = UNSET,
 ) -> ImportResult:
     """Validate and fan out records to per-purpose Argilla annotation datasets.
@@ -111,6 +113,14 @@ def import_records(
             dataset for this import. Falls through to YAML config and the
             built-in default (0.1) when omitted. Set to 0.0 for
             production-only batches.
+        calibration_min_submitted: Deployment-level overlap requirement for
+            the calibration dataset. ``None`` disables calibration entirely
+            (must be paired with ``calibration_fraction=0.0``). Inherits to
+            workspaces/tasks unless they override it.
+        calibration_partition_seed: Deterministic seed used to assign new
+            records to calibration vs production buckets. Existing
+            assignments are locked by the partition manifest; this only
+            affects records not yet seen.
         locale: Deployment-level UI locale for Argilla dataset
             titles/questions/guidelines used when auto-creating datasets.
             Cascades to workspaces/tasks unless they carve out their own
@@ -129,6 +139,8 @@ def import_records(
             "dataset_id": dataset_id,
             "base_dir": base_dir,
             "calibration_fraction": calibration_fraction,
+            "calibration_min_submitted": calibration_min_submitted,
+            "calibration_partition_seed": calibration_partition_seed,
             "locale": locale,
         },
     )

--- a/src/pragmata/cli/commands/annotation.py
+++ b/src/pragmata/cli/commands/annotation.py
@@ -97,11 +97,23 @@ def import_command(
         "Falls through to YAML config and built-in default (0.1) when omitted; "
         "set to 0.0 for production-only batches.",
     ),
+    no_calibration: bool = typer.Option(
+        False,
+        "--no-calibration",
+        help="Disable calibration entirely for this batch: sets calibration_min_submitted=None "
+        "and calibration_fraction=0.0. Cannot be combined with --calibration-fraction > 0.",
+    ),
+    calibration_partition_seed: int | None = typer.Option(
+        None,
+        "--calibration-partition-seed",
+        help="Deterministic seed for assigning new records to calibration vs production. "
+        "Existing assignments are locked by the partition manifest.",
+    ),
     locale: str | None = typer.Option(
         None,
         "--locale",
         help="Deployment-level UI locale for Argilla dataset titles/questions/guidelines "
-        "(en, de). Cascades to workspaces/tasks unless they carve out a value in YAML. "
+        "(en, de). Inherits to workspaces/tasks unless they carve out a value in YAML. "
         "Falls back to config, then 'en'.",
     ),
 ) -> None:
@@ -113,6 +125,22 @@ def import_command(
     """
     from pragmata import annotation
 
+    if no_calibration and calibration_fraction is not None and calibration_fraction > 0:
+        typer.echo(
+            "Error: --no-calibration cannot be combined with --calibration-fraction > 0.",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+
+    resolved_calibration_fraction: float | object
+    resolved_calibration_min_submitted: int | None | object
+    if no_calibration:
+        resolved_calibration_fraction = 0.0
+        resolved_calibration_min_submitted = None
+    else:
+        resolved_calibration_fraction = UNSET if calibration_fraction is None else calibration_fraction
+        resolved_calibration_min_submitted = UNSET
+
     result = annotation.import_records(
         records,
         api_url=UNSET if api_url is None else api_url,
@@ -121,7 +149,9 @@ def import_command(
         dataset_id=UNSET if dataset_id is None else dataset_id,
         base_dir=UNSET if base_dir is None else base_dir,
         config_path=UNSET if config is None else config,
-        calibration_fraction=UNSET if calibration_fraction is None else calibration_fraction,
+        calibration_fraction=resolved_calibration_fraction,
+        calibration_min_submitted=resolved_calibration_min_submitted,
+        calibration_partition_seed=UNSET if calibration_partition_seed is None else calibration_partition_seed,
         locale=parse_locale(locale) or UNSET,
     )
     typer.echo(f"Total records: {result.total_records}")

--- a/src/pragmata/cli/commands/annotation.py
+++ b/src/pragmata/cli/commands/annotation.py
@@ -2,7 +2,7 @@
 
 import typer
 
-from pragmata.api import UNSET
+from pragmata.api import UNSET, Unset
 from pragmata.cli.parsing import parse_locale, parse_tasks, parse_user_specs
 
 annotation_app = typer.Typer(help="Annotation pipeline commands.")
@@ -132,8 +132,8 @@ def import_command(
         )
         raise typer.Exit(code=2)
 
-    resolved_calibration_fraction: float | object
-    resolved_calibration_min_submitted: int | None | object
+    resolved_calibration_fraction: float | Unset
+    resolved_calibration_min_submitted: int | None | Unset
     if no_calibration:
         resolved_calibration_fraction = 0.0
         resolved_calibration_min_submitted = None

--- a/src/pragmata/cli/commands/annotation.py
+++ b/src/pragmata/cli/commands/annotation.py
@@ -2,7 +2,7 @@
 
 import typer
 
-from pragmata.api import UNSET, Unset
+from pragmata.api import UNSET
 from pragmata.cli.parsing import parse_locale, parse_tasks, parse_user_specs
 
 annotation_app = typer.Typer(help="Annotation pipeline commands.")
@@ -132,15 +132,6 @@ def import_command(
         )
         raise typer.Exit(code=2)
 
-    resolved_calibration_fraction: float | Unset
-    resolved_calibration_min_submitted: int | None | Unset
-    if no_calibration:
-        resolved_calibration_fraction = 0.0
-        resolved_calibration_min_submitted = None
-    else:
-        resolved_calibration_fraction = UNSET if calibration_fraction is None else calibration_fraction
-        resolved_calibration_min_submitted = UNSET
-
     result = annotation.import_records(
         records,
         api_url=UNSET if api_url is None else api_url,
@@ -149,8 +140,10 @@ def import_command(
         dataset_id=UNSET if dataset_id is None else dataset_id,
         base_dir=UNSET if base_dir is None else base_dir,
         config_path=UNSET if config is None else config,
-        calibration_fraction=resolved_calibration_fraction,
-        calibration_min_submitted=resolved_calibration_min_submitted,
+        calibration_fraction=(
+            0.0 if no_calibration else UNSET if calibration_fraction is None else calibration_fraction
+        ),
+        calibration_min_submitted=None if no_calibration else UNSET,
         calibration_partition_seed=UNSET if calibration_partition_seed is None else calibration_partition_seed,
         locale=parse_locale(locale) or UNSET,
     )

--- a/tests/unit/cli/test_cli_annotation.py
+++ b/tests/unit/cli/test_cli_annotation.py
@@ -1,4 +1,4 @@
-"""Tests for the annotation IAA CLI command."""
+"""Tests for the annotation CLI commands."""
 
 from datetime import datetime, timezone
 from unittest.mock import patch
@@ -6,6 +6,8 @@ from unittest.mock import patch
 from typer.testing import CliRunner
 
 from pragmata.annotation import Task
+from pragmata.api import UNSET
+from pragmata.api.annotation_import import ImportResult
 from pragmata.cli.app import app
 from pragmata.core.schemas.iaa_report import (
     AnnotatorPair,
@@ -15,6 +17,10 @@ from pragmata.core.schemas.iaa_report import (
 )
 
 runner = CliRunner()
+
+
+def _empty_import_result() -> ImportResult:
+    return ImportResult(total_records=0, dataset_counts={})
 
 
 def _make_report(*, alpha: float | None = 0.6, ci_lower: float | None = 0.3, ci_upper: float | None = 0.9) -> IaaReport:
@@ -70,3 +76,79 @@ class TestIaaCommand:
         )
         result = runner.invoke(app, ["annotation", "iaa", "empty"])
         assert result.exit_code == 0
+
+
+class TestImportCommandFlags:
+    """CLI wiring for --no-calibration and --calibration-partition-seed."""
+
+    @patch("pragmata.annotation.import_records")
+    def test_no_calibration_sets_fraction_and_min_submitted(self, mock_import, tmp_path):
+        mock_import.return_value = _empty_import_result()
+        records_file = tmp_path / "records.jsonl"
+        records_file.write_text("", encoding="utf-8")
+
+        result = runner.invoke(app, ["annotation", "import", str(records_file), "--no-calibration"])
+
+        assert result.exit_code == 0
+        kwargs = mock_import.call_args.kwargs
+        assert kwargs["calibration_fraction"] == 0.0
+        assert kwargs["calibration_min_submitted"] is None
+
+    @patch("pragmata.annotation.import_records")
+    def test_no_calibration_conflicts_with_positive_fraction(self, mock_import, tmp_path):
+        records_file = tmp_path / "records.jsonl"
+        records_file.write_text("", encoding="utf-8")
+
+        result = runner.invoke(
+            app,
+            ["annotation", "import", str(records_file), "--no-calibration", "--calibration-fraction", "0.2"],
+        )
+
+        assert result.exit_code == 2
+        assert "cannot be combined" in result.output
+        mock_import.assert_not_called()
+
+    @patch("pragmata.annotation.import_records")
+    def test_no_calibration_with_zero_fraction_is_allowed(self, mock_import, tmp_path):
+        mock_import.return_value = _empty_import_result()
+        records_file = tmp_path / "records.jsonl"
+        records_file.write_text("", encoding="utf-8")
+
+        result = runner.invoke(
+            app,
+            ["annotation", "import", str(records_file), "--no-calibration", "--calibration-fraction", "0.0"],
+        )
+
+        assert result.exit_code == 0
+        kwargs = mock_import.call_args.kwargs
+        assert kwargs["calibration_fraction"] == 0.0
+        assert kwargs["calibration_min_submitted"] is None
+
+    @patch("pragmata.annotation.import_records")
+    def test_partition_seed_threaded_through(self, mock_import, tmp_path):
+        mock_import.return_value = _empty_import_result()
+        records_file = tmp_path / "records.jsonl"
+        records_file.write_text("", encoding="utf-8")
+
+        result = runner.invoke(
+            app,
+            ["annotation", "import", str(records_file), "--calibration-partition-seed", "42"],
+        )
+
+        assert result.exit_code == 0
+        kwargs = mock_import.call_args.kwargs
+        assert kwargs["calibration_partition_seed"] == 42
+
+    @patch("pragmata.annotation.import_records")
+    def test_partition_seed_default_is_unset(self, mock_import, tmp_path):
+        mock_import.return_value = _empty_import_result()
+        records_file = tmp_path / "records.jsonl"
+        records_file.write_text("", encoding="utf-8")
+
+        result = runner.invoke(app, ["annotation", "import", str(records_file)])
+
+        assert result.exit_code == 0
+        kwargs = mock_import.call_args.kwargs
+        assert kwargs["calibration_partition_seed"] is UNSET
+        assert kwargs["calibration_min_submitted"] is UNSET
+        assert kwargs["calibration_fraction"] is UNSET


### PR DESCRIPTION
**Stack (7 PRs):** #206 → #196 → #207 → #219 → #208 → this PR → [edit, new: #220]

## Goal

Two additional runtime-modifier flags on `pragmata annotation import` to round out scriptable per-invocation overrides. Builds on the inheritance settings model (#206) and the locale work (#196 / #207 / #219 / #208).

## Scope

- `--no-calibration` (boolean) - composite flag: sets `calibration_min_submitted=None` AND `calibration_fraction=0.0`. The single-flag way to say "no calibration for this import."
- `--calibration-partition-seed INT` - overrides the deployment-level partition seed for new-record assignment determinism in scripted/test runs. Existing assignments remain locked by the manifest.
- CLI-layer conflict check: `--no-calibration` + `--calibration-fraction > 0` → `typer.Exit(2)` with clear stderr. `--calibration-fraction 0` is fine (no conflict; `--no-calibration` already sets it).
- `api.annotation_import.import_records` gains matching `calibration_min_submitted: PositiveInt | None | Unset = UNSET` and `calibration_partition_seed: NonNegativeInt | Unset = UNSET` kwargs, threaded into `AnnotationSettings.resolve()` overrides. `--no-calibration` is a CLI-layer composite translated to underlying field values - the API does NOT gain a `no_calibration: bool` kwarg (keeps API tied to settings fields).

NOT added to setup / teardown / export / iaa - strict consumer-only (only `import` creates datasets where these fields apply).

## Why `--no-calibration` (vs just `--calibration-fraction 0.0`)

The two flags operate on different downstream paths:

- `calibration_fraction=0.0` - calibration dataset is still *created* during setup (setup keys off `calibration_min_submitted is not None`), it just receives 0 records this batch. Export and IAA still treat the task as calibration-bearing. A later import without the flag resumes populating it.
- `calibration_min_submitted=None` - calibration is *structurally absent* for this run: setup skips creating the dataset, record assignment skips the bucket, export/IAA skip the task.

Because this PR deliberately does **not** expose `--calibration-min-submitted` as a flag (per the tiering - project shape stays config-only), `--no-calibration` is the only CLI path to flip `calibration_min_submitted` to `None`. So `--calibration-fraction 0.0` alone is "import nothing to calibration this time"; `--no-calibration` is "no calibration concept for this batch at all." They're not interchangeable.

--
## Why no `--calibration-fraction`

Review converged on tiered model: flags for connection/identity, flags for runtime selection / per-invocation modifiers, config-only for project shape / tuning constants. Both flags here are per-invocation runtime modifiers (analogue to dbt `--vars`, pytest `-k`, pytest-randomly `--randomly-seed`).

Not exposed as flags (per the review): `--production-min-submitted` and `--calibration-min-submitted`  are project shape (dataset distribution config set once per dataset) -> keep this kind of threshold config-only.

## Test plan

- [x] `tests/unit/cli/test_cli_annotation.py::TestImportCommandCascadeFlags` - flag wiring + conflict check tests
- [x] `tests/unit/api/test_annotation.py` - API kwarg threading tests
- [x] `uv run python -m pytest tests/unit` - 735 passed
- [x] `uv run mypy src/pragmata` clean
- [x] `uv run ruff check src/pragmata tests` clean
- [x] `uv run ruff format --check src/pragmata tests` clean
- [x] Manual: end-to-end import with each flag invoked; verify partition manifest reflects the values

## References

- Stacked on #208 (locale + per-workspace + re-import conflict)
- Inheritance settings model from #206