### PR TITLE
feat(annotation): constraint severity in AnnotationSettings

### DIFF
--- a/src/pragmata/core/annotation/logical_constraints.py
+++ b/src/pragmata/core/annotation/logical_constraints.py
@@ -85,6 +85,24 @@ LOGICAL_CONSTRAINTS: dict[Task, list[LogicalConstraint]] = {
     Task.GENERATION: [],
 }
 
-# By-id lookup over the flattened catalogue, used by the settings layer to
-# validate that override maps reference known constraint_ids.
-CONSTRAINT_BY_ID: dict[str, LogicalConstraint] = {c.constraint_id: c for cs in LOGICAL_CONSTRAINTS.values() for c in cs}
+
+def _build_constraint_by_id(
+    catalogue: dict[Task, list[LogicalConstraint]] = LOGICAL_CONSTRAINTS,
+) -> dict[str, LogicalConstraint]:
+    """By-id lookup over the flattened catalogue.
+
+    Used by the settings layer to validate that override maps reference known
+    constraint_ids. Raises eagerly on a duplicate constraint_id rather than
+    silently letting the last one win, which would otherwise hide the earlier
+    constraint from validation and export checks.
+    """
+    by_id: dict[str, LogicalConstraint] = {}
+    for constraints in catalogue.values():
+        for constraint in constraints:
+            if constraint.constraint_id in by_id:
+                raise ValueError(f"duplicate constraint_id {constraint.constraint_id!r} in constraint catalogue")
+            by_id[constraint.constraint_id] = constraint
+    return by_id
+
+
+CONSTRAINT_BY_ID: dict[str, LogicalConstraint] = _build_constraint_by_id()

--- a/src/pragmata/core/annotation/logical_constraints.py
+++ b/src/pragmata/core/annotation/logical_constraints.py
@@ -7,11 +7,16 @@ the export code.
 """
 
 from dataclasses import dataclass
-from typing import Literal
+from enum import StrEnum
 
 from pragmata.core.schemas.annotation_task import Task
 
-Severity = Literal["warn", "block"]
+
+class Severity(StrEnum):
+    """Annotator-time feedback severity for a logical constraint violation."""
+
+    WARN = "warn"
+    BLOCK = "block"
 
 
 @dataclass(frozen=True)

--- a/src/pragmata/core/annotation/logical_constraints.py
+++ b/src/pragmata/core/annotation/logical_constraints.py
@@ -7,8 +7,11 @@ the export code.
 """
 
 from dataclasses import dataclass
+from typing import Literal
 
 from pragmata.core.schemas.annotation_task import Task
+
+Severity = Literal["warn", "block"]
 
 
 @dataclass(frozen=True)
@@ -81,3 +84,7 @@ LOGICAL_CONSTRAINTS: dict[Task, list[LogicalConstraint]] = {
     ],
     Task.GENERATION: [],
 }
+
+# By-id lookup over the flattened catalogue, used by the settings layer to
+# validate that override maps reference known constraint_ids.
+CONSTRAINT_BY_ID: dict[str, LogicalConstraint] = {c.constraint_id: c for cs in LOGICAL_CONSTRAINTS.values() for c in cs}

--- a/src/pragmata/core/settings/annotation_settings.py
+++ b/src/pragmata/core/settings/annotation_settings.py
@@ -1,6 +1,6 @@
 """Operational settings for annotation (workspace topology, distribution).
 
-Settings are organised into three scopes — deployment (``AnnotationSettings``),
+Settings are organised into three scopes: deployment (``AnnotationSettings``),
 workspace (``WorkspaceSettings``), task (``TaskSettings``). The inheritable
 fields (``production_min_submitted``, ``calibration_min_submitted``, ``locale``,
 ``calibration_fraction``) may be set at any scope; child scopes default to
@@ -9,6 +9,12 @@ fields (``production_min_submitted``, ``calibration_min_submitted``, ``locale``,
 ``model_dump()``). ``resolved_task(workspace_name, task)`` returns the
 **computed** values after walking task → workspace → deployment — the CSS
 "computed value" analogy: first non-``INHERIT`` ancestor wins.
+
+Multi-key maps (e.g. ``constraint_severity: dict[str, Severity]``) use
+**sparse-dict overlay** rather than the ``INHERIT`` sentinel: user-supplied keys
+override the deployment default for that key only; omitted keys fall through.
+This is the natural mechanism for dict-shaped fields; INHERIT is reserved for
+single-value primitives.
 """
 
 from dataclasses import dataclass, field
@@ -17,6 +23,7 @@ from typing import Annotated, Literal, Self, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field, NonNegativeInt, PositiveInt, model_validator
 
