### PR TITLE
feat(cli): expose querygen runtime and throttle options

### DIFF
--- a/src/pragmata/cli/commands/querygen.py
+++ b/src/pragmata/cli/commands/querygen.py
@@ -93,10 +93,10 @@ def gen_queries_command(
         "--near-duplicate-tolerance",
         help="Similarity tolerance for near-duplicate blueprint removal. Accepts a float in (0, 1].",
     ),
-    no_planning_memory: bool = typer.Option(
-        False,
-        "--no-planning-memory",
-        help="Disable planning memory across runs. Accepts a flag.",
+    enable_planning_memory: bool | None = typer.Option(
+        None,
+        "--enable-planning-memory/--no-enable-planning-memory",
+        help="Enable or disable planning memory for the run. Accepts a boolean flag.",
     ),
 ) -> None:
     """Prepare a synthetic query generation run."""
@@ -125,7 +125,7 @@ def gen_queries_command(
         max_bucket_size=UNSET if max_bucket_size is None else max_bucket_size,
         batch_size=UNSET if batch_size is None else batch_size,
         near_duplicate_tolerance=UNSET if near_duplicate_tolerance is None else near_duplicate_tolerance,
-        enable_planning_memory=False if no_planning_memory else UNSET,
+        enable_planning_memory=UNSET if enable_planning_memory is None else enable_planning_memory,
     )
 
     typer.echo("Synthetic query generation run prepared.")

--- a/src/pragmata/cli/commands/querygen.py
+++ b/src/pragmata/cli/commands/querygen.py
@@ -93,10 +93,10 @@ def gen_queries_command(
         "--near-duplicate-tolerance",
         help="Similarity tolerance for near-duplicate blueprint removal. Accepts a float in (0, 1].",
     ),
-    enable_planning_memory: bool | None = typer.Option(
-        None,
-        "--enable-planning-memory/--no-enable-planning-memory",
-        help="Enable or disable planning memory for the run. Accepts a boolean flag.",
+    no_planning_memory: bool = typer.Option(
+        False,
+        "--no-planning-memory",
+        help="Disable planning memory across runs. Accepts a flag.",
     ),
 ) -> None:
     """Prepare a synthetic query generation run."""
@@ -125,7 +125,7 @@ def gen_queries_command(
         max_bucket_size=UNSET if max_bucket_size is None else max_bucket_size,
         batch_size=UNSET if batch_size is None else batch_size,
         near_duplicate_tolerance=UNSET if near_duplicate_tolerance is None else near_duplicate_tolerance,
-        enable_planning_memory=UNSET if enable_planning_memory is None else enable_planning_memory,
+        enable_planning_memory=False if no_planning_memory else UNSET,
     )
 
     typer.echo("Synthetic query generation run prepared.")

--- a/src/pragmata/cli/commands/querygen.py
+++ b/src/pragmata/cli/commands/querygen.py
@@ -68,6 +68,36 @@ def gen_queries_command(
         "--realization-model-kwargs",
         help="Additional realization-stage model keyword arguments. Accepts a JSON object.",
     ),
