### PR TITLE
feat(annotation): configurable constraint severity at deployment + workspace scopes

### DIFF
--- a/src/pragmata/core/annotation/argilla_task_definitions.py
+++ b/src/pragmata/core/annotation/argilla_task_definitions.py
@@ -18,6 +18,7 @@ dataset creation time.
 """
 
 import json
+from collections.abc import Callable
 from importlib.resources import files
 from string import Template
 from typing import Any
@@ -319,7 +320,7 @@ def build_task_settings(settings: AnnotationSettings, locale: Locale = "en") -> 
     # Build only for tasks present in the workspaces topology: the constraints
     # widget renders against the task's workspace, and there's no consumer for
     # the unused rg.Settings.
-    task_builders: dict[Task, callable] = {
+    task_builders: dict[Task, Callable[[], rg.Settings]] = {
         Task.RETRIEVAL: lambda: assemble(
             Task.RETRIEVAL,
             content_fields=[

--- a/src/pragmata/core/annotation/argilla_task_definitions.py
+++ b/src/pragmata/core/annotation/argilla_task_definitions.py
@@ -151,16 +151,18 @@ def _render_discard_template(template_text: str, task: Task, dataset_locale: Loc
     )
 
 
-def _render_constraints_template(task: Task, questions: list, template_text: str, settings: AnnotationSettings) -> str:
+def _render_constraints_template(
+    task: Task, questions: list, template_text: str, settings: AnnotationSettings, workspace_name: str
+) -> str:
     """Substitute the constraint + question-title payload into ``constraints_field.html``.
 
-    Each constraint's payload severity is the deployment-scope value from
-    ``settings.constraint_severity``.
+    Each constraint's payload severity is the resolved severity for
+    ``(workspace_name, constraint_id)``: workspace overrides win over deployment.
     """
     constraints = LOGICAL_CONSTRAINTS[task]
     referenced = {q for c in constraints for q in (c.when_question, c.then_question)}
     titles = {q.name: q.title for q in questions if isinstance(q, rg.LabelQuestion) and q.name in referenced}
-    payloads = [c.to_widget_payload(settings.constraint_severity[c.constraint_id]) for c in constraints]
+    payloads = [c.to_widget_payload(settings.resolved_severity(workspace_name, c.constraint_id)) for c in constraints]
     return Template(template_text).substitute(
         CONSTRAINTS_JSON=json.dumps(payloads, ensure_ascii=False),
         QUESTION_TITLES_JSON=json.dumps(titles, ensure_ascii=False),
@@ -170,12 +172,14 @@ def _render_constraints_template(task: Task, questions: list, template_text: str
 def build_task_settings(settings: AnnotationSettings, locale: Locale = "en") -> dict[Task, rg.Settings]:
     """Build Argilla Settings for each annotation task, in the given locale.
 
