### PR TITLE
feat: add settings models for eval workflows

### DIFF
--- a/src/pragmata/core/settings/eval_settings.py
+++ b/src/pragmata/core/settings/eval_settings.py
@@ -1,0 +1,91 @@
+"""Evaluation workflow settings."""
+
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from pydantic import Field
+
+from pragmata.core.schemas.annotation_task import Task
+from pragmata.core.settings.settings_base import ResolveSettings
+
+
+class EvalTrainSettings(ResolveSettings):
+    """Evaluator training settings.
+
+    Attributes:
+        base_dir: Workspace base directory. Pragmata resolves the eval tool root
+            under this directory and passes `<base_dir>/eval/` to tlmtc as its
+            training `work_dir`.
+        labeled_data_path: Optional direct path to labeled training data. Use this
+            for standalone eval training without relying on annotation-tool export
+            discovery. If omitted, the training workflow selects an annotation
+            export by `export_id` or falls back to the latest available export.
+        export_id: Optional annotation export identifier used to select a specific
+            exported annotation dataset. Ignored when `labeled_data_path` is
+            provided.
+        task: Annotation task to train an evaluator for. The task determines the
+            Pragmata-owned task mapping, serialization, labels, and internally
+            derived split-group column.
+        train_kwargs: Additional `train_tlmtc`-specific keyword arguments passed
+            through to the tlmtc API. Use this for tlmtc-owned options.
+    """
+
+    base_dir: Path = Field(default_factory=Path.cwd)
+    labeled_data_path: Path | None = None
+    export_id: str | None = None
+    task: Task
+    train_kwargs: dict[str, Any] = Field(default_factory=dict)
+
+
+class EvalPredictSettings(ResolveSettings):
+    """Evaluator prediction settings.
+
+    Attributes:
+        base_dir: Workspace base directory. Pragmata resolves the eval tool root
+            under this directory and passes `<base_dir>/eval/` to tlmtc as its
+            prediction `work_dir`.
+        unlabeled_data_path: Direct path to unlabeled data that should receive
+            predicted evaluation labels. Prediction input is intentionally explicit;
+            it is not inferred from prior tool outputs.
+        evaluator_run_id: Optional trained evaluator run identifier. This selects
+            the tlmtc training run to load. If omitted, tlmtc's default latest-run
+            lookup is used.
+        task: Annotation task to predict labels for. The task determines the
+            Pragmata-owned task mapping, serialization, labels, and output contract.
+        predict_kwargs: Additional `predict_tlmtc`-specific keyword arguments passed
+            through to the tlmtc API. Use this for tlmtc-owned options.
+    """
+
+    base_dir: Path = Field(default_factory=Path.cwd)
+    unlabeled_data_path: Path
+    evaluator_run_id: str | None = None
+    task: Task
+    predict_kwargs: dict[str, Any] = Field(default_factory=dict)
+
+
+class EvalScoreSettings(ResolveSettings):
+    """Evaluation scoring settings.
+
+    Attributes:
+        base_dir: Workspace base directory. Pragmata resolves score artifacts under
+            `<base_dir>/eval/scores/<score_id>/`.
+        score_id: Unique identifier for the score run. Used to name the
+            Pragmata-owned score artifact directory.
+        labeled_input_path: Optional direct path to labeled data to score. Use this
+            for standalone scoring, including human-labeled datasets or externally
+            prepared labeled records. If provided, it takes precedence over
+            `prediction_run_id`.
+        prediction_run_id: Optional Pragmata prediction run identifier. Use this to
+            score labels produced by `pragmata eval predict`. If omitted together
+            with `labeled_input_path`, the scoring workflow selects the latest
+            available prediction run.
+        task: Annotation task to score. The task determines which task-specific
+            label contract and score metrics are applied.
+    """
+
+    base_dir: Path = Field(default_factory=Path.cwd)
+    score_id: str = Field(default_factory=lambda: uuid4().hex)
+    labeled_input_path: Path | None = None
+    prediction_run_id: str | None = None
+    task: Task

--- a/tests/unit/core/settings/test_eval_settings.py
+++ b/tests/unit/core/settings/test_eval_settings.py
@@ -1,6 +1,7 @@
 """Unit tests for evaluation workflow settings."""
 
 from pathlib import Path
+from uuid import UUID
 
 import pytest
 from pydantic import BaseModel, ValidationError
@@ -12,7 +13,9 @@ from pragmata.core.settings.eval_settings import EvalPredictSettings, EvalScoreS
 def _assert_uuid_hex(value: str) -> None:
     """Assert that a value is a UUID4-style hex string."""
     assert len(value) == 32