+    requests_per_second: float | None = typer.Option(
+        None,
+        "--requests-per-second",
+        help="Maximum LLM requests per second for the rate limiter. Accepts a positive float.",
+    ),
+    check_every_n_seconds: float | None = typer.Option(
+        None,
+        "--check-every-n-seconds",
+        help="Interval at which the LLM rate limiter checks for capacity. Accepts a positive float.",
+    ),
+    max_bucket_size: int | None = typer.Option(
+        None,
+        "--max-bucket-size",
+        help="Maximum burst size for the LLM rate limiter. Accepts a positive integer.",
+    ),
+    batch_size: int | None = typer.Option(
+        None,
+        "--batch-size",
+        help="Number of queries to generate per LLM call. Accepts a positive integer.",
+    ),
+    near_duplicate_tolerance: float | None = typer.Option(
+        None,
+        "--near-duplicate-tolerance",
+        help="Similarity tolerance for near-duplicate blueprint removal. Accepts a float in (0, 1].",
+    ),
+    enable_planning_memory: bool | None = typer.Option(
+        None,
+        "--enable-planning-memory/--no-enable-planning-memory",
+        help="Enable or disable planning memory for the run. Accepts a boolean flag.",
+    ),
 ) -> None:
     """Prepare a synthetic query generation run."""
     result = querygen.gen_queries(
@@ -90,6 +120,12 @@ def gen_queries_command(
         base_url=UNSET if base_url is None else base_url,
         planning_model_kwargs=parse_cli_value(planning_model_kwargs),
         realization_model_kwargs=parse_cli_value(realization_model_kwargs),
+        requests_per_second=UNSET if requests_per_second is None else requests_per_second,
+        check_every_n_seconds=UNSET if check_every_n_seconds is None else check_every_n_seconds,
+        max_bucket_size=UNSET if max_bucket_size is None else max_bucket_size,
+        batch_size=UNSET if batch_size is None else batch_size,
+        near_duplicate_tolerance=UNSET if near_duplicate_tolerance is None else near_duplicate_tolerance,
+        enable_planning_memory=UNSET if enable_planning_memory is None else enable_planning_memory,
     )
 
     typer.echo("Synthetic query generation run prepared.")

--- a/tests/unit/cli/test_cli_querygen.py
+++ b/tests/unit/cli/test_cli_querygen.py
@@ -1,5 +1,6 @@
 """Tests CLI command for synthetic query generation."""
 
+import re
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -8,6 +9,12 @@ from pragmata.api import UNSET
 from pragmata.cli.app import app
 
 runner = CliRunner()
+
+ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def strip_ansi(text: str) -> str:
+    return ANSI_ESCAPE_RE.sub("", text)
 
 
 class _PreparedResult:
@@ -30,10 +37,24 @@ def test_querygen_command_registered() -> None:
     assert "querygen" in result.output
 
 
-def test_querygen_gen_queries_help_available() -> None:
-    result = runner.invoke(app, ["querygen", "gen-queries", "--help"])
+def test_querygen_gen_queries_help_available(monkeypatch) -> None:
+    monkeypatch.setenv("COLUMNS", "200")
+    result = runner.invoke(app, ["querygen", "gen-queries", "--help"], color=False)
+    output = strip_ansi(result.output)
 
     assert result.exit_code == 0
+    assert "Prepare a synthetic query generation run." in output
+    assert "--domains" in output
+    assert "--run-id" in output
+    assert "--planning-model-kwargs" in output
+    assert "--realization-model-kwargs" in output
+    assert "--requests-per-second" in output
+    assert "--check-every-n-seconds" in output
+    assert "--max-bucket-size" in output
+    assert "--batch-size" in output
+    assert "--near-duplicate-tolerance" in output
+    assert "--enable-planning-memory" in output
+    assert "--no-enable-planning-memory" in output
 
 
 def test_querygen_cli_delegates_to_public_api(monkeypatch) -> None:

--- a/tests/unit/cli/test_cli_querygen.py
+++ b/tests/unit/cli/test_cli_querygen.py
@@ -141,7 +141,7 @@ def test_querygen_cli_forwards_runtime_and_throttle_options(monkeypatch) -> None
             "8",
             "--near-duplicate-tolerance",
             "0.8",
-            "--no-planning-memory",
+            "--no-enable-planning-memory",
         ],
     )
 
@@ -152,6 +152,21 @@ def test_querygen_cli_forwards_runtime_and_throttle_options(monkeypatch) -> None
     assert captured["batch_size"] == 8
     assert captured["near_duplicate_tolerance"] == 0.8
     assert captured["enable_planning_memory"] is False
