### PR TITLE
feat(annotation): annotator-time constraint feedback widget

### DIFF
--- a/docs/design/annotation-interface.md
+++ b/docs/design/annotation-interface.md
@@ -176,10 +176,19 @@ Hidden questions persist discard data on the discarded response so it is availab
 
 **Implementation note:** The CustomField uses `srcdoc`-rendered iframe with same-origin parent DOM access (`window.parent.document`). DOM selectors (`[data-question-name="..."]`, `.button--discard`) may need re-verification on Argilla upgrades.
 
+### Annotation-time constraint feedback
+
+The same logical constraints validated at export time (see [Annotation Protocol](../methodology/annotation-protocol.md)) also drive a live annotator-facing widget. A `constraints_panel` `rg.CustomField` is added to each task whose protocol defines rules; it mirrors the discard-panel pattern (srcdoc iframe, same-origin parent DOM access). On every mutation of the record form, it re-evaluates each rule against the currently-selected chip values for the relevant questions and either:
+
+- **Warns** (yellow banner) — inline explanation, submission still allowed; for soft/heuristic constraints
+- **Blocks** (red banner + native Submit button disabled) — submission is prevented until the violation is resolved; for hard logical constraints
+
+Both consumers (export-time Python checks and annotation-time JS widget) read from one declarative rule list (`pragmata.core.annotation.logical_constraints.LOGICAL_CONSTRAINTS`), so they cannot drift.
+
 
 ## Design Rationale
 
-**Joint labelling:** Argilla v2 does not support conditional question logic or grouping headers. Custom progressive disclosure would require building a frontend, which is out of scope. Joint labelling is the accepted limitation.
+**Joint labelling:** Argilla v2 does not support conditional question logic or grouping headers. Custom progressive disclosure would require building a frontend, which is out of scope. Joint labelling is the accepted limitation; logical consistency between answers is instead enforced by the annotation-time constraint widget described above, not by hiding questions.
 
 **Visibility contract:** Primary content is the minimal unit needed for the labelling task. Supporting context is included to aid consistency but kept secondary to reduce anchoring bias on the primary judgement.
 

--- a/src/pragmata/core/annotation/argilla_task_definitions.py
+++ b/src/pragmata/core/annotation/argilla_task_definitions.py
@@ -17,7 +17,6 @@ setting controlled by AnnotationSettings.workspaces and applied at
 dataset creation time.
 """
 
-import functools
 import json
 from importlib.resources import files
 from string import Template
@@ -28,7 +27,9 @@ import argilla as rg
 from pragmata.core.annotation.locales.loader import DISCARD_WIDGET_KEYS
 from pragmata.core.annotation.locales.registry import CATALOGS, get_catalog
 from pragmata.core.annotation.locales.types import Catalog, CatalogKind
+from pragmata.core.annotation.logical_constraints import LOGICAL_CONSTRAINTS
 from pragmata.core.schemas.annotation_task import DiscardReason, Locale, Task
+from pragmata.core.settings.annotation_settings import AnnotationSettings
 
 
 class _DiscardTemplate(Template):
@@ -42,6 +43,16 @@ class _DiscardTemplate(Template):
     """
 
     delimiter = "@@"
+
+
+# Static placeholder values seeded on every record for widget-only CustomFields.
+# Argilla's frontend silently skips rendering a CustomField when the record has
+# no value for that field, so even pure UI widgets need a placeholder. This is
+# the SSOT mirror of the widget CustomField names below.
+WIDGET_FIELD_PLACEHOLDERS: dict[str, dict[str, str]] = {
+    "discard_flow": {"text": ""},
+    "constraints_panel": {"text": ""},
+}
 
 
 DATASET_NAMES: dict[Task, str] = {
@@ -140,16 +151,36 @@ def _render_discard_template(template_text: str, task: Task, dataset_locale: Loc
     )
 
 
-@functools.cache
-def build_task_settings(locale: Locale = "en") -> dict[Task, rg.Settings]:
+def _render_constraints_template(task: Task, questions: list, template_text: str, settings: AnnotationSettings) -> str:
+    """Substitute the constraint + question-title payload into ``constraints_field.html``.
+
+    Each constraint's payload severity is the deployment-scope value from
+    ``settings.constraint_severity``.
+    """
+    constraints = LOGICAL_CONSTRAINTS[task]
+    referenced = {q for c in constraints for q in (c.when_question, c.then_question)}
+    titles = {q.name: q.title for q in questions if isinstance(q, rg.LabelQuestion) and q.name in referenced}
+    payloads = [c.to_widget_payload(settings.constraint_severity[c.constraint_id]) for c in constraints]
+    return Template(template_text).substitute(
+        CONSTRAINTS_JSON=json.dumps(payloads, ensure_ascii=False),
+        QUESTION_TITLES_JSON=json.dumps(titles, ensure_ascii=False),
+    )
+
+
+def build_task_settings(settings: AnnotationSettings, locale: Locale = "en") -> dict[Task, rg.Settings]:
     """Build Argilla Settings for each annotation task, in the given locale.
 
-    Deferred construction — call after an Argilla client is connected
-    (or with a mock client in tests). Cached per locale after first call.
+    Not cached: result depends on ``settings.constraint_severity``, so callers
+    should hold the returned dict for the duration of an import operation
+    rather than calling repeatedly. Deferred construction: call after an
+    Argilla client is connected (or with a mock client in tests).
     """
     catalog = get_catalog(locale)
     template_text = files("pragmata.core.annotation").joinpath("collapsible_field.html").read_text(encoding="utf-8")
     discard_template = files("pragmata.core.annotation").joinpath("discard_flow.html").read_text(encoding="utf-8")
+    constraints_template = (
+        files("pragmata.core.annotation").joinpath("constraints_field.html").read_text(encoding="utf-8")
+    )
 
     # Fresh CustomField per task — FieldBase carries a `_dataset` attribute that
     # Argilla's Settings/Dataset plumbing mutates, so sharing one instance across
@@ -163,11 +194,117 @@ def build_task_settings(locale: Locale = "en") -> dict[Task, rg.Settings]:
             required=False,
         )
 
+    def constraints_field(task: Task, questions: list) -> rg.CustomField:
+        # Always present on every task. Argilla requires every CustomField to
+        # have a value on every record; WIDGET_FIELD_PLACEHOLDERS supplies one
+        # for `constraints_panel`. When LOGICAL_CONSTRAINTS[task] is empty the
+        # widget evaluates to no hits and stays hidden.
+        return rg.CustomField(
+            name="constraints_panel",
+            title="Constraint checks",
+            template=_render_constraints_template(task, questions, constraints_template, settings),
+            advanced_mode=True,
+            required=False,
+        )
+
     def t(task: Task, kind: CatalogKind, name: str) -> str:
         return catalog[(task, kind, name)]
 
     def _yes_no(task: Task, question: str) -> dict[str, str]:
         return _localised_labels(catalog, task, question, ["yes", "no"])
