### PR TITLE
refactor(annotation): DRY build_task_settings via assemble() helper

### DIFF
--- a/src/pragmata/core/annotation/argilla_task_definitions.py
+++ b/src/pragmata/core/annotation/argilla_task_definitions.py
@@ -213,6 +213,12 @@ def build_task_settings(settings: AnnotationSettings, locale: Locale = "en") -> 
     def _yes_no(task: Task, question: str) -> dict[str, str]:
         return _localised_labels(catalog, task, question, ["yes", "no"])
 
+    def assemble(task: Task, content_fields: list, questions: list, metadata: list, guidelines: str) -> rg.Settings:
+        # Constraints panel sits last in fields so it renders right above the
+        # discard panel - adjacent to the submit area where the annotator acts.
+        fields = [*content_fields, constraints_field(task, questions), discard_field(task)]
+        return rg.Settings(fields=fields, questions=questions, metadata=metadata, guidelines=guidelines)
+
     retrieval_questions: list = [
         rg.LabelQuestion(
             name="topically_relevant",
@@ -307,13 +313,12 @@ def build_task_settings(settings: AnnotationSettings, locale: Locale = "en") -> 
     ]
 
     return {
-        Task.RETRIEVAL: rg.Settings(
-            fields=[
+        Task.RETRIEVAL: assemble(
+            Task.RETRIEVAL,
+            content_fields=[
                 rg.TextField(name="query", title=t(Task.RETRIEVAL, "field", "query"), required=True),
                 rg.TextField(name="chunk", title=t(Task.RETRIEVAL, "field", "chunk"), required=True),
                 _collapsible_field("generated_answer", t(Task.RETRIEVAL, "field", "generated_answer"), template_text),
-                constraints_field(Task.RETRIEVAL, retrieval_questions),
-                discard_field(Task.RETRIEVAL),
             ],
             questions=retrieval_questions,
             metadata=[
@@ -325,13 +330,12 @@ def build_task_settings(settings: AnnotationSettings, locale: Locale = "en") -> 
             ],
             guidelines=t(Task.RETRIEVAL, "guidelines", ""),
         ),
-        Task.GROUNDING: rg.Settings(
-            fields=[
+        Task.GROUNDING: assemble(
+            Task.GROUNDING,
+            content_fields=[
                 rg.TextField(name="answer", title=t(Task.GROUNDING, "field", "answer"), required=True),
                 rg.TextField(name="context_set", title=t(Task.GROUNDING, "field", "context_set"), required=True),
                 _collapsible_field("query", t(Task.GROUNDING, "field", "query"), template_text),
-                constraints_field(Task.GROUNDING, grounding_questions),
-                discard_field(Task.GROUNDING),
             ],
             questions=grounding_questions,
             metadata=[
@@ -340,13 +344,12 @@ def build_task_settings(settings: AnnotationSettings, locale: Locale = "en") -> 
             ],
             guidelines=t(Task.GROUNDING, "guidelines", ""),
         ),
-        Task.GENERATION: rg.Settings(
-            fields=[
+        Task.GENERATION: assemble(
+            Task.GENERATION,
+            content_fields=[
                 rg.TextField(name="query", title=t(Task.GENERATION, "field", "query"), required=True),
                 rg.TextField(name="answer", title=t(Task.GENERATION, "field", "answer"), required=True),
                 _collapsible_field("context_set", t(Task.GENERATION, "field", "context_set"), template_text),
-                constraints_field(Task.GENERATION, generation_questions),
-                discard_field(Task.GENERATION),
             ],
             questions=generation_questions,
             metadata=[

--- a/src/pragmata/core/annotation/argilla_task_definitions.py
+++ b/src/pragmata/core/annotation/argilla_task_definitions.py
@@ -215,7 +215,7 @@ def build_task_settings(settings: AnnotationSettings, locale: Locale = "en") -> 
 
     def assemble(task: Task, content_fields: list, questions: list, metadata: list, guidelines: str) -> rg.Settings:
         # Constraints panel sits last in fields so it renders right above the
-        # discard panel - adjacent to the submit area where the annotator acts.
+        # discard panel, adjacent to the submit area where the annotator acts.
         fields = [*content_fields, constraints_field(task, questions), discard_field(task)]
         return rg.Settings(fields=fields, questions=questions, metadata=metadata, guidelines=guidelines)
 


### PR DESCRIPTION
**Stack:** #213 (merged) → #214 (severity settings) → #223 (widget) → **#215** → #216 → #217

**Chain goal:** Annotator-time logical-constraint feedback (warn/block) on top of a shared constraint SSOT, with deployment- and workspace-level severity overrides.

**This PR (4/6):** Pure refactor of `build_task_settings` to fold three near-identical `rg.Settings(fields=..., questions=..., metadata=..., guidelines=...)` blocks into a single `assemble()` closure. Prerequisite for PR 5 (#216) per-workspace severity resolution.

---

## Scope

- `core/annotation/argilla_task_definitions.py`: introduce a local `assemble(task, content_fields, questions, metadata, guidelines)` closure. Each task constructs its `rg.Settings` by calling it instead of repeating the field-list + Settings boilerplate.
- No behaviour change; test count unchanged.

## Why

PR 5 (#216) needs to resolve severity per `(workspace_name, constraint_id)` inside the per-task settings build, and threading that through three duplicate blocks would have meant three near-identical edits. Pulling the shared shape up first makes PR 5 a single-touch change.

## Test plan
- [x] `uv run python -m pytest tests/unit`