-    assert int(value, 16) >= 0
+    parsed = UUID(hex=value)
+    assert parsed.version == 4
+    assert parsed.hex == value
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/core/settings/test_eval_settings.py
+++ b/tests/unit/core/settings/test_eval_settings.py
@@ -1,0 +1,217 @@
+"""Unit tests for evaluation workflow settings."""
+
+from pathlib import Path
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from pragmata.core.schemas.annotation_task import Task
+from pragmata.core.settings.eval_settings import EvalPredictSettings, EvalScoreSettings, EvalTrainSettings
+
+
+def _assert_uuid_hex(value: str) -> None:
+    """Assert that a value is a UUID4-style hex string."""
+    assert len(value) == 32
+    assert int(value, 16) >= 0
+
+
+@pytest.mark.parametrize(
+    ("model_cls", "payload", "expected_message"),
+    [
+        pytest.param(
+            EvalTrainSettings,
+            {},
+            "Field required",
+            id="train-requires-task",
+        ),
+        pytest.param(
+            EvalPredictSettings,
+            {"task": "retrieval"},
+            "Field required",
+            id="predict-requires-unlabeled-data-path",
+        ),
+        pytest.param(
+            EvalPredictSettings,
+            {"unlabeled_data_path": "data/unlabeled.csv"},
+            "Field required",
+            id="predict-requires-task",
+        ),
+        pytest.param(
+            EvalScoreSettings,
+            {},
+            "Field required",
+            id="score-requires-task",
+        ),
+        pytest.param(
+            EvalTrainSettings,
+            {"task": "retrieval", "run_id": "not-a-pragmata-train-setting"},
+            "Extra inputs are not permitted",
+            id="train-rejects-extra-fields",
+        ),
+        pytest.param(
+            EvalPredictSettings,
+            {
+                "unlabeled_data_path": "data/unlabeled.csv",
+                "task": "retrieval",
+                "run_id": "not-a-pragmata-predict-setting",
+            },
+            "Extra inputs are not permitted",
+            id="predict-rejects-extra-fields",
+        ),
+        pytest.param(
+            EvalScoreSettings,
+            {"task": "retrieval", "label_source": "predicted"},
+            "Extra inputs are not permitted",
+            id="score-rejects-extra-fields",
+        ),
+    ],
+)
+def test_eval_settings_validation_constraints(
+    model_cls: type[BaseModel],
+    payload: dict[str, object],
+    expected_message: str,
+) -> None:
+    """Eval settings enforce required fields and reject undeclared top-level fields."""
+    with pytest.raises(ValidationError, match=expected_message):
+        model_cls.model_validate(payload)
+
+
+def test_eval_train_settings_construction_with_defaults() -> None:
+    """EvalTrainSettings applies train-level defaults when task is provided."""
+    settings = EvalTrainSettings.model_validate({"task": "retrieval"})
+
+    assert settings.base_dir == Path.cwd()
+    assert settings.labeled_data_path is None
+    assert settings.export_id is None
+    assert settings.task == Task.RETRIEVAL
+    assert settings.train_kwargs == {}
+
+
+def test_eval_train_settings_accepts_labeled_data_path() -> None:
+    """EvalTrainSettings accepts a direct labeled data path."""
+    settings = EvalTrainSettings.model_validate(
+        {
+            "labeled_data_path": "data/labeled.csv",
+            "task": "grounding",
+        }
+    )
+
+    assert settings.labeled_data_path == Path("data/labeled.csv")
+    assert settings.task == Task.GROUNDING
+
+
+def test_eval_train_settings_accepts_export_id_and_train_kwargs() -> None:
+    """EvalTrainSettings accepts annotation export selection and tlmtc train kwargs."""
+    settings = EvalTrainSettings.model_validate(
+        {
+            "export_id": "export-001",
+            "task": "generation",
+            "train_kwargs": {
+                "run_id": "custom-train-run",
+                "batch_size": 8,
+            },
+        }
+    )
+
+    assert settings.export_id == "export-001"
+    assert settings.task == Task.GENERATION
+    assert settings.train_kwargs == {
+        "run_id": "custom-train-run",
+        "batch_size": 8,
+    }
+
+
+def test_eval_predict_settings_construction_with_defaults() -> None:
+    """EvalPredictSettings applies predict-level defaults when required fields are provided."""
+    settings = EvalPredictSettings.model_validate(
+        {
+            "unlabeled_data_path": "data/unlabeled.csv",
+            "task": "retrieval",
+        }
+    )
+
+    assert settings.base_dir == Path.cwd()
+    assert settings.unlabeled_data_path == Path("data/unlabeled.csv")
+    assert settings.evaluator_run_id is None
+    assert settings.task == Task.RETRIEVAL
+    assert settings.predict_kwargs == {}
+
+
+def test_eval_predict_settings_accepts_evaluator_run_id_and_predict_kwargs() -> None:
+    """EvalPredictSettings accepts evaluator selection and tlmtc predict kwargs."""
+    settings = EvalPredictSettings.model_validate(
+        {
+            "unlabeled_data_path": "data/unlabeled.csv",
+            "evaluator_run_id": "train-run-001",
+            "task": "grounding",
+            "predict_kwargs": {
+                "batch_size": 32,
+                "use_cpu": True,
+            },
+        }
+    )
+
+    assert settings.unlabeled_data_path == Path("data/unlabeled.csv")
+    assert settings.evaluator_run_id == "train-run-001"
+    assert settings.task == Task.GROUNDING
+    assert settings.predict_kwargs == {
+        "batch_size": 32,
+        "use_cpu": True,
+    }
+
+
+def test_eval_score_settings_construction_with_labeled_input_path() -> None:
+    """EvalScoreSettings accepts a direct labeled input path."""
+    settings = EvalScoreSettings.model_validate(
+        {
+            "labeled_input_path": "data/labeled.csv",
+            "task": "retrieval",
+        }
+    )
+
+    assert settings.base_dir == Path.cwd()
+    assert settings.score_id
+    assert settings.labeled_input_path == Path("data/labeled.csv")
+    assert settings.prediction_run_id is None
+    assert settings.task == Task.RETRIEVAL
+
+
+def test_eval_score_settings_construction_with_prediction_run_id() -> None:
+    """EvalScoreSettings accepts a prediction run selector."""
+    settings = EvalScoreSettings.model_validate(
+        {
+            "prediction_run_id": "prediction-run-001",
+            "task": "grounding",
+        }
+    )
+
+    assert settings.base_dir == Path.cwd()
+    assert settings.score_id
+    assert settings.labeled_input_path is None
+    assert settings.prediction_run_id == "prediction-run-001"
+    assert settings.task == Task.GROUNDING
+
+
+def test_eval_score_settings_generates_distinct_score_ids() -> None:
+    """EvalScoreSettings generates a default score_id for each instance."""
+    first = EvalScoreSettings.model_validate({"task": "retrieval"})
+    second = EvalScoreSettings.model_validate({"task": "retrieval"})
+
+    assert first.score_id != second.score_id
+    _assert_uuid_hex(first.score_id)
+    _assert_uuid_hex(second.score_id)
+
+
+def test_eval_score_settings_resolve_score_id_override_precedence() -> None:
+    """Resolve applies explicit score_id overrides over config values."""
+    resolved = EvalScoreSettings.resolve(
+        config={
+            "score_id": "score-config",
+            "task": "retrieval",
+        },
+        overrides={
+            "score_id": "score-override",
+        },
+    )
+
+    assert resolved.score_id == "score-override"


### PR DESCRIPTION
### Summary

Adds the initial eval settings models for training evaluator models, predicting labels, and scoring labeled evaluation data. The settings define the Pragmata-owned configuration surface while keeping tlmtc-specific training and prediction options behind explicit pass-through kwargs.

### Key changes

- Add `EvalTrainSettings`
  - Selects `base_dir`, `labeled_data_path`, `export_id`, and `task`
  - Supports `train_kwargs` for `train_tlmtc`-specific options
- Add `EvalPredictSettings`
  - Selects `base_dir`, `unlabeled_data_path`, `evaluator_run_id`, and `task`
  - Supports `predict_kwargs` for `predict_tlmtc`-specific options
- Add `EvalScoreSettings`
  - Selects `base_dir`, `score_id`, `labeled_input_path`, `prediction_run_id`, and `task`
  - Keeps scoring independent of tlmtc
- Reuse the existing annotation `Task` enum for retrieval, grounding, and generation

**Tests**

- Add unit tests for eval settings construction and validation.
- Verify that undeclared top-level fields such as `run_id` and `label_source` are rejected.
- Verify that `train_kwargs` and `predict_kwargs` are accepted as pass-through dictionaries.
- Verify that default `score_id` values are distinct UUID-style hex strings.