+
+    retrieval_questions: list = [
+        rg.LabelQuestion(
+            name="topically_relevant",
+            title=t(Task.RETRIEVAL, "question", "topically_relevant"),
+            labels=_yes_no(Task.RETRIEVAL, "topically_relevant"),
+            required=True,
+        ),
+        rg.LabelQuestion(
+            name="evidence_sufficient",
+            title=t(Task.RETRIEVAL, "question", "evidence_sufficient"),
+            labels=_yes_no(Task.RETRIEVAL, "evidence_sufficient"),
+            required=True,
+        ),
+        rg.LabelQuestion(
+            name="misleading",
+            title=t(Task.RETRIEVAL, "question", "misleading"),
+            labels=_yes_no(Task.RETRIEVAL, "misleading"),
+            required=True,
+        ),
+        rg.TextQuestion(name="notes", title=t(Task.RETRIEVAL, "question", "notes"), required=False),
+        *_discard_questions(Task.RETRIEVAL, catalog),
+    ]
+
+    grounding_questions: list = [
+        rg.LabelQuestion(
+            name="support_present",
+            title=t(Task.GROUNDING, "question", "support_present"),
+            labels=_yes_no(Task.GROUNDING, "support_present"),
+            required=True,
+        ),
+        rg.LabelQuestion(
+            name="unsupported_claim_present",
+            title=t(Task.GROUNDING, "question", "unsupported_claim_present"),
+            labels=_yes_no(Task.GROUNDING, "unsupported_claim_present"),
+            required=True,
+        ),
+        rg.LabelQuestion(
+            name="contradicted_claim_present",
+            title=t(Task.GROUNDING, "question", "contradicted_claim_present"),
+            labels=_yes_no(Task.GROUNDING, "contradicted_claim_present"),
+            required=True,
+        ),
+        rg.LabelQuestion(
+            name="source_cited",
+            title=t(Task.GROUNDING, "question", "source_cited"),
+            labels=_yes_no(Task.GROUNDING, "source_cited"),
+            required=True,
+        ),
+        rg.LabelQuestion(
+            name="fabricated_source",
+            title=t(Task.GROUNDING, "question", "fabricated_source"),
+            labels=_yes_no(Task.GROUNDING, "fabricated_source"),
+            required=True,
+        ),
+        rg.TextQuestion(name="notes", title=t(Task.GROUNDING, "question", "notes"), required=False),
+        *_discard_questions(Task.GROUNDING, catalog),
+    ]
+
+    generation_questions: list = [
+        rg.LabelQuestion(
+            name="proper_action",
+            title=t(Task.GENERATION, "question", "proper_action"),
+            labels=_yes_no(Task.GENERATION, "proper_action"),
+            required=True,
+        ),
+        rg.LabelQuestion(
+            name="response_on_topic",
+            title=t(Task.GENERATION, "question", "response_on_topic"),
+            labels=_yes_no(Task.GENERATION, "response_on_topic"),
+            required=True,
+        ),
+        rg.LabelQuestion(
+            name="helpful",
+            title=t(Task.GENERATION, "question", "helpful"),
+            labels=_yes_no(Task.GENERATION, "helpful"),
+            required=True,
+        ),
+        rg.LabelQuestion(
+            name="incomplete",
+            title=t(Task.GENERATION, "question", "incomplete"),
+            labels=_yes_no(Task.GENERATION, "incomplete"),
+            required=True,
+        ),
+        rg.LabelQuestion(
+            name="unsafe_content",
+            title=t(Task.GENERATION, "question", "unsafe_content"),
+            labels=_yes_no(Task.GENERATION, "unsafe_content"),
+            required=True,
+        ),
+        rg.TextQuestion(name="notes", title=t(Task.GENERATION, "question", "notes"), required=False),
+        *_discard_questions(Task.GENERATION, catalog),
+    ]
 
     return {
         Task.RETRIEVAL: rg.Settings(
@@ -175,30 +312,10 @@ def build_task_settings(locale: Locale = "en") -> dict[Task, rg.Settings]:
                 rg.TextField(name="query", title=t(Task.RETRIEVAL, "field", "query"), required=True),
                 rg.TextField(name="chunk", title=t(Task.RETRIEVAL, "field", "chunk"), required=True),
                 _collapsible_field("generated_answer", t(Task.RETRIEVAL, "field", "generated_answer"), template_text),
+                constraints_field(Task.RETRIEVAL, retrieval_questions),
                 discard_field(Task.RETRIEVAL),
             ],
-            questions=[
-                rg.LabelQuestion(
-                    name="topically_relevant",
-                    title=t(Task.RETRIEVAL, "question", "topically_relevant"),
-                    labels=_yes_no(Task.RETRIEVAL, "topically_relevant"),
-                    required=True,
-                ),
-                rg.LabelQuestion(
-                    name="evidence_sufficient",
-                    title=t(Task.RETRIEVAL, "question", "evidence_sufficient"),
-                    labels=_yes_no(Task.RETRIEVAL, "evidence_sufficient"),
-                    required=True,
-                ),
-                rg.LabelQuestion(
-                    name="misleading",
-                    title=t(Task.RETRIEVAL, "question", "misleading"),
-                    labels=_yes_no(Task.RETRIEVAL, "misleading"),
-                    required=True,
-                ),
-                rg.TextQuestion(name="notes", title=t(Task.RETRIEVAL, "question", "notes"), required=False),
-                *_discard_questions(Task.RETRIEVAL, catalog),
-            ],
+            questions=retrieval_questions,
             metadata=[
                 rg.TermsMetadataProperty("record_uuid", visible_for_annotators=False),
                 rg.TermsMetadataProperty("language", visible_for_annotators=False),
@@ -213,42 +330,10 @@ def build_task_settings(locale: Locale = "en") -> dict[Task, rg.Settings]:
                 rg.TextField(name="answer", title=t(Task.GROUNDING, "field", "answer"), required=True),
                 rg.TextField(name="context_set", title=t(Task.GROUNDING, "field", "context_set"), required=True),
                 _collapsible_field("query", t(Task.GROUNDING, "field", "query"), template_text),
+                constraints_field(Task.GROUNDING, grounding_questions),
                 discard_field(Task.GROUNDING),
             ],
-            questions=[
-                rg.LabelQuestion(
-                    name="support_present",
-                    title=t(Task.GROUNDING, "question", "support_present"),
-                    labels=_yes_no(Task.GROUNDING, "support_present"),
-                    required=True,
-                ),
-                rg.LabelQuestion(
-                    name="unsupported_claim_present",
-                    title=t(Task.GROUNDING, "question", "unsupported_claim_present"),
-                    labels=_yes_no(Task.GROUNDING, "unsupported_claim_present"),
-                    required=True,
-                ),
-                rg.LabelQuestion(
-                    name="contradicted_claim_present",
-                    title=t(Task.GROUNDING, "question", "contradicted_claim_present"),
-                    labels=_yes_no(Task.GROUNDING, "contradicted_claim_present"),
-                    required=True,
-                ),
-                rg.LabelQuestion(
-                    name="source_cited",
-                    title=t(Task.GROUNDING, "question", "source_cited"),
-                    labels=_yes_no(Task.GROUNDING, "source_cited"),
-                    required=True,
-                ),
-                rg.LabelQuestion(
-                    name="fabricated_source",
-                    title=t(Task.GROUNDING, "question", "fabricated_source"),
-                    labels=_yes_no(Task.GROUNDING, "fabricated_source"),
-                    required=True,
-                ),
-                rg.TextQuestion(name="notes", title=t(Task.GROUNDING, "question", "notes"), required=False),
-                *_discard_questions(Task.GROUNDING, catalog),
-            ],
+            questions=grounding_questions,
             metadata=[
                 rg.TermsMetadataProperty("record_uuid", visible_for_annotators=False),
                 rg.TermsMetadataProperty("language", visible_for_annotators=False),
@@ -260,42 +345,10 @@ def build_task_settings(locale: Locale = "en") -> dict[Task, rg.Settings]:
                 rg.TextField(name="query", title=t(Task.GENERATION, "field", "query"), required=True),
                 rg.TextField(name="answer", title=t(Task.GENERATION, "field", "answer"), required=True),
                 _collapsible_field("context_set", t(Task.GENERATION, "field", "context_set"), template_text),
+                constraints_field(Task.GENERATION, generation_questions),
                 discard_field(Task.GENERATION),
             ],
-            questions=[
-                rg.LabelQuestion(
-                    name="proper_action",
-                    title=t(Task.GENERATION, "question", "proper_action"),
-                    labels=_yes_no(Task.GENERATION, "proper_action"),
-                    required=True,
-                ),
-                rg.LabelQuestion(
-                    name="response_on_topic",
-                    title=t(Task.GENERATION, "question", "response_on_topic"),
-                    labels=_yes_no(Task.GENERATION, "response_on_topic"),
-                    required=True,
-                ),
-                rg.LabelQuestion(
-                    name="helpful",
-                    title=t(Task.GENERATION, "question", "helpful"),
-                    labels=_yes_no(Task.GENERATION, "helpful"),
-                    required=True,
-                ),
-                rg.LabelQuestion(
-                    name="incomplete",
-                    title=t(Task.GENERATION, "question", "incomplete"),
-                    labels=_yes_no(Task.GENERATION, "incomplete"),
-                    required=True,
-                ),
-                rg.LabelQuestion(
-                    name="unsafe_content",
-                    title=t(Task.GENERATION, "question", "unsafe_content"),
-                    labels=_yes_no(Task.GENERATION, "unsafe_content"),
-                    required=True,
-                ),
-                rg.TextQuestion(name="notes", title=t(Task.GENERATION, "question", "notes"), required=False),
-                *_discard_questions(Task.GENERATION, catalog),
-            ],
+            questions=generation_questions,
             metadata=[
                 rg.TermsMetadataProperty("record_uuid", visible_for_annotators=False),
                 rg.TermsMetadataProperty("language", visible_for_annotators=False),

--- a/src/pragmata/core/annotation/constraints_field.html
+++ b/src/pragmata/core/annotation/constraints_field.html
@@ -1,0 +1,293 @@
+<!DOCTYPE html>
+<html>
+<head></head>
+<body>
+<script>
+(function () {
+  // Substituted at dataset creation time by argilla_task_definitions.py.
+  // CONSTRAINTS shape: see LogicalConstraint.to_widget_payload in logical_constraints.py.
+  var CONSTRAINTS = $CONSTRAINTS_JSON;
+  var QUESTION_TITLES = $QUESTION_TITLES_JSON;
+
+  // Argilla DOM contract — verified against argilla-frontend v2.8.0 source.
+  // QuestionHeader stamps title onto `<div class="title-area" aria-label=...>`;
+  // SingleLabel wraps the whole component in `<div class="wrapper">`;
+  // LabelSelection renders chips as `<input type=checkbox>` + `<label class="label-text">`
+  // with `.label-active` added when selected; QuestionsForm puts the submit
+  // button (`<button type=submit class="button--submit">`) inside `.footer-form`.
+  // Any of these moving will need re-verification on Argilla upgrades.
+  var pdoc = window.parent.document;
+  var SUBMIT_SEL = '.button--submit, button[type="submit"]';
+  var FOOTER_SEL = '.footer-form';
+  var INJECTED_PANEL_ID = '__constraints_injected_panel';
+  var INJECTED_STYLE_ID = '__constraints_injected_style';
+
+  function ensureNode(id, parent, build) {
+    var existing = pdoc.getElementById(id);
+    if (existing && existing.isConnected) return existing;
+    if (!parent) return null;
+    var node = build();
+    node.id = id;
+    parent.appendChild(node);
+    return node;
+  }
+
+  function ensureInjectedStyle() {
+    return ensureNode(INJECTED_STYLE_ID, pdoc.head, function () {
+      var s = pdoc.createElement('style');
+      s.textContent =
+        '#' + INJECTED_PANEL_ID + '{border-radius:6px;padding:10px 12px;' +
+        'font-family:system-ui,sans-serif;font-size:13px;line-height:1.4;margin:0 0 12px 0}' +
+        '#' + INJECTED_PANEL_ID + '[hidden]{display:none}' +
+        '#' + INJECTED_PANEL_ID + '.warn{border:2px solid #d4a017;background:#fff8e1;color:#5d4400}' +
+        '#' + INJECTED_PANEL_ID + '.block{border:2px solid #d9534f;background:#fff5f5;color:#6e0a0a}' +
+        '#' + INJECTED_PANEL_ID + ' h4{margin:0 0 6px 0;font-size:13px}' +
+        '#' + INJECTED_PANEL_ID + ' ul{margin:0;padding-left:18px}' +
+        '#' + INJECTED_PANEL_ID + ' li{margin-top:4px}' +
+        // Trailing space in a CSS \HEX escape is the terminator (consumed),
+        // so add literal spaces after it for the actual gap.
+        '#' + INJECTED_PANEL_ID + ' li.warn::marker{content:"\\26A0   "}' +
+        '#' + INJECTED_PANEL_ID + ' li.block::marker{content:"\\2715   "}' +
+        '#' + INJECTED_PANEL_ID + ' .constraint-msg{display:block}' +
+        '#' + INJECTED_PANEL_ID + ' .constraint-cite{font-style:italic;opacity:0.8;font-size:12px}' +
+        '#' + INJECTED_PANEL_ID + ' .constraint-cite code{font-style:normal;background:rgba(0,0,0,0.06);padding:1px 4px;border-radius:3px}';
+      return s;
+    });
+  }
+
+  function ensureInjectedPanel() {
+    var submit = pdoc.querySelector(SUBMIT_SEL);
+    if (!submit) return null;
+    var footer = submit.closest(FOOTER_SEL) || submit.parentElement;
+    if (!footer || !footer.parentElement) return null;
+    var existing = pdoc.getElementById(INJECTED_PANEL_ID);
+    if (existing && existing.isConnected) return existing;
+    var panel = pdoc.createElement('div');
+    panel.id = INJECTED_PANEL_ID;
+    panel.hidden = true;
+    panel.innerHTML = '<h4 class="__title"></h4><ul class="__list"></ul>';
+    footer.parentElement.insertBefore(panel, footer);
+    return panel;
+  }
+
+  // Depends on Argilla v2 showing one record at a time — `pdoc.querySelector`
+  // matches the first element in parent DOM. Same assumption holds in discard_flow.html.
+  function cardFor(questionName) {
+    var title = QUESTION_TITLES[questionName];
+    if (!title) return null;
+    var titleArea = pdoc.querySelector('[aria-label="' + title.replace(/"/g, '\\"') + '"]');
+    return titleArea ? titleArea.closest('.wrapper') : null;
+  }
+
+  function normalize(s) {
+    var v = String(s).trim().toLowerCase();
+    if (v === 'yes' || v === 'y' || v === 'true' || v === '1') return 'yes';
+    if (v === 'no'  || v === 'n' || v === 'false' || v === '0') return 'no';
+    return null;
+  }
+
+  // Two independent paths so a future tweak that breaks one still leaves the
+  // other working — see DOM contract block at the top.
+  function selectedValue(questionName) {
+    var card = cardFor(questionName);
+    if (!card) return null;
+    var activeLabel = card.querySelector('label.label-active');
+    if (activeLabel) {
+      // Argilla emits the label's `for` attribute as `<question_name>_<machine_value>`
+      // (locale-invariant). Read that first so localised display text — e.g. "Ja"/"Nein"
+      // in DE — does not break the constraint match against the constraint's
+      // English machine `when_value` / `then_value`.
+      var forAttr = activeLabel.getAttribute('for') || '';
+      var prefix = questionName + '_';
+      if (forAttr.indexOf(prefix) === 0) return forAttr.slice(prefix.length);
+      // Fallback for any Argilla version that drops `for=` on the active label:
+      // try the displayed text (works in EN where display == machine value).
+      var textSpan = activeLabel.querySelector('.label-text__text');
+      var raw = (textSpan ? textSpan.textContent : activeLabel.textContent) || '';
+      var n = normalize(raw.trim());
+      if (n) return n;
+    }
+    var checkedInput = card.querySelector('input[type="checkbox"]:checked');
+    if (checkedInput && checkedInput.name) return normalize(checkedInput.name);
+    return null;
+  }
+
+  function evaluate() {
+    var hits = [];
+    for (var i = 0; i < CONSTRAINTS.length; i++) {
+      var c = CONSTRAINTS[i];
+      if (selectedValue(c.when_question) !== c.when_value) continue;
+      var thenVal = selectedValue(c.then_question);
+      if (thenVal === null) continue;  // dependent not answered yet
+      if (thenVal !== c.then_value) hits.push(c);
+    }
+    return hits;
+  }
+
+  function render(hits) {
+    ensureInjectedStyle();
+    var panel = ensureInjectedPanel();
+    if (!panel) return;
+
+    var listEl = panel.querySelector('.__list');
+    var titleEl = panel.querySelector('.__title');
+
+    if (hits.length === 0) {
+      panel.hidden = true;
+      panel.className = '';
+      listEl.innerHTML = '';
+      return;
+    }
+
+    var hasBlock = hits.some(function (h) { return h.severity === 'block'; });
+    panel.className = hasBlock ? 'block' : 'warn';
+    titleEl.textContent = hasBlock
+      ? 'Please resolve the following before submitting:'
+      : 'Please reconsider:';
+
+    listEl.innerHTML = '';
+    hits.forEach(function (h) {
+      var li = pdoc.createElement('li');
+      li.className = h.severity;
+      var msg = pdoc.createElement('span');
+      msg.className = 'constraint-msg';
+      msg.textContent = h.message;
+      li.appendChild(msg);
+      var cite = pdoc.createElement('span');
+      cite.className = 'constraint-cite';
+      var whenTitle = QUESTION_TITLES[h.when_question] || h.when_question;
+      var thenTitle = QUESTION_TITLES[h.then_question] || h.then_question;
+      var thenDisplay = h.then_value === 'yes' ? 'no' : 'yes';
+      function codeFragment(title, value) {
+        var code = pdoc.createElement('code');
+        code.appendChild(pdoc.createTextNode(title + ' = '));
+        var strong = pdoc.createElement('strong');
+        strong.textContent = value;
+        code.appendChild(strong);
+        return code;
+      }
+      cite.appendChild(pdoc.createTextNode('(You selected '));
+      cite.appendChild(codeFragment(whenTitle, h.when_value));
+      cite.appendChild(pdoc.createTextNode(', but also '));
+      cite.appendChild(codeFragment(thenTitle, thenDisplay));
+      cite.appendChild(pdoc.createTextNode(')'));
+      li.appendChild(cite);
+      listEl.appendChild(li);
+    });
+
+    panel.hidden = false;
+  }
+
+  // Disable rather than hide — keep the control visible so the annotator
+  // understands why submit isn't responding.
+  function applySubmitGate(hasBlocked) {
+    var btns = pdoc.querySelectorAll(SUBMIT_SEL);
+    for (var i = 0; i < btns.length; i++) {
+      var b = btns[i];
+      if (hasBlocked) {
+        if (!b.dataset.constraintBlocked) {
+          b.dataset.constraintBlocked = '1';
+          b.dataset.prevTitle = b.title || '';
+          b.disabled = true;
+          b.setAttribute('aria-disabled', 'true');
+          b.title = 'Resolve the constraint violations above before submitting.';
+          b.style.opacity = '0.5';
+          b.style.cursor = 'not-allowed';
+        }
+      } else if (b.dataset.constraintBlocked) {
+        delete b.dataset.constraintBlocked;
+        b.disabled = false;
+        b.removeAttribute('aria-disabled');
+        b.title = b.dataset.prevTitle || '';
+        delete b.dataset.prevTitle;
+        b.style.opacity = '';
+        b.style.cursor = '';
+      }
+    }
+  }
+
+  // Collapse the iframe's own host box — the visible panel lives in parent DOM
+  // above the footer now, so the iframe just runs the script.
+  function hideHostBox() {
+    try {
+      var frame = window.frameElement;
+      if (!frame) return;
+      var host = frame.closest('.custom_field_component');
+      if (host) host.style.display = 'none';
+    } catch (e) {
+      console.warn('constraints widget: hideHostBox failed', e);
+    }
+  }
+
+  // Skip re-rendering when nothing the user-visible state depends on has
+  // changed. Without this, every observed class change in the parent app
+  // would write `panel.className = ''` again, fire its own mutation, and
+  // burn frames in a self-driving loop.
+  var lastSig = null;
+  function tick() {
+    var hits = evaluate();
+    var hasBlock = false;
+    var sig = '';
+    for (var i = 0; i < hits.length; i++) {
+      sig += hits[i].constraint_id + '|';
+      if (hits[i].severity === 'block') hasBlock = true;
+    }
+    sig += hasBlock ? '1' : '0';
+    if (sig === lastSig) {
+      // Visible state unchanged, but the submit button may have mounted after
+      // the previous tick (e.g. block hit on the very first evaluation against
+      // a pre-populated draft). Re-apply the gate if its state has drifted.
+      var btn = pdoc.querySelector(SUBMIT_SEL);
+      var btnBlocked = !!(btn && btn.dataset.constraintBlocked);
+      if (btnBlocked === hasBlock) return;
+    }
+    lastSig = sig;
+    render(hits);
+    applySubmitGate(hasBlock);
+  }
+
+  var pending = false;
+  function schedule() {
+    if (pending) return;
+    pending = true;
+    requestAnimationFrame(function () { pending = false; tick(); });
+  }
+
+  // Setup. The MutationObserver target needs to exist; if pdoc.body isn't
+  // populated yet we retry next frame. attributeFilter:['class'] is narrow
+  // enough to skip the worst of Argilla's per-frame attribute churn.
+  var observer = null;
+  function attachObserver() {
+    var target = pdoc.body || pdoc.documentElement;
+    if (!target) return window.requestAnimationFrame(attachObserver);
+    observer = new MutationObserver(schedule);
+    observer.observe(target, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['class'],
+    });
+    target.addEventListener('change', schedule, true);
+    target.addEventListener('click', schedule, true);
+  }
+
+  // Clean up across iframe reloads. Argilla re-renders the iframe's srcdoc
+  // when the underlying record changes, so without this each navigation
+  // would orphan a listener on parent body — accumulating over a session.
+  window.addEventListener('pagehide', function () {
+    if (observer) observer.disconnect();
+    var target = pdoc.body || pdoc.documentElement;
+    if (target) {
+      target.removeEventListener('change', schedule, true);
+      target.removeEventListener('click', schedule, true);
+    }
+  });
+
+  hideHostBox();
+  tick();
+  attachObserver();
+  window.addEventListener('load', function () { hideHostBox(); tick(); });
+})();
+</script>
+</body>
+</html>

--- a/src/pragmata/core/annotation/constraints_field.html
+++ b/src/pragmata/core/annotation/constraints_field.html
@@ -219,6 +219,19 @@
     }
   }
 
+  // Argilla's own Submit shortcut (Enter) calls a Vue method directly,
+  // gated by Argilla's internal isSubmitDisabled prop — it never looks at
+  // the DOM button we disable in applySubmitGate, so it isn't blocked by
+  // that alone. Intercept in the capture phase (which always runs before
+  // Argilla's document-level bubble listener) and swallow the key.
+  var blockActive = false;
+  function interceptBlockedSubmit(e) {
+    if (blockActive && e.code === 'Enter' && !e.shiftKey) {
+      e.stopPropagation();
+      e.preventDefault();
+    }
+  }
+
   // Skip re-rendering when nothing the user-visible state depends on has
   // changed. Without this, every observed class change in the parent app
   // would write `panel.className = ''` again, fire its own mutation, and
@@ -232,6 +245,7 @@
       sig += hits[i].constraint_id + '|';
       if (hits[i].severity === 'block') hasBlock = true;
     }