+from pragmata.core.annotation.logical_constraints import CONSTRAINT_BY_ID, Severity
 from pragmata.core.schemas.annotation_task import Locale, Task
 from pragmata.core.settings.settings_base import INHERIT, Inherit, ResolveSettings
 from pragmata.core.types import SafePathSegment
@@ -25,6 +32,13 @@ T = TypeVar("T")
 
 # Inheritable calibration_fraction override: bounded [0, 1] or the INHERIT sentinel.
 CalibrationFractionOverride = Annotated[float, Field(ge=0.0, le=1.0)] | Inherit
+
+_DEFAULT_CONSTRAINT_SEVERITY: dict[str, Severity] = {
+    "evidence_requires_relevance": "block",
+    "evidence_excludes_misleading": "warn",
+    "contradiction_requires_unsupported": "block",
+    "fabricated_requires_cited": "block",
+}
 
 
 class ArgillaSettings(BaseModel):
@@ -117,6 +131,7 @@ class AnnotationSettings(ResolveSettings):
     calibration_fraction: float = Field(0.1, ge=0.0, le=1.0)
     calibration_partition_seed: NonNegativeInt = 0
     include_discarded: bool = False
+    constraint_severity: dict[str, Severity] = Field(default_factory=lambda: dict(_DEFAULT_CONSTRAINT_SEVERITY))
     workspaces: dict[str, WorkspaceSettings] = Field(
         default_factory=lambda: {
             "retrieval": WorkspaceSettings(tasks={Task.RETRIEVAL: TaskSettings()}),
@@ -145,6 +160,29 @@ class AnnotationSettings(ResolveSettings):
             locale=_inherit(ts.locale, ws.locale, self.locale),
             calibration_fraction=_inherit(ts.calibration_fraction, ws.calibration_fraction, self.calibration_fraction),
         )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _merge_constraint_severity_defaults(cls, data: object) -> object:
+        """Overlay user-provided deployment severities onto the built-in defaults.
+
+        Users supply only the constraint_ids they want to override; the rest
+        fall through to the field's default.
+        """
+        if isinstance(data, dict) and isinstance(data.get("constraint_severity"), dict):
+            data["constraint_severity"] = {**_DEFAULT_CONSTRAINT_SEVERITY, **data["constraint_severity"]}
+        return data
+
+    @model_validator(mode="after")
+    def _validate_constraint_severity_keys(self) -> Self:
+        known = set(CONSTRAINT_BY_ID)
+        unknown = set(self.constraint_severity) - known
+        if unknown:
+            raise ValueError(
+                f"deployment constraint_severity references unknown constraint_id(s): "
+                f"{sorted(unknown)}. Known constraint_ids: {sorted(known)}."
+            )
+        return self
 
     @model_validator(mode="after")
     def _validate_task_uniqueness(self) -> Self:

--- a/src/pragmata/core/settings/annotation_settings.py
+++ b/src/pragmata/core/settings/annotation_settings.py
@@ -33,8 +33,8 @@ T = TypeVar("T")
 # Inheritable calibration_fraction override: bounded [0, 1] or the INHERIT sentinel.
 CalibrationFractionOverride = Annotated[float, Field(ge=0.0, le=1.0)] | Inherit
 
-# Severity is a deployment concern (not a property of the rule itself); it's user 
-# configurable. The same LogicalConstraint may b "block" in one deployment and 
+# Severity is a deployment concern (not a property of the rule itself); it's user
+# configurable. The same LogicalConstraint may b "block" in one deployment and
 # "warn" in another. so it lives here rather than as a field on LogicalConstraint.
 _DEFAULT_CONSTRAINT_SEVERITY: dict[str, Severity] = {
     "evidence_requires_relevance": Severity.BLOCK,

--- a/src/pragmata/core/settings/annotation_settings.py
+++ b/src/pragmata/core/settings/annotation_settings.py
@@ -37,10 +37,10 @@ CalibrationFractionOverride = Annotated[float, Field(ge=0.0, le=1.0)] | Inherit
 # LogicalConstraint may warrant "block" in one deployment and "warn" in another.
 # It therefore lives here rather than as a field on LogicalConstraint.
 _DEFAULT_CONSTRAINT_SEVERITY: dict[str, Severity] = {
-    "evidence_requires_relevance": "block",
-    "evidence_excludes_misleading": "warn",
-    "contradiction_requires_unsupported": "block",
-    "fabricated_requires_cited": "block",
+    "evidence_requires_relevance": Severity.BLOCK,
+    "evidence_excludes_misleading": Severity.WARN,
+    "contradiction_requires_unsupported": Severity.BLOCK,
+    "fabricated_requires_cited": Severity.BLOCK,
 }
 
 

--- a/src/pragmata/core/settings/annotation_settings.py
+++ b/src/pragmata/core/settings/annotation_settings.py
@@ -33,9 +33,9 @@ T = TypeVar("T")
 # Inheritable calibration_fraction override: bounded [0, 1] or the INHERIT sentinel.
 CalibrationFractionOverride = Annotated[float, Field(ge=0.0, le=1.0)] | Inherit
 
-# Severity is a deployment concern, not a property of the rule itself - the same
-# LogicalConstraint may warrant "block" in one deployment and "warn" in another.
-# It therefore lives here rather than as a field on LogicalConstraint.
+# Severity is a deployment concern (not a property of the rule itself); it's user 
+# configurable. The same LogicalConstraint may b "block" in one deployment and 
+# "warn" in another. so it lives here rather than as a field on LogicalConstraint.
 _DEFAULT_CONSTRAINT_SEVERITY: dict[str, Severity] = {
     "evidence_requires_relevance": Severity.BLOCK,
     "evidence_excludes_misleading": Severity.WARN,

--- a/src/pragmata/core/settings/annotation_settings.py
+++ b/src/pragmata/core/settings/annotation_settings.py
@@ -33,6 +33,9 @@ T = TypeVar("T")
 # Inheritable calibration_fraction override: bounded [0, 1] or the INHERIT sentinel.
 CalibrationFractionOverride = Annotated[float, Field(ge=0.0, le=1.0)] | Inherit
 
+# Severity is a deployment concern, not a property of the rule itself - the same
+# LogicalConstraint may warrant "block" in one deployment and "warn" in another.
+# It therefore lives here rather than as a field on LogicalConstraint.
 _DEFAULT_CONSTRAINT_SEVERITY: dict[str, Severity] = {
     "evidence_requires_relevance": "block",
     "evidence_excludes_misleading": "warn",
@@ -170,7 +173,7 @@ class AnnotationSettings(ResolveSettings):
         fall through to the field's default.
         """
         if isinstance(data, dict) and isinstance(data.get("constraint_severity"), dict):
-            data["constraint_severity"] = {**_DEFAULT_CONSTRAINT_SEVERITY, **data["constraint_severity"]}
+            return {**data, "constraint_severity": {**_DEFAULT_CONSTRAINT_SEVERITY, **data["constraint_severity"]}}
         return data
 
     @model_validator(mode="after")

--- a/tests/unit/core/annotation/test_logical_constraints.py
+++ b/tests/unit/core/annotation/test_logical_constraints.py
@@ -9,8 +9,10 @@ from typing import get_args
 import pytest
 
 from pragmata.core.annotation.logical_constraints import (
+    CONSTRAINT_BY_ID,
     LOGICAL_CONSTRAINTS,
     LogicalConstraint,
+    _build_constraint_by_id,
 )
 from pragmata.core.schemas.annotation_export import (
     GenerationAnnotation,
@@ -45,6 +47,38 @@ class TestCatalogue:
     def test_grounding_constraint_ids_unique(self):
         ids = [c.constraint_id for c in LOGICAL_CONSTRAINTS[Task.GROUNDING]]
         assert len(ids) == len(set(ids))
+
+
+class TestConstraintById:
+    def test_covers_every_catalogue_entry(self):
+        all_ids = {c.constraint_id for constraints in LOGICAL_CONSTRAINTS.values() for c in constraints}
+        assert set(CONSTRAINT_BY_ID) == all_ids
+
+    def test_duplicate_constraint_id_across_tasks_raises(self):
+        duplicated = {
+            Task.RETRIEVAL: [
+                LogicalConstraint(
+                    task=Task.RETRIEVAL,
+                    constraint_id="dup",
+                    when_question="a",
+                    when_value=True,
+                    then_question="b",
+                    then_value=True,
+                )
+            ],
+            Task.GROUNDING: [
+                LogicalConstraint(
+                    task=Task.GROUNDING,
+                    constraint_id="dup",
+                    when_question="c",
+                    when_value=True,
+                    then_question="d",
+                    then_value=True,
+                )
+            ],
+        }
+        with pytest.raises(ValueError, match=r"duplicate constraint_id 'dup'"):
+            _build_constraint_by_id(duplicated)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/core/settings/test_annotation_settings.py
+++ b/tests/unit/core/settings/test_annotation_settings.py
@@ -513,6 +513,14 @@ class TestConstraintSeverityDefaults:
         with pytest.raises(ValidationError, match=r"deployment constraint_severity references unknown constraint_id"):
             AnnotationSettings(constraint_severity={"nonexistent_constraint": "warn"})
 
+    def test_input_dict_not_mutated(self):
+        """The (mode='before') validator must not mutate the caller's dict in place."""
+        user_override = {"evidence_requires_relevance": "warn"}
+        data = {"constraint_severity": user_override}
+        AnnotationSettings(**data)
+        assert data["constraint_severity"] is user_override
+        assert user_override == {"evidence_requires_relevance": "warn"}
+
     def test_yaml_subset_override(self):
         data = yaml.safe_load(
             """

--- a/tests/unit/core/settings/test_annotation_settings.py
+++ b/tests/unit/core/settings/test_annotation_settings.py
@@ -4,6 +4,7 @@ import pytest
 import yaml
 from pydantic import ValidationError
 
+from pragmata.core.annotation.logical_constraints import CONSTRAINT_BY_ID
 from pragmata.core.schemas.annotation_task import Task
 from pragmata.core.settings.annotation_settings import (
     AnnotationSettings,
@@ -482,6 +483,46 @@ class TestYamlRoundtrip:
         )
         s = AnnotationSettings(**data)
         assert s.resolved_task("r", Task.RETRIEVAL).production_min_submitted == 4
+
+
+class TestConstraintSeverityDefaults:
+    """Out-of-the-box severity defaults live on ``AnnotationSettings.constraint_severity``."""
+
+    def test_default_factory_covers_all_known_constraint_ids(self):
+        s = AnnotationSettings()
+        assert set(s.constraint_severity) == set(CONSTRAINT_BY_ID)
+
+    def test_default_for_block_constraint(self):
+        s = AnnotationSettings()
+        assert s.constraint_severity["evidence_requires_relevance"] == "block"
+
+    def test_default_for_warn_constraint(self):
+        s = AnnotationSettings()
+        assert s.constraint_severity["evidence_excludes_misleading"] == "warn"
+
+    def test_user_subset_merges_with_defaults(self):
+        s = AnnotationSettings(constraint_severity={"evidence_requires_relevance": "warn"})
+        # user override applied
+        assert s.constraint_severity["evidence_requires_relevance"] == "warn"
+        # other defaults preserved
+        assert s.constraint_severity["evidence_excludes_misleading"] == "warn"
+        assert s.constraint_severity["contradiction_requires_unsupported"] == "block"
+        assert s.constraint_severity["fabricated_requires_cited"] == "block"
+
+    def test_unknown_constraint_id_rejected(self):
+        with pytest.raises(ValidationError, match=r"deployment constraint_severity references unknown constraint_id"):
+            AnnotationSettings(constraint_severity={"nonexistent_constraint": "warn"})
+
+    def test_yaml_subset_override(self):
+        data = yaml.safe_load(
+            """
+            constraint_severity:
+              evidence_requires_relevance: warn
+            """
+        )
+        s = AnnotationSettings(**data)
+        assert s.constraint_severity["evidence_requires_relevance"] == "warn"
+        assert s.constraint_severity["evidence_excludes_misleading"] == "warn"
 
 
 class TestArgillaSettings:


### PR DESCRIPTION
**Stack:** #213 (merged) → **#214** → #223 → #215 → #216 → #217

**Chain/feature goal:** Annotatotion-time logical-constraint feedback (warn/block annotator if/when annotation violates declared logical constraints). Sits on top of a shared constraint SSOT, with deployment- and workspace-level severity overrides.

Severity becomes a property of a deployment, not of a rule, so it lives in `AnnotationSettings` rather than on `LogicalConstraint`. 

**This PR (settings layer):** Add deployment-scope `constraint_severity` to `AnnotationSettings` - the SSOT the annotator-time widget (#223) consumes. Severity is a runtime setting, not a property of the rule.

---

## Scope

- `core/annotation/logical_constraints.py`: `Severity` type alias; `CONSTRAINT_BY_ID` by-id lookup over the flattened catalogue, used to validate that override maps reference known `constraint_id`s.
- `core/settings/annotation_settings.py`: `constraint_severity: dict[str, Severity]` with full defaults via `_DEFAULT_CONSTRAINT_SEVERITY` (alongside other deployment defaults like `production_min_submitted`, `calibration_min_submitted`). A `model_validator(mode="before")` overlays user-supplied entries on top (sparse overlay — configs specify only the `constraint_id`s they override; omitted keys fall through). Unknown `constraint_id`s are rejected at construction.

## Test plan
- [x] `uv run python -m pytest tests/unit` (978 passing)
