### PR TITLE
refactor(annotation): key constraint_summary by constraint_id

### DIFF
--- a/docs/design/annotation-export-pipeline.md
+++ b/docs/design/annotation-export-pipeline.md
@@ -201,7 +201,7 @@ exports/{export_id}/
 | `include_discarded` | bool | Whether discarded responses were included in the fetch |
 | `row_counts` | object | `{task: int}` rows written per task |
 | `n_annotators` | object | `{task: int}` distinct annotators per task |
-| `constraint_summary` | object | `{rule_name: int}` violation counts |
+| `constraint_summary` | object | `{constraint_id: int}` violation counts |
 
 The CSVs hold per-row data only; run-level configuration and counts live in the sidecar so downstream pipelines can filter cleanly without unpacking metadata from columns.
 

--- a/src/pragmata/core/annotation/export_constraint_checks.py
+++ b/src/pragmata/core/annotation/export_constraint_checks.py
@@ -18,7 +18,7 @@ Both halves consume the same definitions in :mod:`logical_constraints`
 
 from collections.abc import Callable
 
-from pragmata.core.annotation.logical_constraints import LOGICAL_CONSTRAINTS
+from pragmata.core.annotation.logical_constraints import LOGICAL_CONSTRAINTS, LogicalConstraint
 from pragmata.core.schemas.annotation_export import (
     GenerationAnnotation,
     GroundingAnnotation,
@@ -27,22 +27,22 @@ from pragmata.core.schemas.annotation_export import (
 from pragmata.core.schemas.annotation_task import Task
 
 
-def _evaluate(task: Task, row: object) -> list[str]:
-    return [c.violation_string() for c in LOGICAL_CONSTRAINTS[task] if c.violated_by(row)]
+def _evaluate(task: Task, row: object) -> list[LogicalConstraint]:
+    return [c for c in LOGICAL_CONSTRAINTS[task] if c.violated_by(row)]
 
 
-def check_retrieval(row: RetrievalAnnotation) -> list[str]:
-    """Return constraint violation strings for a retrieval annotation row."""
+def check_retrieval(row: RetrievalAnnotation) -> list[LogicalConstraint]:
+    """Return violated logical constraints for a retrieval annotation row."""
     return _evaluate(Task.RETRIEVAL, row)
 
 
-def check_grounding(row: GroundingAnnotation) -> list[str]:
-    """Return constraint violation strings for a grounding annotation row."""
+def check_grounding(row: GroundingAnnotation) -> list[LogicalConstraint]:
+    """Return violated logical constraints for a grounding annotation row."""
     return _evaluate(Task.GROUNDING, row)
 
 
-def check_generation(row: GenerationAnnotation) -> list[str]:
-    """Return constraint violation strings for a generation annotation row."""
+def check_generation(row: GenerationAnnotation) -> list[LogicalConstraint]:
+    """Return violated logical constraints for a generation annotation row."""
     return _evaluate(Task.GENERATION, row)
 
 

--- a/src/pragmata/core/annotation/export_constraint_checks.py
+++ b/src/pragmata/core/annotation/export_constraint_checks.py
@@ -46,8 +46,8 @@ def check_generation(row: GenerationAnnotation) -> list[LogicalConstraint]:
     return _evaluate(Task.GENERATION, row)
 
 
-type ConstraintChecker = Callable[..., list[str]]
-"""A task checker: takes an annotation row and returns violation strings."""
+type ConstraintChecker = Callable[..., list[LogicalConstraint]]
+"""A task checker: takes an annotation row and returns the violated logical constraints."""
 
 CONSTRAINT_CHECKERS: dict[Task, ConstraintChecker] = {
     Task.RETRIEVAL: check_retrieval,

--- a/src/pragmata/core/annotation/export_fetcher.py
+++ b/src/pragmata/core/annotation/export_fetcher.py
@@ -12,6 +12,7 @@ import argilla as rg
 
 from pragmata.core.annotation.argilla_task_definitions import dataset_name
 from pragmata.core.annotation.export_constraint_checks import CONSTRAINT_CHECKERS
+from pragmata.core.annotation.logical_constraints import LogicalConstraint
 from pragmata.core.schemas.annotation_export import (
     GenerationAnnotation,
     GroundingAnnotation,
@@ -98,7 +99,7 @@ def fetch_task(
     user_lookup: dict[UUID, str],
     *,
     include_discarded: bool,
-) -> list[tuple[AnnotationModel, list[str]]]:
+) -> list[tuple[AnnotationModel, list[LogicalConstraint]]]:
     """Fetch records for a task across calibration and production datasets.
 
     Iterates the production dataset (always present) and the calibration
@@ -123,7 +124,7 @@ def fetch_task(
     query = rg.Query(filter=rg.Filter([("response.status", "in", statuses)]))
     check_constraints = CONSTRAINT_CHECKERS[task]
 
-    rows: list[tuple[AnnotationModel, list[str]]] = []
+    rows: list[tuple[AnnotationModel, list[LogicalConstraint]]] = []
     missing_uuid_count = 0
 
     for calibration in purposes:

--- a/src/pragmata/core/annotation/export_runner.py
+++ b/src/pragmata/core/annotation/export_runner.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 import argilla as rg
 
 from pragmata.core.annotation.export_fetcher import AnnotationModel, build_user_lookup, fetch_task
+from pragmata.core.annotation.logical_constraints import LogicalConstraint
 from pragmata.core.csv_io import _to_csv_value
 from pragmata.core.paths.annotation_paths import AnnotationExportPaths
 from pragmata.core.schemas.annotation_export import (
@@ -58,7 +59,8 @@ class ExportResult:
         paths: Path bundle used for this export.
         files: Mapping of task to written CSV file path.
         row_counts: Number of rows written per task.
-        constraint_summary: Violation count per rule name (namespaced by task).
+        constraint_summary: Violation count per ``constraint_id`` (the stable
+            short identifier defined in :mod:`logical_constraints`).
         n_annotators: Count of distinct annotators per task.
     """
 
@@ -70,7 +72,7 @@ class ExportResult:
 
 
 def write_export_csv(
-    rows: list[tuple[RetrievalAnnotation | GroundingAnnotation | GenerationAnnotation, list[str]]],
+    rows: list[tuple[RetrievalAnnotation | GroundingAnnotation | GenerationAnnotation, list[LogicalConstraint]]],
     path: Path,
     task: Task,
 ) -> None:
@@ -82,7 +84,10 @@ def write_export_csv(
     header row even when rows is empty.
 
     Args:
-        rows: List of (annotation, violations) tuples.
+        rows: List of (annotation, violations) tuples. Each violation is a
+            ``LogicalConstraint``; the CSV ``constraint_details`` column is
+            generated from ``LogicalConstraint.violation_string()`` and stays
+            in the legacy verbose ``";"``-joined format for human readers.
         path: Final output path.
         task: Task type — determines the export-row schema.
     """
@@ -97,7 +102,7 @@ def write_export_csv(
                 export_row = row_cls(
                     **annotation.model_dump(),
                     constraint_violated=bool(violations),
-                    constraint_details=";".join(violations),
+                    constraint_details=";".join(c.violation_string() for c in violations),
                 )
                 raw = export_row.model_dump(mode="json")
                 writer.writerow({k: _to_csv_value(raw[k]) for k in headers})
@@ -151,7 +156,7 @@ def assemble_export_meta(
         n_annotators: Distinct annotator count per task.
         calibration_enabled: Whether the topology declared a calibration
             dataset for each task.
-        constraint_summary: Constraint violation count per rule name.
+        constraint_summary: Violation count keyed by ``constraint_id``.
 
     Returns:
         Provenance sidecar with an internally stamped creation time.
@@ -204,7 +209,7 @@ def run_export(
 
     user_lookup = build_user_lookup(client)
 
-    task_rows: dict[Task, list[tuple[AnnotationModel, list[str]]]] = {}
+    task_rows: dict[Task, list[tuple[AnnotationModel, list[LogicalConstraint]]]] = {}
     for task in tasks:
         task_rows[task] = fetch_task(client, settings, task, user_lookup, include_discarded=include_discarded)
 
@@ -228,8 +233,8 @@ def run_export(
     constraint_summary: dict[str, int] = {}
     for task in tasks:
         for _, violations in task_rows[task]:
-            for v in violations:
-                constraint_summary[v] = constraint_summary.get(v, 0) + 1
+            for c in violations:
+                constraint_summary[c.constraint_id] = constraint_summary.get(c.constraint_id, 0) + 1
 
     meta = assemble_export_meta(
         export_id=paths.export_dir.name,

--- a/src/pragmata/core/annotation/logical_constraints.py
+++ b/src/pragmata/core/annotation/logical_constraints.py
@@ -4,7 +4,7 @@ A logical constraint is a binary implication on label values: when one question
 is answered with a specific yes/no value, another question is constrained to a
 specific yes/no value. The same definitions drive:
 
-1. Export-time validation (``constraints.check_*`` returns violation strings)
+1. Export-time validation (``export_constraint_checks.check_*`` returns violated constraints)
 2. Annotation-time UI warnings/blocks (constraints serialised via
    ``to_widget_payload()`` into ``constraints_field.html``)
 

--- a/src/pragmata/core/annotation/logical_constraints.py
+++ b/src/pragmata/core/annotation/logical_constraints.py
@@ -53,7 +53,7 @@ class LogicalConstraint:
         return getattr(row, self.then_question, None) != self.then_value
 
     def violation_string(self) -> str:
-        """Violation string used in export CSV/constraint_summary."""
+        """Human-readable violation string rendered into the per-row CSV ``constraint_details`` column."""
         return (
             f"{self.task.value}: {self.when_question}={self.when_value} but {self.then_question}={not self.then_value}"
         )

--- a/tests/unit/core/annotation/test_export_constraint_checks.py
+++ b/tests/unit/core/annotation/test_export_constraint_checks.py
@@ -8,6 +8,7 @@ from pragmata.core.annotation.export_constraint_checks import (
     check_grounding,
     check_retrieval,
 )
+from pragmata.core.annotation.logical_constraints import LogicalConstraint
 from pragmata.core.schemas.annotation_export import (
     GenerationAnnotation,
     GroundingAnnotation,
@@ -98,10 +99,11 @@ class TestCheckRetrieval:
         row = _retrieval(topically_relevant=True, evidence_sufficient=True, misleading=False)
         assert check_retrieval(row) == []
 
-    def test_returns_strings(self) -> None:
+    def test_returns_logical_constraints(self) -> None:
         row = _retrieval(topically_relevant=False, evidence_sufficient=True)
         violations = check_retrieval(row)
-        assert all(isinstance(v, str) for v in violations)
+        assert all(isinstance(v, LogicalConstraint) for v in violations)
+        assert violations[0].constraint_id == "evidence_requires_relevance"
 
 
 # ---------------------------------------------------------------------------
@@ -129,10 +131,11 @@ class TestCheckGrounding:
         )
         assert check_grounding(row) == []
 
-    def test_returns_strings(self) -> None:
+    def test_returns_logical_constraints(self) -> None:
         row = _grounding(contradicted_claim_present=True, unsupported_claim_present=False)
         violations = check_grounding(row)
-        assert all(isinstance(v, str) for v in violations)
+        assert all(isinstance(v, LogicalConstraint) for v in violations)
+        assert violations[0].constraint_id == "contradiction_requires_unsupported"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/core/annotation/test_export_runner.py
+++ b/tests/unit/core/annotation/test_export_runner.py
@@ -363,22 +363,7 @@ class TestYesNoConversion:
 
 class TestConstraintViolations:
     def test_constraint_violations_in_summary(self, tmp_path: Path, mock_client: MagicMock) -> None:
-        from pragmata.api.annotation_export import export_annotations
-
-        record = _make_record(
-            fields=RETRIEVAL_FIELDS,
-            metadata=BASE_METADATA,
-            responses=_retrieval_responses(_UID1, topically_relevant="no", evidence_sufficient="yes"),
-        )
-        dataset = MagicMock()
-        dataset.records.return_value = iter([record])
-        _set_production_dataset(mock_client, dataset)
-
-        result = export_annotations(base_dir=tmp_path, export_id="test-run", tasks=[Task.RETRIEVAL])
-        assert result.constraint_summary == {"evidence_requires_relevance": 1}
-
-    def test_constraint_summary_keyed_by_constraint_id(self, tmp_path: Path, mock_client: MagicMock) -> None:
-        """Summary keys are stable short ids, not verbose violation strings."""
+        """Summary keys are stable short ids, not verbose violation strings; sidecar mirrors it."""
         from pragmata.api.annotation_export import export_annotations
 
         record = _make_record(

--- a/tests/unit/core/annotation/test_export_runner.py
+++ b/tests/unit/core/annotation/test_export_runner.py
@@ -14,6 +14,7 @@ from pragmata.core.annotation.export_runner import (
     ExportResult,
     write_export_csv,
 )
+from pragmata.core.annotation.logical_constraints import CONSTRAINT_BY_ID
 from pragmata.core.csv_io import read_csv
 from pragmata.core.paths.annotation_paths import AnnotationExportPaths
 from pragmata.core.schemas.annotation_export import (
@@ -155,24 +156,28 @@ class TestWriteExportCsv:
 
     def test_writes_row_with_violations(self, tmp_path: Path) -> None:
         row = _retrieval(topically_relevant=False, evidence_sufficient=True)
-        violations = ["retrieval: evidence_sufficient=True but topically_relevant=False"]
+        violations = [CONSTRAINT_BY_ID["evidence_requires_relevance"]]
         out = tmp_path / "out.csv"
         write_export_csv([(row, violations)], out, Task.RETRIEVAL)
         with out.open() as f:
             reader = csv.DictReader(f)
             data = list(reader)
         assert data[0]["constraint_violated"] == "true"
-        assert data[0]["constraint_details"] == violations[0]
+        assert data[0]["constraint_details"] == violations[0].violation_string()
 
     def test_multiple_violations_semicolon_joined(self, tmp_path: Path) -> None:
         row = _retrieval()
-        violations = ["violation A", "violation B"]
+        violations = [
+            CONSTRAINT_BY_ID["evidence_requires_relevance"],
+            CONSTRAINT_BY_ID["evidence_excludes_misleading"],
+        ]
         out = tmp_path / "out.csv"
         write_export_csv([(row, violations)], out, Task.RETRIEVAL)
         with out.open() as f:
             reader = csv.DictReader(f)
             data = list(reader)
-        assert data[0]["constraint_details"] == "violation A;violation B"
+        expected = ";".join(c.violation_string() for c in violations)
+        assert data[0]["constraint_details"] == expected
 
     def test_bool_values_serialised_lowercase(self, tmp_path: Path) -> None:
         row = _retrieval(topically_relevant=True, evidence_sufficient=False)
@@ -239,8 +244,12 @@ class TestExportRowRoundTrip:
 
     def test_csv_roundtrips_via_read_csv(self, tmp_path: Path) -> None:
         out = tmp_path / "out.csv"
+        violations = [
+            CONSTRAINT_BY_ID["evidence_requires_relevance"],
+            CONSTRAINT_BY_ID["evidence_excludes_misleading"],
+        ]
         write_export_csv(
-            [(_retrieval(), []), (_retrieval(chunk_id="c2"), ["rule_a", "rule_b"])],
+            [(_retrieval(), []), (_retrieval(chunk_id="c2"), violations)],
             out,
             Task.RETRIEVAL,
         )
@@ -249,7 +258,7 @@ class TestExportRowRoundTrip:
         assert rows[0].constraint_violated is False
         assert rows[0].constraint_details == ""
         assert rows[1].constraint_violated is True
-        assert rows[1].constraint_details == "rule_a;rule_b"
+        assert rows[1].constraint_details == ";".join(c.violation_string() for c in violations)
 
 
 # ---------------------------------------------------------------------------
@@ -366,8 +375,35 @@ class TestConstraintViolations:
         _set_production_dataset(mock_client, dataset)
 
         result = export_annotations(base_dir=tmp_path, export_id="test-run", tasks=[Task.RETRIEVAL])
-        assert result.constraint_summary
-        assert sum(result.constraint_summary.values()) >= 1
+        assert result.constraint_summary == {"evidence_requires_relevance": 1}
+
+    def test_constraint_summary_keyed_by_constraint_id(self, tmp_path: Path, mock_client: MagicMock) -> None:
+        """Summary keys are stable short ids, not verbose violation strings."""
+        from pragmata.api.annotation_export import export_annotations
+
+        record = _make_record(
+            fields=RETRIEVAL_FIELDS,
+            metadata=BASE_METADATA,
+            responses=_retrieval_responses(
+                _UID1, topically_relevant="no", evidence_sufficient="yes", misleading="yes"
+            ),
+        )
+        dataset = MagicMock()
+        dataset.records.return_value = iter([record])
+        _set_production_dataset(mock_client, dataset)
+
+        result = export_annotations(base_dir=tmp_path, export_id="test-run", tasks=[Task.RETRIEVAL])
+        # Both retrieval constraints trip on this row.
+        assert result.constraint_summary == {
+            "evidence_requires_relevance": 1,
+            "evidence_excludes_misleading": 1,
+        }
+        # Sidecar mirrors the in-memory summary.
+        payload = json.loads(result.paths.export_meta_json.read_text())
+        assert payload["constraint_summary"] == {
+            "evidence_requires_relevance": 1,
+            "evidence_excludes_misleading": 1,
+        }
 
 
 class TestNotesCoercion:

--- a/tests/unit/core/annotation/test_export_runner.py
+++ b/tests/unit/core/annotation/test_export_runner.py
@@ -384,9 +384,7 @@ class TestConstraintViolations:
         record = _make_record(
             fields=RETRIEVAL_FIELDS,
             metadata=BASE_METADATA,
-            responses=_retrieval_responses(
-                _UID1, topically_relevant="no", evidence_sufficient="yes", misleading="yes"
-            ),
+            responses=_retrieval_responses(_UID1, topically_relevant="no", evidence_sufficient="yes", misleading="yes"),
         )
         dataset = MagicMock()
         dataset.records.return_value = iter([record])


### PR DESCRIPTION
**Stack:** #213 (merged) → #214 (severity settings) → #223 (widget) → #215 → #216 → **#217**

**Chain goal:** Annotator-time logical-constraint feedback (warn/block) on top of a shared constraint SSOT, with deployment- and workspace-level severity overrides.

**This PR (6/6):** Finish the SSOT migration on the export side. `constraint_summary` aggregation in `export_meta.json` now keys by stable `constraint_id` (e.g. `evidence_requires_relevance`) instead of the verbose violation string. Closes the inconsistency where PR 5's (#216) severity overrides used `constraint_id` keys but the export summary used the formatted message string.

---

## Scope

- `core/annotation/export_constraint_checks.py`: `check_*` return `list[LogicalConstraint]` instead of `list[str]`; `CONSTRAINT_CHECKERS` and the `ConstraintChecker` type alias updated accordingly.
- `core/annotation/export_fetcher.py`: row tuples now carry `list[LogicalConstraint]` through to the runner.
- `core/annotation/export_runner.py`:
  - `write_export_csv`: per-row `constraint_details` CSV column unchanged - still verbose `";"`-joined violation strings (generated via `LogicalConstraint.violation_string()` at write time).
  - `run_export`: `constraint_summary[c.constraint_id] += 1` aggregation.
- Tests updated for the new key format.

## What stays the same

- Per-row CSV `constraint_details` column format (verbose strings - human-readable).
- `constraint_violated: bool` column (still derived from `bool(violations)`).
- `AnnotationExportMeta.constraint_summary` schema type (`dict[str, NonNegativeInt]`) - keys are arbitrary strings, only the runtime values change.

## Breaking change

`export_meta.json`'s `constraint_summary` keys change from verbose strings to short ids. If any downstream consumer reads those keys, it needs updating. Counts and per-row CSV data are unaffected.

## Test plan
- [x] `uv run python -m pytest tests/unit` (994 passing)