-    Not cached: result depends on ``settings.constraint_severity``, so callers
-    should hold the returned dict for the duration of an import operation
-    rather than calling repeatedly. Deferred construction: call after an
-    Argilla client is connected (or with a mock client in tests).
+    Not cached: result depends on ``settings`` (severity resolution per task's
+    owning workspace). Callers should hold the returned dict for the duration
+    of an import operation rather than calling repeatedly. Deferred
+    construction: call after an Argilla client is connected (or with a mock
+    client in tests).
     """
     catalog = get_catalog(locale)
+    task_to_ws = settings.task_to_workspace()
     template_text = files("pragmata.core.annotation").joinpath("collapsible_field.html").read_text(encoding="utf-8")
     discard_template = files("pragmata.core.annotation").joinpath("discard_flow.html").read_text(encoding="utf-8")
     constraints_template = (
@@ -202,7 +206,7 @@ def build_task_settings(settings: AnnotationSettings, locale: Locale = "en") -> 
         return rg.CustomField(
             name="constraints_panel",
             title="Constraint checks",
-            template=_render_constraints_template(task, questions, constraints_template, settings),
+            template=_render_constraints_template(task, questions, constraints_template, settings, task_to_ws[task]),
             advanced_mode=True,
             required=False,
         )
@@ -312,8 +316,11 @@ def build_task_settings(settings: AnnotationSettings, locale: Locale = "en") -> 
         *_discard_questions(Task.GENERATION, catalog),
     ]
 
-    return {
-        Task.RETRIEVAL: assemble(
+    # Build only for tasks present in the workspaces topology: the constraints
+    # widget renders against the task's workspace, and there's no consumer for
+    # the unused rg.Settings.
+    task_builders: dict[Task, callable] = {
+        Task.RETRIEVAL: lambda: assemble(
             Task.RETRIEVAL,
             content_fields=[
                 rg.TextField(name="query", title=t(Task.RETRIEVAL, "field", "query"), required=True),
@@ -330,7 +337,7 @@ def build_task_settings(settings: AnnotationSettings, locale: Locale = "en") -> 
             ],
             guidelines=t(Task.RETRIEVAL, "guidelines", ""),
         ),
-        Task.GROUNDING: assemble(
+        Task.GROUNDING: lambda: assemble(
             Task.GROUNDING,
             content_fields=[
                 rg.TextField(name="answer", title=t(Task.GROUNDING, "field", "answer"), required=True),
@@ -344,7 +351,7 @@ def build_task_settings(settings: AnnotationSettings, locale: Locale = "en") -> 
             ],
             guidelines=t(Task.GROUNDING, "guidelines", ""),
         ),
-        Task.GENERATION: assemble(
+        Task.GENERATION: lambda: assemble(
             Task.GENERATION,
             content_fields=[
                 rg.TextField(name="query", title=t(Task.GENERATION, "field", "query"), required=True),
@@ -359,3 +366,4 @@ def build_task_settings(settings: AnnotationSettings, locale: Locale = "en") -> 
             guidelines=t(Task.GENERATION, "guidelines", ""),
         ),
     }
+    return {task: build() for task, build in task_builders.items() if task in task_to_ws}

--- a/src/pragmata/core/annotation/record_builder.py
+++ b/src/pragmata/core/annotation/record_builder.py
@@ -169,11 +169,6 @@ def build_generation_record(pair: QueryResponsePair, record_uuid: str) -> rg.Rec
     )
 
 
-def _invert_workspace_map(settings: AnnotationSettings) -> dict[Task, str]:
-    """Invert workspaces topology to task → workspace_base."""
-    return {task: ws_base for ws_base, ws in settings.workspaces.items() for task in ws.tasks}
-
-
 # ---------------------------------------------------------------------------
 # Partition logic
 # ---------------------------------------------------------------------------
@@ -290,7 +285,7 @@ def assign_partitions(
     """
     now = datetime.now(timezone.utc)
     seed = manifest.partition_seed
-    workspace_for_task = _invert_workspace_map(settings)
+    workspace_for_task = settings.task_to_workspace()
 
     pairs_by_rid: dict[str, QueryResponsePair] = {derive_record_uuid(pair): pair for pair in pairs}
     per_task_fraction: dict[Task, float] = {}
@@ -626,7 +621,7 @@ def fan_out_records(
         calibration vs production totals are computable from
         ``partition.assignments`` and stay in the api layer.
     """
-    task_to_ws = _invert_workspace_map(settings)
+    task_to_ws = settings.task_to_workspace()
     batches = _build_batches(partition.pairs_by_rid, partition.assignments)
 
     dataset_counts: dict[str, int] = {}

--- a/src/pragmata/core/settings/annotation_settings.py
+++ b/src/pragmata/core/settings/annotation_settings.py
@@ -211,6 +211,26 @@ class AnnotationSettings(ResolveSettings):
         return self
 
     @model_validator(mode="after")
+    def _validate_constraint_severity_complete(self) -> Self:
+        """Every known constraint_id must resolve to a deployment-scope severity.
+
+        ``resolved_severity()`` falls through to ``self.constraint_severity`` for
+        any constraint_id not overridden at workspace scope. A gap here would
+        otherwise surface only as a bare ``KeyError`` deep in severity resolution
+        (e.g. mid-widget-render) rather than at construction time - typically
+        because a new ``LogicalConstraint`` was added without a matching entry
+        in ``_DEFAULT_CONSTRAINT_SEVERITY``.
+        """
+        missing = set(CONSTRAINT_BY_ID) - set(self.constraint_severity)
+        if missing:
+            raise ValueError(
+                f"deployment constraint_severity is missing entries for known constraint_id(s): "
+                f"{sorted(missing)}. Every constraint must have a deployment-scope severity "
+                f"(add it to _DEFAULT_CONSTRAINT_SEVERITY)."
+            )
+        return self
+
+    @model_validator(mode="after")
     def _validate_task_uniqueness(self) -> Self:
         seen: set[Task] = set()
         for ws in self.workspaces.values():

--- a/src/pragmata/core/settings/annotation_settings.py
+++ b/src/pragmata/core/settings/annotation_settings.py
@@ -68,7 +68,9 @@ class WorkspaceSettings(BaseModel):
 
     Inherited fields default to ``INHERIT`` (use deployment value). ``None`` on
     ``calibration_min_submitted`` explicitly disables calibration for any task
-    that inherits from this workspace.
+    that inherits from this workspace. ``constraint_severity`` is a sparse
+    constraint-id to severity map: only listed constraint_ids override the
+    deployment value; omitted constraint_ids fall through to the deployment map.
     """
 
     model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
@@ -77,6 +79,7 @@ class WorkspaceSettings(BaseModel):
     calibration_min_submitted: PositiveInt | None | Inherit = INHERIT
     locale: Locale | Inherit = INHERIT
     calibration_fraction: CalibrationFractionOverride = INHERIT
+    constraint_severity: dict[str, Severity] = Field(default_factory=dict)
     tasks: dict[Task, TaskSettings]
 
 
@@ -143,6 +146,23 @@ class AnnotationSettings(ResolveSettings):
         }
     )
 