+
+
+def test_querygen_cli_enable_planning_memory_flag_true(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_gen_queries(**kwargs):
+        captured.update(kwargs)
+        return _PreparedResult()
+
+    monkeypatch.setattr("pragmata.querygen.gen_queries", fake_gen_queries)
+
+    result = runner.invoke(app, ["querygen", "gen-queries", "--enable-planning-memory"])
+
+    assert result.exit_code == 0
+    assert captured["enable_planning_memory"] is True
 
 
 def test_querygen_cli_prints_prepared_run_summary(monkeypatch) -> None:

--- a/tests/unit/cli/test_cli_querygen.py
+++ b/tests/unit/cli/test_cli_querygen.py
@@ -1,6 +1,5 @@
 """Tests CLI command for synthetic query generation."""
 
-import re
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -9,12 +8,6 @@ from pragmata.api import UNSET
 from pragmata.cli.app import app
 
 runner = CliRunner()
-
-ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
-
-
-def strip_ansi(text: str) -> str:
-    return ANSI_ESCAPE_RE.sub("", text)
 
 
 class _PreparedResult:
@@ -37,24 +30,10 @@ def test_querygen_command_registered() -> None:
     assert "querygen" in result.output
 
 
-def test_querygen_gen_queries_help_available(monkeypatch) -> None:
-    monkeypatch.setenv("COLUMNS", "200")
-    result = runner.invoke(app, ["querygen", "gen-queries", "--help"], color=False)
-    output = strip_ansi(result.output)
+def test_querygen_gen_queries_help_available() -> None:
+    result = runner.invoke(app, ["querygen", "gen-queries", "--help"])
 
     assert result.exit_code == 0
-    assert "Prepare a synthetic query generation run." in output
-    assert "--domains" in output
-    assert "--run-id" in output
-    assert "--planning-model-kwargs" in output
-    assert "--realization-model-kwargs" in output
-    assert "--requests-per-second" in output
-    assert "--check-every-n-seconds" in output
-    assert "--max-bucket-size" in output
-    assert "--batch-size" in output
-    assert "--near-duplicate-tolerance" in output
-    assert "--enable-planning-memory" in output
-    assert "--no-enable-planning-memory" in output
 
 
 def test_querygen_cli_delegates_to_public_api(monkeypatch) -> None:

--- a/tests/unit/cli/test_cli_querygen.py
+++ b/tests/unit/cli/test_cli_querygen.py
@@ -141,7 +141,7 @@ def test_querygen_cli_forwards_runtime_and_throttle_options(monkeypatch) -> None
             "8",
             "--near-duplicate-tolerance",
             "0.8",
-            "--no-enable-planning-memory",
+            "--no-planning-memory",
         ],
     )
 
@@ -152,21 +152,6 @@ def test_querygen_cli_forwards_runtime_and_throttle_options(monkeypatch) -> None
     assert captured["batch_size"] == 8
     assert captured["near_duplicate_tolerance"] == 0.8
     assert captured["enable_planning_memory"] is False
-
-
-def test_querygen_cli_enable_planning_memory_flag_true(monkeypatch) -> None:
-    captured: dict[str, object] = {}
-
-    def fake_gen_queries(**kwargs):
-        captured.update(kwargs)
-        return _PreparedResult()
-
-    monkeypatch.setattr("pragmata.querygen.gen_queries", fake_gen_queries)
-
-    result = runner.invoke(app, ["querygen", "gen-queries", "--enable-planning-memory"])
-
-    assert result.exit_code == 0
-    assert captured["enable_planning_memory"] is True
 
 
 def test_querygen_cli_prints_prepared_run_summary(monkeypatch) -> None:

--- a/tests/unit/cli/test_cli_querygen.py
+++ b/tests/unit/cli/test_cli_querygen.py
@@ -37,7 +37,8 @@ def test_querygen_command_registered() -> None:
     assert "querygen" in result.output
 
 
-def test_querygen_gen_queries_help_available() -> None:
+def test_querygen_gen_queries_help_available(monkeypatch) -> None:
+    monkeypatch.setenv("COLUMNS", "200")
     result = runner.invoke(app, ["querygen", "gen-queries", "--help"], color=False)
     output = strip_ansi(result.output)
 
@@ -47,6 +48,13 @@ def test_querygen_gen_queries_help_available() -> None:
     assert "--run-id" in output
     assert "--planning-model-kwargs" in output
     assert "--realization-model-kwargs" in output
+    assert "--requests-per-second" in output
+    assert "--check-every-n-seconds" in output
+    assert "--max-bucket-size" in output
+    assert "--batch-size" in output
+    assert "--near-duplicate-tolerance" in output
+    assert "--enable-planning-memory" in output
+    assert "--no-enable-planning-memory" in output
 
 
 def test_querygen_cli_delegates_to_public_api(monkeypatch) -> None:
