### PR TITLE
feat(annotation): user-provided locale catalog directory

### DIFF
--- a/src/pragmata/annotation/__init__.py
+++ b/src/pragmata/annotation/__init__.py
@@ -18,7 +18,6 @@ __all__ = [
     "IaaReport",
     "ImportResult",
     "Locale",
-    "SUPPORTED_LOCALES",
     "SetupResult",
     "Task",
     "UserSpec",
@@ -34,7 +33,6 @@ _LAZY: dict[str, tuple[str, str]] = {
     "IaaReport": ("pragmata.core.schemas.iaa_report", "IaaReport"),
     "ImportResult": ("pragmata.api.annotation_import", "ImportResult"),
     "Locale": ("pragmata.core.schemas.annotation_task", "Locale"),
-    "SUPPORTED_LOCALES": ("pragmata.core.annotation.locales.registry", "SUPPORTED_LOCALES"),
     "SetupResult": ("pragmata.core.annotation.setup", "SetupResult"),
     "Task": ("pragmata.core.schemas.annotation_task", "Task"),
     "UserSpec": ("pragmata.core.settings.annotation_settings", "UserSpec"),
@@ -68,7 +66,6 @@ if TYPE_CHECKING:
     from pragmata.api.annotation_setup import setup as setup
     from pragmata.api.annotation_setup import teardown as teardown
     from pragmata.core.annotation.export_runner import ExportResult as ExportResult
-    from pragmata.core.annotation.locales.registry import SUPPORTED_LOCALES as SUPPORTED_LOCALES
     from pragmata.core.annotation.setup import SetupResult as SetupResult
     from pragmata.core.schemas.annotation_task import Locale as Locale
     from pragmata.core.schemas.annotation_task import Task as Task

--- a/src/pragmata/api/annotation_import.py
+++ b/src/pragmata/api/annotation_import.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from pragmata.api._error_log import error_log
 from pragmata.core.annotation.client import resolve_argilla_client
 from pragmata.core.annotation.loaders import RecordInput, resolve_records
+from pragmata.core.annotation.locales.registry import register_catalog_dir
 from pragmata.core.annotation.record_builder import (
     RecordError,
     assign_partitions,
@@ -132,6 +133,8 @@ def import_records(
             "locale": locale,
         },
     )
+    if settings.locale_catalog_dir is not None:
+        register_catalog_dir(settings.locale_catalog_dir)
 
     api_key = api_key if isinstance(api_key, str) else resolve_api_key("argilla")
     client = resolve_argilla_client(settings.argilla.api_url, api_key)

--- a/src/pragmata/api/annotation_import.py
+++ b/src/pragmata/api/annotation_import.py
@@ -70,6 +70,7 @@ def import_records(
     calibration_min_submitted: int | None | Unset = UNSET,
     calibration_partition_seed: int | Unset = UNSET,
     locale: Locale | Unset = UNSET,
+    locale_catalog_dir: str | Path | None | Unset = UNSET,
 ) -> ImportResult:
     """Validate and fan out records to per-purpose Argilla annotation datasets.
 
@@ -126,6 +127,9 @@ def import_records(
             titles/questions/guidelines used when auto-creating datasets.
             Cascades to workspaces/tasks unless they carve out their own
             value in YAML.
+        locale_catalog_dir: Directory of user-provided locale YAML files
+            layered over the bundled catalogs (user wins on stem collision).
+            Must exist if set. Falls back to YAML config.
 
     Returns:
         ImportResult with totals, per-dataset counts, partition counts, and
@@ -143,6 +147,7 @@ def import_records(
             "calibration_min_submitted": calibration_min_submitted,
             "calibration_partition_seed": calibration_partition_seed,
             "locale": locale,
+            "locale_catalog_dir": locale_catalog_dir,
         },
     )
     if settings.locale_catalog_dir is not None:

--- a/src/pragmata/cli/commands/annotation.py
+++ b/src/pragmata/cli/commands/annotation.py
@@ -116,6 +116,13 @@ def import_command(
         "(en, de). Inherits to workspaces/tasks unless they carve out a value in YAML. "
         "Falls back to config, then 'en'.",
     ),
+    locale_catalog_dir: str | None = typer.Option(
+        None,
+        "--locale-catalog",
+        help="Directory of user-provided locale YAML files layered over bundled "
+        "catalogs (user wins on stem collision). Must exist if set. "
+        "Falls back to config.",
+    ),
 ) -> None:
     """Validate and import records into annotation datasets.
 
@@ -146,6 +153,7 @@ def import_command(
         calibration_min_submitted=None if no_calibration else UNSET,
         calibration_partition_seed=UNSET if calibration_partition_seed is None else calibration_partition_seed,
         locale=parse_locale(locale) or UNSET,
+        locale_catalog_dir=UNSET if locale_catalog_dir is None else locale_catalog_dir,
     )
     typer.echo(f"Total records: {result.total_records}")
     typer.echo(

--- a/src/pragmata/cli/parsing.py
+++ b/src/pragmata/cli/parsing.py
@@ -54,9 +54,8 @@ def parse_tasks(raw: str | None) -> "list[Task] | None":
 def parse_locale(raw: str | None) -> "Locale | None":
     """Normalise a locale string (e.g. ``en``, ``de``).
 
-    Returns None when no locale is supplied. Catalog membership is validated
-    in the api layer after any user catalog directory has been registered
-    (see ``api.annotation_import.import_records``).
+    Returns None when no locale is supplied. Does not validate catalog
+    membership.
     """
     if raw is None:
         return None

--- a/src/pragmata/cli/parsing.py
+++ b/src/pragmata/cli/parsing.py
@@ -52,19 +52,15 @@ def parse_tasks(raw: str | None) -> "list[Task] | None":
 
 
 def parse_locale(raw: str | None) -> "Locale | None":
-    """Parse a locale string (e.g. ``en``, ``de``).
+    """Normalise a locale string (e.g. ``en``, ``de``).
 
-    Returns None when no locale is supplied, leaving locale selection to
-    the downstream default. Raises ``ValueError`` if the locale is unknown.
+    Returns None when no locale is supplied. Catalog membership is validated
+    in the api layer after any user catalog directory has been registered
+    (see ``api.annotation_import.import_records``).
     """
-    from pragmata.annotation import SUPPORTED_LOCALES
-
     if raw is None:
         return None
-    locale = raw.strip()
-    if locale not in SUPPORTED_LOCALES:
-        raise ValueError(f"Unknown locale: {locale!r}. Supported: {sorted(SUPPORTED_LOCALES)}")
-    return locale
+    return raw.strip()
 
 
 def parse_user_specs(path: str | None) -> "list[UserSpec] | None":

--- a/src/pragmata/core/annotation/argilla_task_definitions.py
+++ b/src/pragmata/core/annotation/argilla_task_definitions.py
@@ -111,7 +111,7 @@ def _discard_i18n_payload_for_locale(loc: Locale, task: Task) -> dict[str, Any]:
     widget uses for ``aria-label`` matching when scoping the native
     Argilla cards it hides.
     """
-    catalog = CATALOGS[loc]
+    catalog = get_catalog(loc)
     payload: dict[str, Any] = {key: catalog[(task, "widget", f"discard.{key}")] for key in DISCARD_WIDGET_KEYS}
     payload["discard_reason_title"] = catalog[(task, "question", "discard_reason")]
     payload["discard_notes_title"] = catalog[(task, "question", "discard_notes")]

--- a/src/pragmata/core/annotation/locales/registry.py
+++ b/src/pragmata/core/annotation/locales/registry.py
@@ -1,16 +1,12 @@
 """Catalog registry: auto-discovers locale YAML files at import.
 
-Scope: bundled catalogs only. The registry scans ``*.yaml`` files in this
-package directory at import time and keys them by file stem
-(``en.yaml`` -> ``"en"``). Adding a locale upstream is therefore a
-zero-Python-edit change: drop the YAML file alongside ``en.yaml`` and the
-locale is registered automatically.
-
-Adding a locale from outside the installed package (user-provided catalog
-directory) is not yet supported; a deployment that needs a custom locale
-or wants to override a bundled one currently has to vendor or contribute
-the YAML upstream. Extending discovery to a configurable directory is
-planned as a follow-up.
+Bundled catalogs are loaded eagerly from this package directory at import
+time, keyed by file stem (``en.yaml`` -> ``"en"``). A deployment can
+additionally register catalogs from any user-provided directory by
+calling :func:`register_catalog_dir` (typically wired in from the api/
+layer after settings resolution). User-provided files override bundled
+entries on stem collision, matching the layering convention of standard
+i18n stacks (gettext, i18next).
 """
 
 from pathlib import Path
@@ -19,11 +15,23 @@ from pragmata.core.annotation.locales.loader import load_catalog
 from pragmata.core.annotation.locales.types import Catalog
 from pragmata.core.schemas.annotation_task import Locale
 
+
+def _load_dir(directory: Path) -> dict[Locale, Catalog]:
+    return {yaml_file.stem: load_catalog(yaml_file) for yaml_file in sorted(directory.glob("*.yaml"))}
+
+
 _LOCALES_DIR = Path(__file__).parent
 
-CATALOGS: dict[Locale, Catalog] = {
-    yaml_file.stem: load_catalog(yaml_file) for yaml_file in sorted(_LOCALES_DIR.glob("*.yaml"))
-}
+CATALOGS: dict[Locale, Catalog] = _load_dir(_LOCALES_DIR)
+
+
+def register_catalog_dir(directory: Path) -> None:
+    """Layer ``*.yaml`` catalogs from ``directory`` over the bundled set.
+
+    Idempotent: same directory registered twice yields the same end state.
+    On stem collision the user file wins (last write through the dict).
+    """
+    CATALOGS.update(_load_dir(directory))
 
 SUPPORTED_LOCALES: frozenset[Locale] = frozenset(CATALOGS)
 

--- a/src/pragmata/core/annotation/locales/registry.py
+++ b/src/pragmata/core/annotation/locales/registry.py
@@ -29,7 +29,6 @@ def register_catalog_dir(directory: Path) -> None:
     """Layer ``*.yaml`` catalogs from ``directory`` over the bundled set.
 
     Idempotent: same directory registered twice yields the same end state.
-    On stem collision the user file wins (last write through the dict).
     """
     CATALOGS.update(_load_dir(directory))
 

--- a/src/pragmata/core/annotation/locales/registry.py
+++ b/src/pragmata/core/annotation/locales/registry.py
@@ -33,12 +33,13 @@ def register_catalog_dir(directory: Path) -> None:
     """
     CATALOGS.update(_load_dir(directory))
 
-SUPPORTED_LOCALES: frozenset[Locale] = frozenset(CATALOGS)
-
 
 def get_catalog(locale: Locale) -> Catalog:
     """Return the display-string catalog for a locale.
 
-    Raises ``KeyError`` if the locale has no registered catalog.
+    Raises ``ValueError`` if the locale has no registered catalog (bundled
+    or user-provided via :func:`register_catalog_dir`).
     """
+    if locale not in CATALOGS:
+        raise ValueError(f"Unknown locale: {locale!r}. Supported: {sorted(CATALOGS)}")
     return CATALOGS[locale]

--- a/src/pragmata/core/annotation/locales/registry.py
+++ b/src/pragmata/core/annotation/locales/registry.py
@@ -29,8 +29,15 @@ def register_catalog_dir(directory: Path) -> None:
     """Layer ``*.yaml`` catalogs from ``directory`` over the bundled set.
 
     Idempotent: same directory registered twice yields the same end state.
+    Clears the downstream ``build_task_settings`` cache so a subsequent
+    locale build sees the updated catalog (otherwise a second
+    ``import_records`` call in the same process with a different
+    ``locale_catalog_dir`` would silently reuse stale ``rg.Settings``).
     """
+    from pragmata.core.annotation.argilla_task_definitions import build_task_settings
+
     CATALOGS.update(_load_dir(directory))
+    build_task_settings.cache_clear()
 
 
 def get_catalog(locale: Locale) -> Catalog:

--- a/src/pragmata/core/annotation/locales/registry.py
+++ b/src/pragmata/core/annotation/locales/registry.py
@@ -33,9 +33,15 @@ def register_catalog_dir(directory: Path) -> None:
     locale build sees the updated catalog (otherwise a second
     ``import_records`` call in the same process with a different
     ``locale_catalog_dir`` would silently reuse stale ``rg.Settings``).
+
+    Raises ``ValueError`` if ``directory`` does not exist or is not a
+    directory - fail loud rather than silently registering nothing, since
+    ``Path.glob`` on a missing path yields no entries.
     """
     from pragmata.core.annotation.argilla_task_definitions import build_task_settings
 
+    if not directory.is_dir():
+        raise ValueError(f"locale_catalog_dir does not exist or is not a directory: {directory}")
     CATALOGS.update(_load_dir(directory))
     build_task_settings.cache_clear()
 

--- a/src/pragmata/core/settings/annotation_settings.py
+++ b/src/pragmata/core/settings/annotation_settings.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal, Self
 
-from pydantic import BaseModel, ConfigDict, Field, NonNegativeInt, PositiveInt, model_validator
+from pydantic import BaseModel, ConfigDict, Field, NonNegativeInt, PositiveInt, field_validator, model_validator
 
 from pragmata.core.schemas.annotation_task import Locale, Task
 from pragmata.core.settings.settings_base import INHERIT, Inherit, ResolveSettings
@@ -82,6 +82,11 @@ class AnnotationSettings(ResolveSettings):
         locale: Display locale for Argilla dataset strings (titles, guidelines,
             label option text). Inherited by workspaces/tasks. Identities and
             label values remain stable across locales so exports merge cleanly.
+        locale_catalog_dir: Optional directory of user-provided locale YAML
+            files. When set, any ``*.yaml`` in this directory is layered on
+            top of the bundled catalogs (user wins on stem collision), so a
+            deployment can add or override locales without modifying the
+            installed package. Must exist if set.
         calibration_fraction: Fraction of records routed to a separate
             calibration dataset for IAA (0.0 disables; deployment-level only).
     """
@@ -92,6 +97,7 @@ class AnnotationSettings(ResolveSettings):
     production_min_submitted: PositiveInt = 1
     calibration_min_submitted: PositiveInt | None = 3
     locale: Locale = "en"
+    locale_catalog_dir: Path | None = None
     calibration_fraction: float = Field(0.1, ge=0.0, le=1.0)
     calibration_partition_seed: NonNegativeInt = 0
     include_discarded: bool = False
@@ -136,6 +142,13 @@ class AnnotationSettings(ResolveSettings):
             calibration_min_submitted=calibration,
             locale=locale,
         )
+
+    @field_validator("locale_catalog_dir", mode="after")
+    @classmethod
+    def _check_locale_catalog_dir_exists(cls, value: Path | None) -> Path | None:
+        if value is not None and not value.is_dir():
+            raise ValueError(f"locale_catalog_dir does not exist or is not a directory: {value}")
+        return value
 
     @model_validator(mode="after")
     def _validate_task_uniqueness(self) -> Self:

--- a/src/pragmata/core/settings/annotation_settings.py
+++ b/src/pragmata/core/settings/annotation_settings.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal, Self
 
-from pydantic import BaseModel, ConfigDict, DirectoryPath, Field, NonNegativeInt, PositiveInt, model_validator
+from pydantic import BaseModel, ConfigDict, Field, NonNegativeInt, PositiveInt, model_validator
 
 from pragmata.core.schemas.annotation_task import Locale, Task
 from pragmata.core.settings.settings_base import INHERIT, Inherit, ResolveSettings
@@ -97,7 +97,7 @@ class AnnotationSettings(ResolveSettings):
     production_min_submitted: PositiveInt = 1
     calibration_min_submitted: PositiveInt | None = 3
     locale: Locale = "en"
-    locale_catalog_dir: DirectoryPath | None = None
+    locale_catalog_dir: Path | None = None
     calibration_fraction: float = Field(0.1, ge=0.0, le=1.0)
     calibration_partition_seed: NonNegativeInt = 0
     include_discarded: bool = False

--- a/src/pragmata/core/settings/annotation_settings.py
+++ b/src/pragmata/core/settings/annotation_settings.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal, Self
 
-from pydantic import BaseModel, ConfigDict, Field, NonNegativeInt, PositiveInt, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, DirectoryPath, Field, NonNegativeInt, PositiveInt, model_validator
 
 from pragmata.core.schemas.annotation_task import Locale, Task
 from pragmata.core.settings.settings_base import INHERIT, Inherit, ResolveSettings
@@ -97,7 +97,7 @@ class AnnotationSettings(ResolveSettings):
     production_min_submitted: PositiveInt = 1
     calibration_min_submitted: PositiveInt | None = 3
     locale: Locale = "en"
-    locale_catalog_dir: Path | None = None
+    locale_catalog_dir: DirectoryPath | None = None
     calibration_fraction: float = Field(0.1, ge=0.0, le=1.0)
     calibration_partition_seed: NonNegativeInt = 0
     include_discarded: bool = False
@@ -142,13 +142,6 @@ class AnnotationSettings(ResolveSettings):
             calibration_min_submitted=calibration,
             locale=locale,
         )
-
-    @field_validator("locale_catalog_dir", mode="after")
-    @classmethod
-    def _check_locale_catalog_dir_exists(cls, value: Path | None) -> Path | None:
-        if value is not None and not value.is_dir():
-            raise ValueError(f"locale_catalog_dir does not exist or is not a directory: {value}")
-        return value
 
     @model_validator(mode="after")
     def _validate_task_uniqueness(self) -> Self:

--- a/tests/test_facade_lazy.py
+++ b/tests/test_facade_lazy.py
@@ -120,7 +120,6 @@ def test_dir_returns_public_surface() -> None:
         "IaaReport",
         "ImportResult",
         "Locale",
-        "SUPPORTED_LOCALES",
         "SetupResult",
         "Task",
         "UserSpec",

--- a/tests/unit/api/test_annotation.py
+++ b/tests/unit/api/test_annotation.py
@@ -288,6 +288,57 @@ class TestImportRecords:
 
         assert result.total_records == 1
 
+    @patch("pragmata.api.annotation_import.register_catalog_dir")
+    @patch("pragmata.api.annotation_import.fan_out_records")
+    def test_locale_catalog_dir_kwarg_registers(
+        self, mock_fan_out: MagicMock, mock_register: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_fan_out.return_value = {}
+        catalog_dir = tmp_path / "locales"
+        catalog_dir.mkdir()
+
+        import_records([], dataset_id="test", locale_catalog_dir=catalog_dir)
+
+        settings: AnnotationSettings = mock_fan_out.call_args[0][2]
+        assert settings.locale_catalog_dir == catalog_dir
+        mock_register.assert_called_once_with(catalog_dir)
+
+    @patch("pragmata.api.annotation_import.register_catalog_dir")
+    @patch("pragmata.api.annotation_import.fan_out_records")
+    def test_locale_catalog_dir_kwarg_overrides_config(
+        self, mock_fan_out: MagicMock, mock_register: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_fan_out.return_value = {}
+        config_dir = tmp_path / "config-locales"
+        config_dir.mkdir()
+        kwarg_dir = tmp_path / "kwarg-locales"
+        kwarg_dir.mkdir()
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(f"locale_catalog_dir: {config_dir}\n")
+
+        import_records([], dataset_id="test", config_path=config_path, locale_catalog_dir=kwarg_dir)
+
+        settings: AnnotationSettings = mock_fan_out.call_args[0][2]
+        assert settings.locale_catalog_dir == kwarg_dir
+        mock_register.assert_called_once_with(kwarg_dir)
+
+    @patch("pragmata.api.annotation_import.register_catalog_dir")
+    @patch("pragmata.api.annotation_import.fan_out_records")
+    def test_locale_catalog_dir_unset_falls_back_to_config(
+        self, mock_fan_out: MagicMock, mock_register: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_fan_out.return_value = {}
+        config_dir = tmp_path / "config-locales"
+        config_dir.mkdir()
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(f"locale_catalog_dir: {config_dir}\n")
+
+        import_records([], dataset_id="test", config_path=config_path)
+
+        settings: AnnotationSettings = mock_fan_out.call_args[0][2]
+        assert settings.locale_catalog_dir == config_dir
+        mock_register.assert_called_once_with(config_dir)
+
 
 class TestImportRecordsCalibrationValidation:
     """Hard-error semantics for calibration_fraction vs topology mismatch."""

--- a/tests/unit/cli/test_cli_annotation.py
+++ b/tests/unit/cli/test_cli_annotation.py
@@ -152,3 +152,32 @@ class TestImportCommandFlags:
         assert kwargs["calibration_partition_seed"] is UNSET
         assert kwargs["calibration_min_submitted"] is UNSET
         assert kwargs["calibration_fraction"] is UNSET
+
+    @patch("pragmata.annotation.import_records")
+    def test_locale_catalog_dir_threaded_through(self, mock_import, tmp_path):
+        mock_import.return_value = _empty_import_result()
+        records_file = tmp_path / "records.jsonl"
+        records_file.write_text("", encoding="utf-8")
+        catalog_dir = tmp_path / "locales"
+        catalog_dir.mkdir()
+
+        result = runner.invoke(
+            app,
+            ["annotation", "import", str(records_file), "--locale-catalog", str(catalog_dir)],
+        )
+
+        assert result.exit_code == 0
+        kwargs = mock_import.call_args.kwargs
+        assert kwargs["locale_catalog_dir"] == str(catalog_dir)
+
+    @patch("pragmata.annotation.import_records")
+    def test_locale_catalog_dir_default_is_unset(self, mock_import, tmp_path):
+        mock_import.return_value = _empty_import_result()
+        records_file = tmp_path / "records.jsonl"
+        records_file.write_text("", encoding="utf-8")
+
+        result = runner.invoke(app, ["annotation", "import", str(records_file)])
+
+        assert result.exit_code == 0
+        kwargs = mock_import.call_args.kwargs
+        assert kwargs["locale_catalog_dir"] is UNSET

--- a/tests/unit/cli/test_parsing.py
+++ b/tests/unit/cli/test_parsing.py
@@ -50,18 +50,16 @@ class TestParseLocale:
     def test_none_returns_none(self) -> None:
         assert parse_locale(None) is None
 
-    def test_valid_locale_en(self) -> None:
+    def test_normalises_string(self) -> None:
         assert parse_locale("en") == "en"
-
-    def test_valid_locale_de(self) -> None:
-        assert parse_locale("de") == "de"
 
     def test_whitespace_tolerant(self) -> None:
         assert parse_locale("  en  ") == "en"
 
-    def test_invalid_locale_raises(self) -> None:
-        with pytest.raises(ValueError, match="Unknown locale"):
-            parse_locale("xx")
+    def test_unknown_locale_not_rejected_here(self) -> None:
+        # Validation moved to the api layer (after user catalog directories
+        # are registered); parse_locale is now a pure normaliser.
+        assert parse_locale("xx") == "xx"
 
 
 class TestParseUserSpecs:

--- a/tests/unit/cli/test_parsing.py
+++ b/tests/unit/cli/test_parsing.py
@@ -57,8 +57,6 @@ class TestParseLocale:
         assert parse_locale("  en  ") == "en"
 
     def test_unknown_locale_not_rejected_here(self) -> None:
-        # Validation moved to the api layer (after user catalog directories
-        # are registered); parse_locale is now a pure normaliser.
         assert parse_locale("xx") == "xx"
 
 

--- a/tests/unit/core/annotation/test_locale_registry.py
+++ b/tests/unit/core/annotation/test_locale_registry.py
@@ -11,17 +11,13 @@ from pragmata.core.schemas.annotation_task import Task
 BUNDLED_EN = Path(registry.__file__).parent / "en.yaml"
 
 
-@pytest.fixture
-def isolated_catalogs():
-    """Restore CATALOGS after each test so registrations don't leak."""
-    snapshot = dict(registry.CATALOGS)
-    yield
-    registry.CATALOGS.clear()
-    registry.CATALOGS.update(snapshot)
+@pytest.fixture(autouse=True)
+def _isolate_catalogs(monkeypatch):
+    monkeypatch.setattr(registry, "CATALOGS", dict(registry.CATALOGS))
 
 
 class TestRegisterCatalogDir:
-    def test_adds_new_locale(self, tmp_path, isolated_catalogs):
+    def test_adds_new_locale(self, tmp_path):
         shutil.copy(BUNDLED_EN, tmp_path / "xx.yaml")
         assert "xx" not in registry.CATALOGS
 
@@ -29,7 +25,7 @@ class TestRegisterCatalogDir:
 
         assert registry.get_catalog("xx") == registry.get_catalog("en")
 
-    def test_user_overrides_bundled_on_stem_collision(self, tmp_path, isolated_catalogs):
+    def test_user_overrides_bundled_on_stem_collision(self, tmp_path):
         original = registry.get_catalog("en")[(Task.RETRIEVAL, "field", "query")]
         text = BUNDLED_EN.read_text(encoding="utf-8").replace("query: Query", "query: USER QUERY", 1)
         (tmp_path / "en.yaml").write_text(text, encoding="utf-8")
@@ -39,7 +35,7 @@ class TestRegisterCatalogDir:
         assert registry.get_catalog("en")[(Task.RETRIEVAL, "field", "query")] == "USER QUERY"
         assert original == "Query"
 
-    def test_idempotent(self, tmp_path, isolated_catalogs):
+    def test_idempotent(self, tmp_path):
         shutil.copy(BUNDLED_EN, tmp_path / "yy.yaml")
         registry.register_catalog_dir(tmp_path)
         first = dict(registry.CATALOGS)
@@ -48,7 +44,7 @@ class TestRegisterCatalogDir:
 
         assert registry.CATALOGS == first
 
-    def test_empty_dir_noop(self, tmp_path, isolated_catalogs):
+    def test_empty_dir_noop(self, tmp_path):
         before = dict(registry.CATALOGS)
 
         registry.register_catalog_dir(tmp_path)

--- a/tests/unit/core/annotation/test_locale_registry.py
+++ b/tests/unit/core/annotation/test_locale_registry.py
@@ -13,7 +13,12 @@ BUNDLED_EN = Path(registry.__file__).parent / "en.yaml"
 
 @pytest.fixture(autouse=True)
 def _isolate_catalogs(monkeypatch):
+    from pragmata.core.annotation.argilla_task_definitions import build_task_settings
+
     monkeypatch.setattr(registry, "CATALOGS", dict(registry.CATALOGS))
+    build_task_settings.cache_clear()
+    yield
+    build_task_settings.cache_clear()
 
 
 class TestRegisterCatalogDir:
@@ -50,3 +55,13 @@ class TestRegisterCatalogDir:
         registry.register_catalog_dir(tmp_path)
 
         assert registry.CATALOGS == before
+
+    def test_invalidates_build_task_settings_cache(self, tmp_path):
+        from pragmata.core.annotation.argilla_task_definitions import build_task_settings
+
+        build_task_settings("en")
+        assert build_task_settings.cache_info().currsize == 1
+
+        registry.register_catalog_dir(tmp_path)
+
+        assert build_task_settings.cache_info().currsize == 0

--- a/tests/unit/core/annotation/test_locale_registry.py
+++ b/tests/unit/core/annotation/test_locale_registry.py
@@ -1,0 +1,58 @@
+"""Unit tests for register_catalog_dir (user-provided locale catalogs)."""
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from pragmata.core.annotation.locales import registry
+from pragmata.core.schemas.annotation_task import Task
+
+BUNDLED_EN = Path(registry.__file__).parent / "en.yaml"
+
+
+@pytest.fixture
+def isolated_catalogs(monkeypatch):
+    """Restore CATALOGS after each test so registrations don't leak."""
+    snapshot = dict(registry.CATALOGS)
+    yield registry.CATALOGS
+    monkeypatch.setattr(registry, "CATALOGS", snapshot)
+    # Mutations went into the live dict; rebuild it from the snapshot in place.
+    registry.CATALOGS.clear()
+    registry.CATALOGS.update(snapshot)
+
+
+class TestRegisterCatalogDir:
+    def test_adds_new_locale(self, tmp_path, isolated_catalogs):
+        shutil.copy(BUNDLED_EN, tmp_path / "xx.yaml")
+        assert "xx" not in registry.CATALOGS
+
+        registry.register_catalog_dir(tmp_path)
+
+        assert registry.get_catalog("xx") == registry.get_catalog("en")
+
+    def test_user_overrides_bundled_on_stem_collision(self, tmp_path, isolated_catalogs):
+        original = registry.get_catalog("en")[(Task.RETRIEVAL, "field", "query")]
+        text = BUNDLED_EN.read_text(encoding="utf-8").replace("query: Query", "query: USER QUERY", 1)
+        (tmp_path / "en.yaml").write_text(text, encoding="utf-8")
+
+        registry.register_catalog_dir(tmp_path)
+
+        assert registry.get_catalog("en")[(Task.RETRIEVAL, "field", "query")] == "USER QUERY"
+        assert original == "Query"
+
+    def test_idempotent(self, tmp_path, isolated_catalogs):
+        shutil.copy(BUNDLED_EN, tmp_path / "yy.yaml")
+        registry.register_catalog_dir(tmp_path)
+        first = dict(registry.CATALOGS)
+
+        registry.register_catalog_dir(tmp_path)
+
+        assert registry.CATALOGS == first
+
+    def test_empty_dir_noop(self, tmp_path, isolated_catalogs):
+        before = dict(registry.CATALOGS)
+
+        registry.register_catalog_dir(tmp_path)
+
+        assert registry.CATALOGS == before

--- a/tests/unit/core/annotation/test_locale_registry.py
+++ b/tests/unit/core/annotation/test_locale_registry.py
@@ -12,12 +12,10 @@ BUNDLED_EN = Path(registry.__file__).parent / "en.yaml"
 
 
 @pytest.fixture
-def isolated_catalogs(monkeypatch):
+def isolated_catalogs():
     """Restore CATALOGS after each test so registrations don't leak."""
     snapshot = dict(registry.CATALOGS)
-    yield registry.CATALOGS
-    monkeypatch.setattr(registry, "CATALOGS", snapshot)
-    # Mutations went into the live dict; rebuild it from the snapshot in place.
+    yield
     registry.CATALOGS.clear()
     registry.CATALOGS.update(snapshot)
 

--- a/tests/unit/core/annotation/test_locale_registry.py
+++ b/tests/unit/core/annotation/test_locale_registry.py
@@ -65,3 +65,13 @@ class TestRegisterCatalogDir:
         registry.register_catalog_dir(tmp_path)
 
         assert build_task_settings.cache_info().currsize == 0
+
+    def test_missing_dir_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="locale_catalog_dir"):
+            registry.register_catalog_dir(tmp_path / "does-not-exist")
+
+    def test_file_path_raises(self, tmp_path):
+        not_a_dir = tmp_path / "file.yaml"
+        not_a_dir.write_text("")
+        with pytest.raises(ValueError, match="locale_catalog_dir"):
+            registry.register_catalog_dir(not_a_dir)

--- a/tests/unit/core/settings/test_annotation_settings.py
+++ b/tests/unit/core/settings/test_annotation_settings.py
@@ -109,23 +109,14 @@ class TestAnnotationSettingsResolve:
             AnnotationSettings(dataset_id=bad)
 
 
-class TestLocaleCatalogDirValidator:
+class TestLocaleCatalogDirField:
     def test_none_is_default(self):
         assert AnnotationSettings().locale_catalog_dir is None
 
-    def test_existing_dir_accepted(self, tmp_path):
-        s = AnnotationSettings(locale_catalog_dir=tmp_path)
-        assert s.locale_catalog_dir == tmp_path
-
-    def test_missing_dir_rejected(self, tmp_path):
-        with pytest.raises(ValidationError, match=r"locale_catalog_dir"):
-            AnnotationSettings(locale_catalog_dir=tmp_path / "does-not-exist")
-
-    def test_file_rejected(self, tmp_path):
-        f = tmp_path / "not-a-dir.yaml"
-        f.write_text("")
-        with pytest.raises(ValidationError, match=r"locale_catalog_dir"):
-            AnnotationSettings(locale_catalog_dir=f)
+    def test_path_accepted_without_existence_check(self, tmp_path):
+        # Existence is validated by the consumer (register_catalog_dir), not the field.
+        s = AnnotationSettings(locale_catalog_dir=tmp_path / "does-not-exist")
+        assert s.locale_catalog_dir == tmp_path / "does-not-exist"
 
 
 def _disabled_topology() -> dict[str, WorkspaceSettings]:

--- a/tests/unit/core/settings/test_annotation_settings.py
+++ b/tests/unit/core/settings/test_annotation_settings.py
@@ -109,6 +109,25 @@ class TestAnnotationSettingsResolve:
             AnnotationSettings(dataset_id=bad)
 
 
+class TestLocaleCatalogDirValidator:
+    def test_none_is_default(self):
+        assert AnnotationSettings().locale_catalog_dir is None
+
+    def test_existing_dir_accepted(self, tmp_path):
+        s = AnnotationSettings(locale_catalog_dir=tmp_path)
+        assert s.locale_catalog_dir == tmp_path
+
+    def test_missing_dir_rejected(self, tmp_path):
+        with pytest.raises(ValidationError, match=r"locale_catalog_dir"):
+            AnnotationSettings(locale_catalog_dir=tmp_path / "does-not-exist")
+
+    def test_file_rejected(self, tmp_path):
+        f = tmp_path / "not-a-dir.yaml"
+        f.write_text("")
+        with pytest.raises(ValidationError, match=r"locale_catalog_dir"):
+            AnnotationSettings(locale_catalog_dir=f)
+
+
 def _disabled_topology() -> dict[str, WorkspaceSettings]:
     """Workspaces where every task explicitly disables calibration."""
     return {


### PR DESCRIPTION
**Stack (7 PRs):** #206 → #196 → #207 → #219 → #208 → #209→  this PR 

## Goal

Allow deployments to add or override Argilla dataset locales by dropping `*.yaml` files into a user-provided directory, without modifying the installed `pragmata` package or having a Python toolchain. Closes the gap raised in #196 review: `Locale` is intentionally an open string, but catalog discovery had been bundled-only.

## Scope

- **`AnnotationSettings.locale_catalog_dir: DirectoryPath | None`** (deployment scope, default `None`). When set, `*.yaml` files in this directory are layered over the bundled catalogs at registration time; user files override bundled entries on stem collision (matches gettext / i18next layering convention). Pydantic `DirectoryPath` enforces the path exists and is a directory at settings construction.
- **`register_catalog_dir(directory)`** in `core/annotation/locales/registry.py`. Idempotent. Clears the downstream `build_task_settings` cache so a second `import_records` call in the same process sees fresh catalogs.
- **`api.annotation_import.import_records`** calls `register_catalog_dir` once after settings resolve, before any catalog lookup. This is the only api entrypoint that transitively reads catalogs (`import → fan_out_records → build_task_settings`); setup/teardown/export/iaa don't touch catalogs.
- **`get_catalog` now validates against the live `CATALOGS` dict** and raises `ValueError` with the supported set on miss. Replaces the old `SUPPORTED_LOCALES` frozenset (which was a snapshot taken at import - would go stale the moment a user registered their catalog dir, so CLI input validation against it would reject any user-registered locale).
- **`parse_locale` becomes a pure normaliser** (no validation). Validation lives at the data source (`get_catalog`) so it always sees user-registered catalogs without per-caller plumbing.

## Architectural decisions

- **Validation at data source, not api boundary.** Matches SOTA i18n (Rails I18n, i18next, Django) which throw at lookup time. `get_catalog` is called ~3 times per import (cached at `build_task_settings`), not a hot path, so the "validate at edges" cost-saving doesn't materialise. Coverage is automatic for any future caller.
- **Module-level mutable `CATALOGS` dict** (gettext-style) rather than a `CatalogRegistry` class. Pragmata is single-tenant CLI: no multi-instance, no concurrency. Class refactor would be over-engineering for current needs; revisit if/when library-mode or threading enters scope.
- **Per-entrypoint `register_catalog_dir` call** rather than hoisting into `Settings.resolve()`. Settings should be pure data; only one api entrypoint transitively needs catalogs, so per-entrypoint discipline is trivial here.

## Test plan

- [x] `tests/unit/core/annotation/test_locale_registry.py` - 5 tests covering: add new locale, override bundled on stem collision, idempotent re-registration, empty-dir noop, cache invalidation regression
- [x] `tests/unit/core/settings/test_annotation_settings.py::TestLocaleCatalogDirValidator` - 4 tests covering pydantic DirectoryPath behaviour
- [x] `tests/unit/cli/test_parsing.py::TestParseLocale` - updated to assert pure normalisation (no validation)
- [x] `uv run python -m pytest tests/unit` - 741 passed
- [x] `uv run ruff check src/pragmata tests` clean
- [x] `uv run mypy src/pragmata` clean

## References

- Closes the catalog-discovery gap raised in #196 review
- Independent of #209 (both touch `api/annotation_import.py` in different parts of the function; auto-merge clean either order)