+    blockActive = hasBlock;
     sig += hasBlock ? '1' : '0';
     if (sig === lastSig) {
       // Visible state unchanged, but the submit button may have mounted after
@@ -281,8 +295,10 @@
       target.removeEventListener('change', schedule, true);
       target.removeEventListener('click', schedule, true);
     }
+    pdoc.removeEventListener('keydown', interceptBlockedSubmit, true);
   });
 
+  pdoc.addEventListener('keydown', interceptBlockedSubmit, true);
   hideHostBox();
   tick();
   attachObserver();

--- a/src/pragmata/core/annotation/locales/registry.py
+++ b/src/pragmata/core/annotation/locales/registry.py
@@ -29,21 +29,17 @@ def register_catalog_dir(directory: Path) -> None:
     """Layer ``*.yaml`` catalogs from ``directory`` over the bundled set.
 
     Idempotent: same directory registered twice yields the same end state.
-    Clears the downstream ``build_task_settings`` cache so a subsequent
-    locale build sees the updated catalog (otherwise a second
-    ``import_records`` call in the same process with a different
-    ``locale_catalog_dir`` would silently reuse stale ``rg.Settings``).
+    ``build_task_settings`` is not cached so no cache invalidation is needed;
+    a subsequent call with the same locale will automatically use the updated
+    catalog.
 
     Raises ``ValueError`` if ``directory`` does not exist or is not a
     directory - fail loud rather than silently registering nothing, since
     ``Path.glob`` on a missing path yields no entries.
     """