@@ -115,6 +123,12 @@ def test_querygen_cli_maps_omitted_options_to_unset(monkeypatch) -> None:
         "base_url",
         "planning_model_kwargs",
         "realization_model_kwargs",
+        "requests_per_second",
+        "check_every_n_seconds",
+        "max_bucket_size",
+        "batch_size",
+        "near_duplicate_tolerance",
+        "enable_planning_memory",
     }
 
     assert result.exit_code == 0
@@ -122,6 +136,58 @@ def test_querygen_cli_maps_omitted_options_to_unset(monkeypatch) -> None:
 
     for key in expected_keys:
         assert captured[key] is UNSET
+
+
+def test_querygen_cli_forwards_runtime_and_throttle_options(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_gen_queries(**kwargs):
+        captured.update(kwargs)
+        return _PreparedResult()
+
+    monkeypatch.setattr("pragmata.querygen.gen_queries", fake_gen_queries)
+
+    result = runner.invoke(
+        app,
+        [
+            "querygen",
+            "gen-queries",
+            "--requests-per-second",
+            "5.5",
+            "--check-every-n-seconds",
+            "0.25",
+            "--max-bucket-size",
+            "10",
+            "--batch-size",
+            "8",
+            "--near-duplicate-tolerance",
+            "0.8",
+            "--no-enable-planning-memory",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["requests_per_second"] == 5.5
+    assert captured["check_every_n_seconds"] == 0.25
+    assert captured["max_bucket_size"] == 10
+    assert captured["batch_size"] == 8
+    assert captured["near_duplicate_tolerance"] == 0.8
+    assert captured["enable_planning_memory"] is False
+
+
+def test_querygen_cli_enable_planning_memory_flag_true(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_gen_queries(**kwargs):
+        captured.update(kwargs)
+        return _PreparedResult()
+
+    monkeypatch.setattr("pragmata.querygen.gen_queries", fake_gen_queries)
+
+    result = runner.invoke(app, ["querygen", "gen-queries", "--enable-planning-memory"])
+
+    assert result.exit_code == 0
+    assert captured["enable_planning_memory"] is True
 
 
 def test_querygen_cli_prints_prepared_run_summary(monkeypatch) -> None:


### PR DESCRIPTION
## Summary


- wires six `QueryGenRunSettings` knobs to the `pragmata querygen gen-queries` Typer CLI that were previously dropped silently when passed via API kwargs.
- CLI users can now tune rate limiting, batch sizing, near-duplicate tolerance, and planning memory without hand-writing a config file / can script them.
- 3 clearly earn keep as per-run operator overrides (i.e. settings operators commonly want to override per run without editing YAML: batch size, near-duplicate tolerance, planning-memory feature flags); the other 3 are rate-limiting knobs that sit on the borderline scheduler knobs included for completeness.
- If we go with all of them this closes the CLI/Python-API parity gap: every keyword accepted by `pragmata.api.querygen.gen_queries` now has a matching CLI flag.

## Changes

- `src/pragmata/cli/commands/querygen.py`: adds six Typer options (`--requests-per-second`, `--check-every-n-seconds`, `--max-bucket-size`, `--batch-size`, `--near-duplicate-tolerance`, `--enable-planning-memory/--no-enable-planning-memory`) and forwards them to `querygen.gen_queries(...)` using the existing `UNSET if x is None else x` pattern.
- `tests/unit/cli/test_cli_querygen.py`: expands the omitted-options assertion from 19 to 25 forwarded kwargs; adds a test that round-trips each new flag through to the API call; adds a separate test asserting `--enable-planning-memory` toggles to `True`; updates the help-text test to cover the new options and pins `COLUMNS=200` so wider help output isn't truncated by the runner.

## Test plan

- [x] `uv run pytest tests/unit/cli/test_cli_querygen.py -x` — 7 passed
- [x] `uv run pytest tests/unit/cli/ -x` — 34 passed
- [x] `uv run ruff format` + `uv run ruff check` clean on both edited files
- [x] `uv run mypy src/pragmata/cli/commands/querygen.py` — no issues
- [x] CI: lint, type-check, full test suite