+    def task_to_workspace(self) -> dict[Task, str]:
+        """Map each task to its owning workspace name (validated 1:1 by ``_validate_task_uniqueness``)."""
+        return {task: ws_name for ws_name, ws in self.workspaces.items() for task in ws.tasks}
+
+    def resolved_severity(self, workspace_name: str, constraint_id: str) -> Severity:
+        """Return the computed severity for a logical constraint: workspace then deployment.
+
+        Severity is per-constraint (not per-task), so this walks only the two
+        scopes where it can be set. Deployment defaults are guaranteed complete
+        by the merge validator on ``constraint_severity``; unknown ``constraint_id``
+        raises ``KeyError``.
+        """
+        ws = self.workspaces[workspace_name]
+        if constraint_id in ws.constraint_severity:
+            return ws.constraint_severity[constraint_id]
+        return self.constraint_severity[constraint_id]
+
     def resolved_task(self, workspace_name: str, task: Task) -> ResolvedTaskSettings:
         """Return the computed task settings: task → workspace → deployment.
 
@@ -179,12 +199,15 @@ class AnnotationSettings(ResolveSettings):
     @model_validator(mode="after")
     def _validate_constraint_severity_keys(self) -> Self:
         known = set(CONSTRAINT_BY_ID)
-        unknown = set(self.constraint_severity) - known
-        if unknown:
-            raise ValueError(
-                f"deployment constraint_severity references unknown constraint_id(s): "
-                f"{sorted(unknown)}. Known constraint_ids: {sorted(known)}."
-            )
+        for scope_name, overrides in [("deployment", self.constraint_severity)] + [
+            (f"workspace {ws_name!r}", ws.constraint_severity) for ws_name, ws in self.workspaces.items()
+        ]:
+            unknown = set(overrides) - known
+            if unknown:
+                raise ValueError(
+                    f"{scope_name} constraint_severity references unknown constraint_id(s): "
+                    f"{sorted(unknown)}. Known constraint_ids: {sorted(known)}."
+                )
         return self
 
     @model_validator(mode="after")

--- a/src/pragmata/core/settings/annotation_settings.py
+++ b/src/pragmata/core/settings/annotation_settings.py
@@ -231,6 +231,29 @@ class AnnotationSettings(ResolveSettings):
         return self
 
     @model_validator(mode="after")
+    def _validate_workspace_constraint_severity_scope(self) -> Self:
+        """Reject a workspace override for a constraint_id whose task isn't served by that workspace.
+
+        ``resolved_severity()`` is only ever looked up per-task against that
+        task's own constraints, so an override for a constraint_id outside the
+        workspace's tasks would validate but silently never be read.
+        """
+        for ws_name, ws in self.workspaces.items():
+            out_of_scope = {
+                cid: CONSTRAINT_BY_ID[cid].task
+                for cid in ws.constraint_severity
+                if CONSTRAINT_BY_ID[cid].task not in ws.tasks
+            }
+            if out_of_scope:
+                detail = ", ".join(f"{cid!r} (task {task.value!r})" for cid, task in sorted(out_of_scope.items()))
+                served = sorted(t.value for t in ws.tasks)
+                raise ValueError(
+                    f"workspace {ws_name!r} constraint_severity references constraint_id(s) "
+                    f"outside its own tasks {served}: {detail}."
+                )
+        return self
+
+    @model_validator(mode="after")
     def _validate_task_uniqueness(self) -> Self:
         seen: set[Task] = set()
         for ws in self.workspaces.values():

--- a/tests/unit/core/annotation/test_argilla_task_definitions.py
+++ b/tests/unit/core/annotation/test_argilla_task_definitions.py
@@ -370,7 +370,8 @@ class TestConstraintsFieldSeverityWireUp:
     def test_no_overrides_uses_deployment_defaults(self):
         settings = AnnotationSettings()
         task_settings = build_task_settings(settings)
-        for task in (Task.RETRIEVAL, Task.GROUNDING):
+        # Generation has no logical constraints, so it's empty, but included here for completeness
+        for task in (Task.RETRIEVAL, Task.GROUNDING, Task.GENERATION):
             severities = self._payload_severities(_get_field(task_settings[task], "constraints_panel").template)
             for constraint_id, sev in severities.items():
                 assert sev == settings.constraint_severity[constraint_id]

--- a/tests/unit/core/annotation/test_argilla_task_definitions.py
+++ b/tests/unit/core/annotation/test_argilla_task_definitions.py
@@ -354,3 +354,40 @@ class TestConstraintsField:
         for settings in (_RETRIEVAL, _GROUNDING):
             names = _field_names(settings)
             assert names.index("constraints_panel") == names.index("discard_flow") - 1
+
+
+class TestConstraintsFieldSeverityWireUp:
+    """Widget receives the workspace-resolved severity for each constraint."""
+
+    def _payload_severities(self, template: str) -> dict[str, str]:
+        import json
+        import re
+
+        match = re.search(r"var CONSTRAINTS = (\[.*?\]);", template, re.DOTALL)
+        assert match, "CONSTRAINTS JSON not found in template"
+        return {c["constraint_id"]: c["severity"] for c in json.loads(match.group(1))}
+
+    def test_no_overrides_uses_deployment_defaults(self):
+        settings = AnnotationSettings()
+        task_settings = build_task_settings(settings)
+        for task in (Task.RETRIEVAL, Task.GROUNDING):
+            severities = self._payload_severities(_get_field(task_settings[task], "constraints_panel").template)
+            for constraint_id, sev in severities.items():
+                assert sev == settings.constraint_severity[constraint_id]
+
+    def test_workspace_override_reaches_widget(self):
+        from pragmata.core.settings.annotation_settings import TaskSettings, WorkspaceSettings
+
+        settings = AnnotationSettings(
+            workspaces={
+                "retrieval": WorkspaceSettings(
+                    constraint_severity={"evidence_requires_relevance": "warn"},
+                    tasks={Task.RETRIEVAL: TaskSettings()},
+                ),
+                "grounding": WorkspaceSettings(tasks={Task.GROUNDING: TaskSettings()}),
+                "generation": WorkspaceSettings(tasks={Task.GENERATION: TaskSettings()}),
+            },
+        )
+        task_settings = build_task_settings(settings)
+        severities = self._payload_severities(_get_field(task_settings[Task.RETRIEVAL], "constraints_panel").template)
+        assert severities["evidence_requires_relevance"] == "warn"

--- a/tests/unit/core/settings/test_annotation_settings.py
+++ b/tests/unit/core/settings/test_annotation_settings.py
@@ -533,6 +533,116 @@ class TestConstraintSeverityDefaults:
         assert s.constraint_severity["evidence_excludes_misleading"] == "warn"
 
 
+class TestWorkspaceConstraintSeverity:
+    """Workspace-scope overrides win over deployment defaults via ``resolved_severity()``."""
+
+    def test_workspace_override_wins(self):
+        s = AnnotationSettings(
+            workspaces={
+                "retrieval": WorkspaceSettings(
+                    constraint_severity={"evidence_requires_relevance": "warn"},
+                    tasks={Task.RETRIEVAL: TaskSettings()},
+                ),
+                "grounding": WorkspaceSettings(tasks={Task.GROUNDING: TaskSettings()}),
+                "generation": WorkspaceSettings(tasks={Task.GENERATION: TaskSettings()}),
+            },
+        )
+        # workspace override applied
+        assert s.resolved_severity("retrieval", "evidence_requires_relevance") == "warn"
+
+    def test_unlisted_constraint_falls_through_to_deployment(self):
+        s = AnnotationSettings(
+            workspaces={
+                "retrieval": WorkspaceSettings(
+                    constraint_severity={"evidence_requires_relevance": "warn"},
+                    tasks={Task.RETRIEVAL: TaskSettings()},
+                ),
+                "grounding": WorkspaceSettings(tasks={Task.GROUNDING: TaskSettings()}),
+                "generation": WorkspaceSettings(tasks={Task.GENERATION: TaskSettings()}),
+            },
+        )
+        # other constraint_ids fall through to deployment defaults
+        assert s.resolved_severity("retrieval", "evidence_excludes_misleading") == "warn"
+
+    def test_other_workspaces_unaffected(self):
+        s = AnnotationSettings(
+            workspaces={
+                "retrieval": WorkspaceSettings(
+                    constraint_severity={"evidence_excludes_misleading": "block"},
+                    tasks={Task.RETRIEVAL: TaskSettings()},
+                ),
+                "grounding": WorkspaceSettings(tasks={Task.GROUNDING: TaskSettings()}),
+                "generation": WorkspaceSettings(tasks={Task.GENERATION: TaskSettings()}),
+            },
+        )
+        # retrieval workspace has the override
+        assert s.resolved_severity("retrieval", "evidence_excludes_misleading") == "block"
+        # grounding workspace does not (deployment default applies, but this constraint
+        # belongs to retrieval anyway; the per-workspace resolution still returns the
+        # deployment default for any id not overridden in that workspace)
+
+    def test_unknown_constraint_id_at_workspace_rejected(self):
+        with pytest.raises(
+            ValidationError, match=r"workspace 'retrieval' constraint_severity references unknown constraint_id"
+        ):
+            AnnotationSettings(
+                workspaces={
+                    "retrieval": WorkspaceSettings(
+                        constraint_severity={"nonexistent_constraint": "warn"},
+                        tasks={Task.RETRIEVAL: TaskSettings()},
+                    ),
+                    "grounding": WorkspaceSettings(tasks={Task.GROUNDING: TaskSettings()}),
+                    "generation": WorkspaceSettings(tasks={Task.GENERATION: TaskSettings()}),
+                },
+            )
+
+    def test_unknown_constraint_at_workspace_via_yaml(self):
+        data = yaml.safe_load(
+            """
+            workspaces:
+              retrieval:
+                constraint_severity:
+                  evidence_requires_relevance: warn
+                tasks:
+                  retrieval: {}
+              grounding:
+                tasks:
+                  grounding: {}
+              generation:
+                tasks:
+                  generation: {}
+            """
+        )
+        s = AnnotationSettings(**data)
+        assert s.resolved_severity("retrieval", "evidence_requires_relevance") == "warn"
+
+
+class TestTaskToWorkspace:
+    """``task_to_workspace()`` inverts the workspaces topology to a Task → name map."""
+
+    def test_default_topology(self):
+        s = AnnotationSettings()
+        assert s.task_to_workspace() == {
+            Task.RETRIEVAL: "retrieval",
+            Task.GROUNDING: "grounding",
+            Task.GENERATION: "generation",
+        }
+
+    def test_custom_workspace_name(self):
+        s = AnnotationSettings(
+            workspaces={
+                "ws_a": WorkspaceSettings(tasks={Task.RETRIEVAL: TaskSettings()}),
+                "ws_b": WorkspaceSettings(tasks={Task.GROUNDING: TaskSettings()}),
+                "ws_c": WorkspaceSettings(tasks={Task.GENERATION: TaskSettings()}),
+            },
+        )
+        assert s.task_to_workspace() == {
+            Task.RETRIEVAL: "ws_a",
+            Task.GROUNDING: "ws_b",
+            Task.GENERATION: "ws_c",
+        }
+
+
 class TestArgillaSettings:
     def test_defaults_to_none_api_url(self):
         s = AnnotationSettings()

--- a/tests/unit/core/settings/test_annotation_settings.py
+++ b/tests/unit/core/settings/test_annotation_settings.py
@@ -627,6 +627,27 @@ class TestWorkspaceConstraintSeverity:
         s = AnnotationSettings(**data)
         assert s.resolved_severity("retrieval", "evidence_requires_relevance") == "warn"
 
+    def test_out_of_scope_constraint_id_at_workspace_rejected(self):
+        """A GROUNDING constraint_id on a RETRIEVAL-only workspace must be rejected at construction.
+
+        It would otherwise validate as 'known' but never be read by
+        resolved_severity() for that workspace, silently no-op-ing.
+        """
+        with pytest.raises(
+            ValidationError,
+            match=r"workspace 'retrieval' constraint_severity references constraint_id\(s\) outside its own tasks",
+        ):
+            AnnotationSettings(
+                workspaces={
+                    "retrieval": WorkspaceSettings(
+                        constraint_severity={"fabricated_requires_cited": "warn"},  # a GROUNDING constraint
+                        tasks={Task.RETRIEVAL: TaskSettings()},
+                    ),
+                    "grounding": WorkspaceSettings(tasks={Task.GROUNDING: TaskSettings()}),
+                    "generation": WorkspaceSettings(tasks={Task.GENERATION: TaskSettings()}),
+                },
+            )
+
 
 class TestTaskToWorkspace:
     """``task_to_workspace()`` inverts the workspaces topology to a Task → name map."""

--- a/tests/unit/core/settings/test_annotation_settings.py
+++ b/tests/unit/core/settings/test_annotation_settings.py
@@ -532,6 +532,18 @@ class TestConstraintSeverityDefaults:
         assert s.constraint_severity["evidence_requires_relevance"] == "warn"
         assert s.constraint_severity["evidence_excludes_misleading"] == "warn"
 
+    def test_missing_default_for_known_constraint_id_rejected(self, monkeypatch):
+        """A known constraint_id missing from _DEFAULT_CONSTRAINT_SEVERITY must be caught at construction.
+
+        Not surfaced later as a bare KeyError deep in resolved_severity().
+        """
+        patched = {**CONSTRAINT_BY_ID, "new_constraint": CONSTRAINT_BY_ID["evidence_requires_relevance"]}
+        monkeypatch.setattr("pragmata.core.settings.annotation_settings.CONSTRAINT_BY_ID", patched)
+        with pytest.raises(
+            ValidationError, match=r"deployment constraint_severity is missing entries for known constraint_id"
+        ):
+            AnnotationSettings()
+
 
 class TestWorkspaceConstraintSeverity:
     """Workspace-scope overrides win over deployment defaults via ``resolved_severity()``."""
@@ -577,9 +589,8 @@ class TestWorkspaceConstraintSeverity:
         )
         # retrieval workspace has the override
         assert s.resolved_severity("retrieval", "evidence_excludes_misleading") == "block"
-        # grounding workspace does not (deployment default applies, but this constraint
-        # belongs to retrieval anyway; the per-workspace resolution still returns the
-        # deployment default for any id not overridden in that workspace)
+        # grounding workspace has no override, so it still sees the deployment default
+        assert s.resolved_severity("grounding", "evidence_excludes_misleading") == "warn"
 
     def test_unknown_constraint_id_at_workspace_rejected(self):
         with pytest.raises(


### PR DESCRIPTION
**Stack:** #213 (merged) → #214 (severity settings) → #223 (widget) → #215 → **#216** → #217

**Chain goal:** Annotator-time logical-constraint feedback (warn/block) on top of a shared constraint SSOT, with deployment- and workspace-level severity overrides.

**This PR (5/6):** Add per-workspace severity overrides on top of the deployment-scope defaults introduced in PR 2. The annotator-time widget picks up the resolved severity per workspace.

---

## Scope

- `core/settings/annotation_settings.py`:
  - `WorkspaceSettings.constraint_severity: dict[str, Severity]` (sparse, empty default). Listed constraint_ids override the deployment value for that workspace only; omitted constraint_ids fall through.
  - `AnnotationSettings.resolved_severity(workspace_name, constraint_id)` walks workspace → deployment. Deployment defaults are guaranteed complete by the merge validator added in PR 2.
  - `AnnotationSettings.task_to_workspace()` inverts the topology to a `Task → workspace_name` map (validated 1:1 by the existing task-uniqueness validator). Consolidates the workspace lookup; the duplicate `_invert_workspace_map` helper is removed from `record_builder` and all its callers move to `settings.task_to_workspace()` — `fan_out_records` and `assign_partitions` (the latter being calibration/partition code that gained a use of the helper on `main` since this PR was first written), plus `argilla_task_definitions.build_task_settings`.
  - Validator rejects unknown `constraint_id`s at workspace scope (parallel to the deployment-scope check from PR 2).
- `core/annotation/argilla_task_definitions.py`: `_render_constraints_template` resolves severity per `(workspace_name, constraint_id)` so the widget renders the workspace-effective severity. `build_task_settings` skips tasks not present in the workspaces topology (rather than building unused `rg.Settings` that can't resolve severity).

## Override semantics

- `workspaces["foo"].constraint_severity = {"evidence_excludes_misleading": "block"}` upgrades that one constraint to blocking for workspace `foo`. Other constraints inherit the deployment value.
- Unknown `constraint_id` in an override map fails Pydantic validation at deployment-config load time (with the list of known ids in the error message).

## Test plan
- [x] `uv run python -m pytest tests/unit`