-    from pragmata.core.annotation.argilla_task_definitions import build_task_settings
-
     if not directory.is_dir():
         raise ValueError(f"locale_catalog_dir does not exist or is not a directory: {directory}")
     CATALOGS.update(_load_dir(directory))
-    build_task_settings.cache_clear()
 
 
 def get_catalog(locale: Locale) -> Catalog:

--- a/src/pragmata/core/annotation/logical_constraints.py
+++ b/src/pragmata/core/annotation/logical_constraints.py
@@ -1,9 +1,14 @@
-"""Declarative logical constraints (SSOT for export-time validation checks).
+"""Declarative logical constraints (SSOT for export-time checks AND the annotator-time UI widget).
 
 A logical constraint is a binary implication on label values: when one question
 is answered with a specific yes/no value, another question is constrained to a
-specific yes/no value. Centralising the rules avoids scattered conditionals in
-the export code.
+specific yes/no value. The same definitions drive:
+
+1. Export-time validation (``constraints.check_*`` returns violation strings)
+2. Annotation-time UI warnings/blocks (constraints serialised via
+   ``to_widget_payload()`` into ``constraints_field.html``)
+
+Keeping both consumers off one definition guarantees they cannot drift.
 """
 
 from dataclasses import dataclass
@@ -23,7 +28,10 @@ class Severity(StrEnum):
 class LogicalConstraint:
     """Binary implication: ``<when_question>=<when_value>`` requires ``<then_question>=<then_value>``.
 
-    ``constraint_id`` is a stable short identifier for the rule.
+    ``constraint_id`` is a stable short identifier for the rule; ``message``
+    is the annotator-facing explanation rendered by the UI widget. Severity
+    is not a property of the rule itself, it is a configurable runtime
+    setting (see ``AnnotationSettings.constraint_severity``).
     """
 
     task: Task
@@ -32,6 +40,7 @@ class LogicalConstraint:
     when_value: bool
     then_question: str
     then_value: bool
+    message: str
 
     def applies(self, row: object) -> bool:
         """Return True if the antecedent matches (i.e. the constraint is relevant to this row)."""
@@ -49,6 +58,22 @@ class LogicalConstraint:
             f"{self.task.value}: {self.when_question}={self.when_value} but {self.then_question}={not self.then_value}"
         )
 
+    def to_widget_payload(self, severity: Severity) -> dict[str, str]:
+        """Serialisable constraint shape for the JS widget; uses string yes/no values.
+
+        ``severity`` is the resolved severity for this constraint
+        (from ``AnnotationSettings.constraint_severity``).
+        """
+        return {
+            "constraint_id": self.constraint_id,
+            "when_question": self.when_question,
+            "when_value": "yes" if self.when_value else "no",
+            "then_question": self.then_question,
+            "then_value": "yes" if self.then_value else "no",
+            "severity": severity,
+            "message": self.message,
+        }
+
 
 LOGICAL_CONSTRAINTS: dict[Task, list[LogicalConstraint]] = {
     Task.RETRIEVAL: [
@@ -59,6 +84,9 @@ LOGICAL_CONSTRAINTS: dict[Task, list[LogicalConstraint]] = {
             when_value=True,
             then_question="topically_relevant",
             then_value=True,
+            message=(
+                "If a passage provides sufficient evidence to answer the query, it must also be topically relevant."
+            ),
         ),
         LogicalConstraint(
             task=Task.RETRIEVAL,
@@ -67,6 +95,11 @@ LOGICAL_CONSTRAINTS: dict[Task, list[LogicalConstraint]] = {
             when_value=True,
             then_question="misleading",
             then_value=False,
+            message=(
+                "A passage marked as providing sufficient evidence is usually not also "
+                "misleading. Double-check this combination. Keep it only if the passage "
+                "genuinely supports the answer while still being plausibly misleading."
+            ),
         ),
     ],
     Task.GROUNDING: [
@@ -77,6 +110,10 @@ LOGICAL_CONSTRAINTS: dict[Task, list[LogicalConstraint]] = {
             when_value=True,
             then_question="unsupported_claim_present",
             then_value=True,
+            message=(
+                "A contradicted claim is by definition not supported by the context, "
+                "so 'unsupported claim present' must also be yes."
+            ),
         ),
         LogicalConstraint(
             task=Task.GROUNDING,
@@ -85,6 +122,9 @@ LOGICAL_CONSTRAINTS: dict[Task, list[LogicalConstraint]] = {
             when_value=True,
             then_question="source_cited",
             then_value=True,
+            message=(
+                "A fabricated source can only exist if the answer cites a source, so 'source cited' must also be yes."
+            ),
         ),
     ],
     Task.GENERATION: [],

--- a/src/pragmata/core/annotation/record_builder.py
+++ b/src/pragmata/core/annotation/record_builder.py
@@ -19,7 +19,11 @@ import argilla as rg
 from argilla.records._dataset_records import RecordErrorHandling  # no public re-export in argilla v2; pinned to ==2.6.0
 
 from pragmata.core.annotation.argilla_ops import create_dataset
-from pragmata.core.annotation.argilla_task_definitions import build_task_settings, dataset_name
+from pragmata.core.annotation.argilla_task_definitions import (
+    WIDGET_FIELD_PLACEHOLDERS,
+    build_task_settings,
+    dataset_name,
+)
 from pragmata.core.annotation.locales.registry import CATALOGS
 from pragmata.core.schemas.annotation_import import (
     Chunk,
@@ -31,10 +35,6 @@ from pragmata.core.schemas.annotation_task import Locale, Task
 from pragmata.core.settings.annotation_settings import AnnotationSettings
 
 logger = logging.getLogger(__name__)
-
-# Static placeholder — the discard_flow CustomField template reads no record
-# data, but Argilla still requires the field to be present on every record.
-_DISCARD_FLOW_FIELD = {"discard_flow": {"text": ""}}
 
 
 # ---------------------------------------------------------------------------
@@ -127,7 +127,7 @@ def build_retrieval_record_for_chunk(
             "query": pair.query,
             "chunk": chunk.text,
             "generated_answer": {"text": pair.answer},
-            **_DISCARD_FLOW_FIELD,
+            **WIDGET_FIELD_PLACEHOLDERS,
         },
         metadata=metadata,
     )
@@ -144,7 +144,7 @@ def build_grounding_record(pair: QueryResponsePair, record_uuid: str) -> rg.Reco
             "answer": pair.answer,
             "context_set": pair.context_set,
             "query": {"text": pair.query},
-            **_DISCARD_FLOW_FIELD,
+            **WIDGET_FIELD_PLACEHOLDERS,
         },
         metadata=metadata,
     )
@@ -161,7 +161,7 @@ def build_generation_record(pair: QueryResponsePair, record_uuid: str) -> rg.Rec
             "query": pair.query,
             "answer": pair.answer,
             "context_set": {"text": pair.context_set},
-            **_DISCARD_FLOW_FIELD,
+            **WIDGET_FIELD_PLACEHOLDERS,
         },
         metadata=metadata,
     )
@@ -648,7 +648,7 @@ def fan_out_records(
         else:
             min_submitted = resolved.production_min_submitted
         locale = resolved.locale
-        task_settings_map = build_task_settings(locale)
+        task_settings_map = build_task_settings(settings, locale)
         dataset = _ensure_dataset(
             client,
             task=task,

--- a/src/pragmata/core/annotation/record_builder.py
+++ b/src/pragmata/core/annotation/record_builder.py
@@ -16,7 +16,9 @@ from pathlib import Path
 from typing import Any
 
 import argilla as rg
-from argilla.records._dataset_records import RecordErrorHandling  # no public re-export in argilla v2; resolved to 2.8.0 (see pyproject.toml)
+
+# RecordErrorHandling has no public re-export in argilla v2; resolved to 2.8.0 (see pyproject.toml)
+from argilla.records._dataset_records import RecordErrorHandling
 
 from pragmata.core.annotation.argilla_ops import create_dataset
 from pragmata.core.annotation.argilla_task_definitions import (

--- a/src/pragmata/core/annotation/record_builder.py
+++ b/src/pragmata/core/annotation/record_builder.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Any
 
 import argilla as rg
-from argilla.records._dataset_records import RecordErrorHandling  # no public re-export in argilla v2; pinned to ==2.6.0
+from argilla.records._dataset_records import RecordErrorHandling  # no public re-export in argilla v2; resolved to 2.8.0 (see pyproject.toml)
 
 from pragmata.core.annotation.argilla_ops import create_dataset
 from pragmata.core.annotation.argilla_task_definitions import (

--- a/src/pragmata/core/annotation/record_builder.py
+++ b/src/pragmata/core/annotation/record_builder.py
@@ -628,6 +628,8 @@ def fan_out_records(
     batches = _build_batches(partition.pairs_by_rid, partition.assignments)
 
     dataset_counts: dict[str, int] = {}
+    # Memoise build_task_settings per locale — its output depends only on (settings, locale).
+    settings_by_locale: dict[Locale, dict[Task, rg.Settings]] = {}
 
     for (task, calibration), rg_records in batches.items():
         if not rg_records:
@@ -648,7 +650,9 @@ def fan_out_records(
         else:
             min_submitted = resolved.production_min_submitted
         locale = resolved.locale
-        task_settings_map = build_task_settings(settings, locale)
+        if locale not in settings_by_locale:
+            settings_by_locale[locale] = build_task_settings(settings, locale)
+        task_settings_map = settings_by_locale[locale]
         dataset = _ensure_dataset(
             client,
             task=task,

--- a/tests/unit/core/annotation/test_argilla_task_definitions.py
+++ b/tests/unit/core/annotation/test_argilla_task_definitions.py
@@ -324,8 +324,8 @@ class TestConstraintsField:
         # unsubstituted (would be a hard-to-debug runtime JS error).
         for settings in (_RETRIEVAL, _GROUNDING):
             template = _get_field(settings, "constraints_panel").template
-            assert "@@CONSTRAINTS_JSON" not in template
-            assert "@@QUESTION_TITLES_JSON" not in template
+            assert "$CONSTRAINTS_JSON" not in template
+            assert "$QUESTION_TITLES_JSON" not in template
 
     def test_template_contains_constraint_messages(self):
         # Constraint messages must round-trip into the widget so the annotator sees them.

--- a/tests/unit/core/annotation/test_argilla_task_definitions.py
+++ b/tests/unit/core/annotation/test_argilla_task_definitions.py
@@ -8,8 +8,9 @@ from pragmata.core.annotation.argilla_task_definitions import (
     build_task_settings,
 )
 from pragmata.core.schemas.annotation_task import DiscardReason, Task
+from pragmata.core.settings.annotation_settings import AnnotationSettings
 
-_TASK_SETTINGS = build_task_settings()
+_TASK_SETTINGS = build_task_settings(AnnotationSettings())
 _RETRIEVAL = _TASK_SETTINGS[Task.RETRIEVAL]
 _GROUNDING = _TASK_SETTINGS[Task.GROUNDING]
 _GENERATION = _TASK_SETTINGS[Task.GENERATION]
@@ -290,13 +291,66 @@ class TestCatalogDrivesRenderedOutput:
         stub = dict(CATALOGS["en"])
         stub[(Task.RETRIEVAL, "field", "query")] = sentinel
         monkeypatch.setitem(CATALOGS, "en", stub)
-        # build_task_settings is @functools.cache'd; clear so the swap takes effect
-        # and again on the way out so later tests see the unmodified catalog.
-        build_task_settings.cache_clear()
-        try:
-            rendered = build_task_settings("en")[Task.RETRIEVAL]
-            query_field = _get_field(rendered, "query")
-            assert query_field is not None
-            assert query_field.title == sentinel
-        finally:
-            build_task_settings.cache_clear()
+        rendered = build_task_settings(AnnotationSettings(), "en")[Task.RETRIEVAL]
+        query_field = _get_field(rendered, "query")
+        assert query_field is not None
+        assert query_field.title == sentinel
+
+
+class TestConstraintsField:
+    """The constraints_panel CustomField wires LOGICAL_CONSTRAINTS into the annotator UI."""
+
+    def test_present_on_every_task(self):
+        # Even Generation (no constraints) gets the field: every record carries a
+        # constraints_panel placeholder value, and Argilla rejects records
+        # whose field keys don't all exist on the dataset.
+        for settings in (_RETRIEVAL, _GROUNDING, _GENERATION):
+            assert _get_field(settings, "constraints_panel") is not None
+
+    def test_generation_widget_payload_has_no_constraints(self):
+        # Generation has no constraints — the widget should serialise an empty
+        # constraints array, so it evaluates to no hits and stays hidden.
+        template = _get_field(_GENERATION, "constraints_panel").template
+        assert "var CONSTRAINTS = [];" in template
+
+    def test_is_advanced_custom_field(self):
+        field = _get_field(_RETRIEVAL, "constraints_panel")
+        assert isinstance(field, rg.CustomField)
+        assert field.advanced_mode is True
+        assert field.required is False
+
+    def test_template_substitutions_are_resolved(self):
+        # The widget receives both placeholders — verify nothing was left
+        # unsubstituted (would be a hard-to-debug runtime JS error).
+        for settings in (_RETRIEVAL, _GROUNDING):
+            template = _get_field(settings, "constraints_panel").template
+            assert "@@CONSTRAINTS_JSON" not in template
+            assert "@@QUESTION_TITLES_JSON" not in template
+
+    def test_template_contains_constraint_messages(self):
+        # Constraint messages must round-trip into the widget so the annotator sees them.
+        from pragmata.core.annotation.logical_constraints import LOGICAL_CONSTRAINTS
+
+        for task, settings in ((Task.RETRIEVAL, _RETRIEVAL), (Task.GROUNDING, _GROUNDING)):
+            template = _get_field(settings, "constraints_panel").template
+            for constraint in LOGICAL_CONSTRAINTS[task]:
+                # First few words is enough — full message has punctuation/escaping noise.
+                assert constraint.message.split(".")[0][:30] in template
+
+    def test_template_carries_question_titles_used_by_constraints(self):
+        # Aria-label probing relies on these titles matching the dataset's questions.
+        from pragmata.core.annotation.logical_constraints import LOGICAL_CONSTRAINTS
+
+        for task, settings in ((Task.RETRIEVAL, _RETRIEVAL), (Task.GROUNDING, _GROUNDING)):
+            template = _get_field(settings, "constraints_panel").template
+            for constraint in LOGICAL_CONSTRAINTS[task]:
+                for qname in (constraint.when_question, constraint.then_question):
+                    title = _get_question(settings, qname).title
+                    assert title in template
+
+    def test_field_is_below_content_above_discard(self):
+        # The panel should sit right before the discard field so it's adjacent
+        # to the submit action area.
+        for settings in (_RETRIEVAL, _GROUNDING):
+            names = _field_names(settings)
+            assert names.index("constraints_panel") == names.index("discard_flow") - 1

--- a/tests/unit/core/annotation/test_fan_out_records.py
+++ b/tests/unit/core/annotation/test_fan_out_records.py
@@ -271,7 +271,7 @@ class TestImportLocaleConflict:
 
         # Build an EN-flavoured existing dataset; _detect_dataset_locale will
         # match its label displays against the EN catalog.
-        en_settings = build_task_settings("en")[Task.RETRIEVAL]
+        en_settings = build_task_settings(AnnotationSettings(), "en")[Task.RETRIEVAL]
         ds_name = dataset_name(Task.RETRIEVAL, calibration=False, dataset_id="run1")
         fake_dataset = fake_dataset_factory(ds_name)
         fake_dataset.settings = rg.Settings(

--- a/tests/unit/core/annotation/test_import.py
+++ b/tests/unit/core/annotation/test_import.py
@@ -106,6 +106,7 @@ class TestBuildRetrievalRecords:
         assert rec.fields["chunk"] == pair.chunks[0].text
         assert rec.fields["generated_answer"] == {"text": pair.answer}
         assert rec.fields["discard_flow"] == {"text": ""}
+        assert rec.fields["constraints_panel"] == {"text": ""}
         assert "answer" not in rec.fields  # must NOT use "answer"
 
     def test_metadata_record_uuid(self) -> None:
@@ -163,6 +164,7 @@ class TestBuildGroundingRecord:
         assert rec.fields["context_set"] == pair.context_set
         assert rec.fields["query"] == {"text": pair.query}
         assert rec.fields["discard_flow"] == {"text": ""}
+        assert rec.fields["constraints_panel"] == {"text": ""}
 
     def test_metadata_record_uuid(self) -> None:
         rec = build_grounding_record(_make_pair(), _UUID)
@@ -198,6 +200,7 @@ class TestBuildGenerationRecord:
         assert rec.fields["answer"] == pair.answer
         assert rec.fields["context_set"] == {"text": pair.context_set}
         assert rec.fields["discard_flow"] == {"text": ""}
+        assert rec.fields["constraints_panel"] == {"text": ""}
 
     def test_metadata_record_uuid(self) -> None:
         rec = build_generation_record(_make_pair(), _UUID)

--- a/tests/unit/core/annotation/test_locale_registry.py
+++ b/tests/unit/core/annotation/test_locale_registry.py
@@ -13,12 +13,7 @@ BUNDLED_EN = Path(registry.__file__).parent / "en.yaml"
 
 @pytest.fixture(autouse=True)
 def _isolate_catalogs(monkeypatch):
-    from pragmata.core.annotation.argilla_task_definitions import build_task_settings
-
     monkeypatch.setattr(registry, "CATALOGS", dict(registry.CATALOGS))
-    build_task_settings.cache_clear()
-    yield
-    build_task_settings.cache_clear()
 
 
 class TestRegisterCatalogDir:
@@ -55,16 +50,6 @@ class TestRegisterCatalogDir:
         registry.register_catalog_dir(tmp_path)
 
         assert registry.CATALOGS == before
-
-    def test_invalidates_build_task_settings_cache(self, tmp_path):
-        from pragmata.core.annotation.argilla_task_definitions import build_task_settings
-
-        build_task_settings("en")
-        assert build_task_settings.cache_info().currsize == 1
-
-        registry.register_catalog_dir(tmp_path)
-
-        assert build_task_settings.cache_info().currsize == 0
 
     def test_missing_dir_raises(self, tmp_path):
         with pytest.raises(ValueError, match="locale_catalog_dir"):

--- a/tests/unit/core/annotation/test_locales.py
+++ b/tests/unit/core/annotation/test_locales.py
@@ -6,7 +6,9 @@ import pytest
 from pragmata.core.annotation.argilla_task_definitions import build_task_settings
 from pragmata.core.annotation.locales.registry import CATALOGS, get_catalog
 from pragmata.core.schemas.annotation_task import Locale, Task
+from pragmata.core.settings.annotation_settings import AnnotationSettings
 
+_SETTINGS = AnnotationSettings()
 _NON_EN_LOCALES = sorted(loc for loc in CATALOGS if loc != "en")
 _ALL_LOCALES = sorted(CATALOGS)
 
@@ -31,18 +33,17 @@ class TestCatalogCompleteness:
 
 
 class TestLocaleAwareSettings:
-    """build_task_settings() returns locale-appropriate titles while preserving structure."""
+    """build_task_settings(_SETTINGS) returns locale-appropriate titles while preserving structure."""
 
     def test_default_locale_is_english(self) -> None:
-        # Cached separately from explicit "en" call, but should produce identical content.
-        default_settings = build_task_settings()
-        en_settings = build_task_settings("en")
+        default_settings = build_task_settings(_SETTINGS)
+        en_settings = build_task_settings(_SETTINGS, "en")
         for task in Task:
             assert _titles(default_settings[task]) == _titles(en_settings[task])
 
     def test_de_titles_differ_from_en(self) -> None:
-        en = build_task_settings("en")
-        de = build_task_settings("de")
+        en = build_task_settings(_SETTINGS, "en")
+        de = build_task_settings(_SETTINGS, "de")
         # At least some titles must differ — otherwise translations aren't wired through.
         for task in Task:
             en_titles = _titles(en[task])
@@ -52,8 +53,8 @@ class TestLocaleAwareSettings:
     @pytest.mark.parametrize("locale", _ALL_LOCALES)
     def test_field_and_question_names_stable_across_locales(self, locale: Locale) -> None:
         """Identities (name=) must not change with locale — exports depend on this."""
-        en = build_task_settings("en")
-        other = build_task_settings(locale)
+        en = build_task_settings(_SETTINGS, "en")
+        other = build_task_settings(_SETTINGS, locale)
         for task in Task:
             assert [f.name for f in en[task].fields] == [f.name for f in other[task].fields]
             assert [q.name for q in en[task].questions] == [q.name for q in other[task].questions]
@@ -61,8 +62,8 @@ class TestLocaleAwareSettings:
     @pytest.mark.parametrize("locale", _ALL_LOCALES)
     def test_label_values_stable_across_locales(self, locale: Locale) -> None:
         """Label values (e.g. 'yes'/'no') must not change with locale — export parsing depends on this."""
-        en = build_task_settings("en")
-        other = build_task_settings(locale)
+        en = build_task_settings(_SETTINGS, "en")
+        other = build_task_settings(_SETTINGS, locale)
         for task in Task:
             for en_q, other_q in zip(en[task].questions, other[task].questions, strict=True):
                 if isinstance(en_q, rg.LabelQuestion):
@@ -73,8 +74,8 @@ class TestLocaleAwareSettings:
 
     def test_label_displays_differ_in_de(self) -> None:
         """Label display text (option text shown in the UI) must change with locale."""
-        en = build_task_settings("en")
-        de = build_task_settings("de")
+        en = build_task_settings(_SETTINGS, "en")
+        de = build_task_settings(_SETTINGS, "de")
         seen_any_diff = False
         for task in Task:
             for en_q, de_q in zip(en[task].questions, de[task].questions, strict=True):
@@ -91,27 +92,27 @@ class TestLocaleAwareSettings:
 
     def test_label_yes_no_displays_in_de(self) -> None:
         """Spot-check: the 'yes'/'no' label values render as 'Ja'/'Nein' in DE."""
-        de = build_task_settings("de")
+        de = build_task_settings(_SETTINGS, "de")
         q = next(q for q in de[Task.GROUNDING].questions if q.name == "support_present")
         assert isinstance(q, rg.LabelQuestion)
         assert _option_map(q) == {"yes": "Ja", "no": "Nein"}
 
     def test_discard_reason_labels_translated_in_de(self) -> None:
         """Spot-check: discard reasons are translated, while their VALUES stay as DiscardReason.*.value."""
-        de = build_task_settings("de")
+        de = build_task_settings(_SETTINGS, "de")
         q = next(q for q in de[Task.GROUNDING].questions if q.name == "discard_reason")
         assert isinstance(q, rg.LabelQuestion)
         opts = _option_map(q)
         assert set(opts.keys()) == {"invalid_or_unrealistic", "unclear", "outside_reviewer_expertise"}
         # All displays should be non-English (cheap heuristic: differ from the EN spelling).
-        en = build_task_settings("en")
+        en = build_task_settings(_SETTINGS, "en")
         en_q = next(q for q in en[Task.GROUNDING].questions if q.name == "discard_reason")
         assert isinstance(en_q, rg.LabelQuestion)
         assert _option_map(q) != _option_map(en_q)
 
 
 def _discard_field(locale: Locale) -> rg.CustomField:
-    settings = build_task_settings(locale)
+    settings = build_task_settings(_SETTINGS, locale)
     return next(f for f in settings[Task.GROUNDING].fields if f.name == "discard_flow")
 
 

--- a/tests/unit/core/annotation/test_logical_constraints.py
+++ b/tests/unit/core/annotation/test_logical_constraints.py
@@ -64,6 +64,7 @@ class TestConstraintById:
                     when_value=True,
                     then_question="b",
                     then_value=True,
+                    message="dup a/b",
                 )
             ],
             Task.GROUNDING: [
@@ -74,6 +75,7 @@ class TestConstraintById:
                     when_value=True,
                     then_question="d",
                     then_value=True,
+                    message="dup c/d",
                 )
             ],
         }
@@ -142,6 +144,7 @@ def implication_constraint():
         when_value=True,
         then_question="topically_relevant",
         then_value=True,
+        message="If evidence is sufficient the chunk must also be relevant.",
     )
 
 


### PR DESCRIPTION
**Stack:** #213 (merged) → #214 → **#223** → #215 → #216 → #217

**Chain goal:** Annotator-time logical-constraint feedback (warn/block) on top of a shared constraint SSOT, with deployment- and workspace-level severity overrides.

**This PR (widget):** Render `LOGICAL_CONSTRAINTS` as an inline warn/block panel in the Argilla annotator UI, with severity sourced from `AnnotationSettings.constraint_severity` (#214). Constraints render right above the discard panel; `warn` shows an advisory, `block` disables submit until inputs are corrected.

> **Restructured:** this PR now carries the full widget (previously the bulk of the original #214), stacked on the settings layer #214. It also subsumes the locale fix that was this branch's original sole content, so the widget reads locale-invariant machine values from the start.

---

## Scope

### Widget
- `core/annotation/constraints_field.html` (new): vanilla-JS Argilla CustomField that reads parent-DOM checkbox/label state per question, evaluates `LOGICAL_CONSTRAINTS` payload entries, and renders an inline panel above the form actions. MutationObserver + rAF-coalesced; signature-based change detection short-circuits no-op renders. Reads each label's machine value from its `for` attribute (`<question_name>_<machine_value>`, locale-invariant) rather than the localised display text, so constraints fire in non-EN locales (e.g. DE "Ja"/"Nein").
- `core/annotation/argilla_task_definitions.py`: `constraints_field()` builder, `_render_constraints_template()` substitutes the constraints/question-titles JSON; `WIDGET_FIELD_PLACEHOLDERS` consolidates the per-record placeholder pattern. `build_task_settings(settings, locale)` now takes settings (was no-arg, was `@functools.cache`d) so it can read severity from `settings.constraint_severity`.
- `core/annotation/logical_constraints.py`: `message` field on `LogicalConstraint` (annotator-facing text); `to_widget_payload(severity)` serialises a constraint for the JS widget (string `yes`/`no`, resolved severity).
- `core/annotation/record_builder.py`: writes both `discard_flow` and `constraints_panel` placeholders per record (Argilla skips a CustomField with no record value).

## UX
- `warn`: yellow panel, submit still allowed.
- `block`: red panel + disabled submit button (title attribute explains why); reverts when inputs change to resolve.
- Empty `LOGICAL_CONSTRAINTS[task]` ⇒ panel hidden automatically.

## Test plan
- [x] `uv run python -m pytest tests/unit` (984 passing)
- [ ] Live Argilla dataset render check — **re-verify post-merge.** The widget JS has no unit coverage and changed since the original check (reads the label `for`-attribute machine value; renders workspace-resolved severity once #216 lands), so the live render path is the real gate and was not re-run during the rebase.
