### PR TITLE
refactor(annotation): extract PartitionResult bundle + collapse count helpers

### DIFF
--- a/src/pragmata/api/annotation_import.py
+++ b/src/pragmata/api/annotation_import.py
@@ -188,19 +188,19 @@ def import_records(
                 manifest.partition_seed,
             )
 
-        assignments = assign_partitions(
+        partition = assign_partitions(
             validation.valid,
             manifest=manifest,
             settings=settings,
             import_id=import_id,
         )
 
-        summary = summarize_partitions(assignments.values(), settings)
+        summary = summarize_partitions(partition.assignments.values(), settings)
 
         # Manifest is written only after fan-out succeeds. On failure, the
         # in-memory assignments are dropped; a retry with the same corpus + seed
         # re-derives identical buckets (deterministic per-unit hashing).
-        dataset_counts = fan_out_records(client, validation.valid, settings, assignments=assignments)
+        dataset_counts = fan_out_records(client, settings, partition=partition)
         write_partition_manifest(import_paths.partition_manifest, manifest)
 
     logger.info(

--- a/src/pragmata/api/annotation_import.py
+++ b/src/pragmata/api/annotation_import.py
@@ -195,7 +195,7 @@ def import_records(
             import_id=import_id,
         )
 
-        summary = summarize_partitions(partition.assignments.values(), settings)
+        summary = summarize_partitions(partition.assignments.values(), partition.calibration_fraction)
 
         # Manifest is written only after fan-out succeeds. On failure, the
         # in-memory assignments are dropped; a retry with the same corpus + seed

--- a/src/pragmata/core/annotation/record_builder.py
+++ b/src/pragmata/core/annotation/record_builder.py
@@ -443,24 +443,6 @@ def count_units_per_task(entries: Iterable[PartitionManifestEntry]) -> TaskUnitC
     return TaskUnitCounts(calibration=calibration, total=total)
 
 
-def _configured_fraction_per_task(settings: AnnotationSettings) -> dict[Task, float]:
-    """Resolve per-task ``calibration_fraction`` for reporting.
-
-    Picks the first workspace that owns each task. Returns ``0.0`` for any task
-    missing from the workspaces topology, matching the assignment behaviour for
-    absent tasks.
-    """
-    fraction: dict[Task, float] = {}
-    for ws_name, ws in settings.workspaces.items():
-        for task in ws.tasks:
-            if task in fraction:
-                continue
-            fraction[task] = settings.resolved_task(ws_name, task).calibration_fraction
-    for task in Task:
-        fraction.setdefault(task, 0.0)
-    return fraction
-
-
 @dataclass(frozen=True)
 class PartitionSummary:
     """Per-task partition reporting derived from a set of manifest entries.
@@ -488,13 +470,16 @@ class PartitionSummary:
 
 def summarize_partitions(
     entries: Iterable[PartitionManifestEntry],
-    settings: AnnotationSettings,
+    configured_fraction: dict[Task, float],
 ) -> PartitionSummary:
-    """Compute per-task partition reporting from manifest entries + settings.
+    """Compute per-task partition reporting from manifest entries.
 
     Counts calibration vs total annotation items per task in a single pass
-    (retrieval counts chunks; grounding/generation count records), derives the
-    realised calibration fraction, and resolves the configured fraction per task.
+    (retrieval counts chunks; grounding/generation count records) and derives
+    the realised calibration fraction. ``configured_fraction`` is the per-task
+    fraction already resolved by ``assign_partitions`` (see
+    ``PartitionResult.calibration_fraction``); it is carried through unchanged
+    rather than re-resolved from settings, keeping a single source of truth.
     """
     counts = count_units_per_task(entries)
     calibration_count = counts.calibration
@@ -503,7 +488,6 @@ def summarize_partitions(
     realised_fraction = {
         task: (calibration_count[task] / total_count[task]) if total_count[task] else 0.0 for task in Task
     }
-    configured_fraction = _configured_fraction_per_task(settings)
     return PartitionSummary(
         calibration_count=calibration_count,
         total_count=total_count,

--- a/src/pragmata/core/annotation/record_builder.py
+++ b/src/pragmata/core/annotation/record_builder.py
@@ -233,13 +233,34 @@ def write_partition_manifest(path: Path, manifest: PartitionManifest) -> None:
     tmp.replace(path)
 
 
+@dataclass(frozen=True)
+class PartitionResult:
+    """Outcome of ``assign_partitions()``.
+
+    Bundles the per-record manifest entries with the per-task fraction
+    resolved this run and the rid → pair map, so downstream callers don't
+    redo the workspace walk or recompute UUIDs.
+
+    Attributes:
+        assignments: record_uuid → PartitionManifestEntry, covering every
+            input pair (existing + newly assigned).
+        pairs_by_rid: record_uuid → QueryResponsePair for every input pair.
+        calibration_fraction: Per-task resolved fraction in force this run.
+            ``0.0`` for tasks absent from the workspaces topology.
+    """
+
+    assignments: dict[str, PartitionManifestEntry]
+    pairs_by_rid: dict[str, QueryResponsePair]
+    calibration_fraction: dict[Task, float]
+
+
 def assign_partitions(
     pairs: list[QueryResponsePair],
     *,
     manifest: PartitionManifest,
     settings: AnnotationSettings,
     import_id: str,
-) -> dict[str, PartitionManifestEntry]:
+) -> PartitionResult:
     """Resolve per-(task, annotation-item) calibration assignments.
 
     The annotation item differs by task: for grounding and generation, one item
@@ -262,13 +283,14 @@ def assign_partitions(
         import_id: Stamped on new entries for provenance.
 
     Returns:
-        record_uuid -> PartitionManifestEntry map covering every input pair
-        (existing + newly assigned).
+        A ``PartitionResult`` bundling the assignments, the rid → pair map, and
+        the per-task fraction resolved this run.
     """
     now = datetime.now(timezone.utc)
     seed = manifest.partition_seed
     workspace_for_task = _invert_workspace_map(settings)
 
+    pairs_by_rid: dict[str, QueryResponsePair] = {derive_record_uuid(pair): pair for pair in pairs}
     per_task_fraction: dict[Task, float] = {}
     threshold_for_task: dict[Task, int | None] = {}
     for task in Task:
@@ -287,10 +309,9 @@ def assign_partitions(
         return fraction >= 1.0 or (threshold is not None and _calibration_digest(unit_id, task, seed) < threshold)
 
     active_tasks = {task for task in Task if workspace_for_task.get(task) is not None}
-    result: dict[str, PartitionManifestEntry] = {}
+    assignments: dict[str, PartitionManifestEntry] = {}
     changed = False
-    for pair in pairs:
-        rid = derive_record_uuid(pair)
+    for rid, pair in pairs_by_rid.items():
         existing = manifest.assignments.get(rid)
         if existing is None:
             grnd_gen: dict[Task, bool] = {}
@@ -306,7 +327,7 @@ def assign_partitions(
                 assigned_at=now,
             )
             manifest.assignments[rid] = entry
-            result[rid] = entry
+            assignments[rid] = entry
             changed = True
             continue
 
@@ -314,11 +335,15 @@ def assign_partitions(
         if entry is not existing:
             manifest.assignments[rid] = entry
             changed = True
-        result[rid] = entry
+        assignments[rid] = entry
 
     if changed:
         manifest.updated_at = now
-    return result
+    return PartitionResult(
+        assignments=assignments,
+        pairs_by_rid=pairs_by_rid,
+        calibration_fraction=per_task_fraction,
+    )
 
 
 def _backfill_entry(
@@ -388,36 +413,34 @@ def _write_unit(
         grnd_gen[task] = is_cal
 
 
-def count_calibration_per_task(entries: Iterable[PartitionManifestEntry]) -> dict[Task, int]:
-    """Per-task calibration unit count across a collection of entries.
+@dataclass(frozen=True)
+class TaskUnitCounts:
+    """Per-task tallies across a collection of manifest entries.
 
-    Single pass over ``entries``. For retrieval, counts chunks; for grounding
-    and generation, counts records.
+    Annotation units are chunks for retrieval and records for grounding /
+    generation. ``calibration`` counts only items routed to calibration;
+    ``total`` counts all items (calibration + production).
     """
-    counts: dict[Task, int] = {task: 0 for task in Task}
-    for entry in entries:
-        for task in (Task.GROUNDING, Task.GENERATION):
-            if entry.grounding_generation_calibration.get(task, False):
-                counts[task] += 1
-        for is_cal in entry.retrieval_chunk_calibration.values():
-            if is_cal:
-                counts[Task.RETRIEVAL] += 1
-    return counts
+
+    calibration: dict[Task, int]
+    total: dict[Task, int]
 
 
-def _total_units_per_task(entries: Iterable[PartitionManifestEntry]) -> dict[Task, int]:
-    """Per-task total annotation-unit count across entries.
-
-    For retrieval, sums chunks; for grounding/generation, counts records that
-    carry a flag for that task.
-    """
-    totals: dict[Task, int] = {task: 0 for task in Task}
+def count_units_per_task(entries: Iterable[PartitionManifestEntry]) -> TaskUnitCounts:
+    """Single pass over ``entries`` returning per-task calibration and total counts."""
+    calibration: dict[Task, int] = {task: 0 for task in Task}
+    total: dict[Task, int] = {task: 0 for task in Task}
     for entry in entries:
         for task in (Task.GROUNDING, Task.GENERATION):
             if task in entry.grounding_generation_calibration:
-                totals[task] += 1
-        totals[Task.RETRIEVAL] += len(entry.retrieval_chunk_calibration)
-    return totals
+                total[task] += 1
+                if entry.grounding_generation_calibration[task]:
+                    calibration[task] += 1
+        for is_cal in entry.retrieval_chunk_calibration.values():
+            total[Task.RETRIEVAL] += 1
+            if is_cal:
+                calibration[Task.RETRIEVAL] += 1
+    return TaskUnitCounts(calibration=calibration, total=total)
 
 
 def _configured_fraction_per_task(settings: AnnotationSettings) -> dict[Task, float]:
@@ -469,13 +492,13 @@ def summarize_partitions(
 ) -> PartitionSummary:
     """Compute per-task partition reporting from manifest entries + settings.
 
-    Counts calibration vs total annotation items per task (retrieval counts
-    chunks; grounding/generation count records), derives the realised
-    calibration fraction, and resolves the configured fraction per task.
+    Counts calibration vs total annotation items per task in a single pass
+    (retrieval counts chunks; grounding/generation count records), derives the
+    realised calibration fraction, and resolves the configured fraction per task.
     """
-    entries = list(entries)
-    calibration_count = count_calibration_per_task(entries)
-    total_count = _total_units_per_task(entries)
+    counts = count_units_per_task(entries)
+    calibration_count = counts.calibration
+    total_count = counts.total
     production_count = {task: total_count[task] - calibration_count[task] for task in Task}
     realised_fraction = {
         task: (calibration_count[task] / total_count[task]) if total_count[task] else 0.0 for task in Task
@@ -496,7 +519,7 @@ def summarize_partitions(
 
 
 def _build_batches(
-    records: list[QueryResponsePair],
+    pairs_by_rid: dict[str, QueryResponsePair],
     assignments: dict[str, PartitionManifestEntry],
 ) -> dict[tuple[Task, bool], list[rg.Record]]:
     """Build Argilla records keyed by (task, calibration) bucket.
@@ -509,8 +532,7 @@ def _build_batches(
     batches: dict[tuple[Task, bool], list[rg.Record]] = {
         (task, is_cal): [] for task in Task for is_cal in (False, True)
     }
-    for pair in records:
-        record_uuid = derive_record_uuid(pair)
+    for record_uuid, pair in pairs_by_rid.items():
         entry = assignments[record_uuid]
         grnd_cal = entry.grounding_generation_calibration.get(Task.GROUNDING, False)
         gen_cal = entry.grounding_generation_calibration.get(Task.GENERATION, False)
@@ -598,10 +620,9 @@ def _ensure_dataset(
 
 def fan_out_records(
     client: rg.Argilla,
-    records: list[QueryResponsePair],
     settings: AnnotationSettings,
     *,
-    assignments: dict[str, PartitionManifestEntry],
+    partition: PartitionResult,
 ) -> dict[str, int]:
     """Build and log Argilla records to per-purpose datasets.
 
@@ -610,20 +631,17 @@ def fan_out_records(
 
     Args:
         client: Argilla client.
-        records: Validated input pairs.
         settings: Annotation settings (topology, dataset_id).
-        assignments: Per-record manifest entries from ``assign_partitions``.
-            Each entry carries per-task and per-chunk calibration flags; the
-            caller has already pinned each annotation item to a bucket via
-            the manifest.
+        partition: Output of ``assign_partitions``. Carries both the per-record
+            manifest entries and the pair-by-rid map needed for fan-out.
 
     Returns:
         Mapping of dataset name to record count for that dataset. Per-task
-        calibration vs production totals are computable from ``assignments``
-        and stay in the api layer.
+        calibration vs production totals are computable from
+        ``partition.assignments`` and stay in the api layer.
     """
     task_to_ws = _invert_workspace_map(settings)
-    batches = _build_batches(records, assignments)
+    batches = _build_batches(partition.pairs_by_rid, partition.assignments)
 
     dataset_counts: dict[str, int] = {}
 

--- a/tests/unit/api/test_annotation.py
+++ b/tests/unit/api/test_annotation.py
@@ -150,7 +150,7 @@ class TestImportRecords:
 
         mock_fan_out.assert_called_once()
         assert mock_client is mock_fan_out.call_args[0][0]
-        assert len(mock_fan_out.call_args[0][1]) == 1
+        assert len(mock_fan_out.call_args.kwargs["partition"].pairs_by_rid) == 1
 
     @patch("pragmata.api.annotation_import.fan_out_records")
     def test_resolves_dataset_id(self, mock_fan_out: MagicMock) -> None:
@@ -158,7 +158,7 @@ class TestImportRecords:
 
         import_records([], dataset_id="myprefix")
 
-        settings: AnnotationSettings = mock_fan_out.call_args[0][2]
+        settings: AnnotationSettings = mock_fan_out.call_args[0][1]
         assert settings.dataset_id == "myprefix"
 
     @patch("pragmata.api.annotation_import.fan_out_records")
@@ -199,7 +199,7 @@ class TestImportRecords:
         assert len(result.errors) == 1
         assert result.errors[0].index == 1
         # Only the valid record was passed to fan_out
-        assert len(mock_fan_out.call_args[0][1]) == 1
+        assert len(mock_fan_out.call_args.kwargs["partition"].pairs_by_rid) == 1
 
     @patch("pragmata.api.annotation_import.fan_out_records")
     def test_all_invalid_skips_fan_out(self, mock_fan_out: MagicMock) -> None:
@@ -211,7 +211,7 @@ class TestImportRecords:
         assert result.total_records == 2
         assert len(result.errors) == 2
         # fan_out called with empty records list
-        assert mock_fan_out.call_args[0][1] == []
+        assert mock_fan_out.call_args.kwargs["partition"].pairs_by_rid == {}
 
     @patch("pragmata.api.annotation_import.fan_out_records")
     def test_accepts_json_file_path(self, mock_fan_out: MagicMock, tmp_path: Path) -> None:
@@ -303,7 +303,7 @@ class TestImportRecords:
 
         import_records([], dataset_id="test", locale_catalog_dir=catalog_dir)
 
-        settings: AnnotationSettings = mock_fan_out.call_args[0][2]
+        settings: AnnotationSettings = mock_fan_out.call_args[0][1]
         assert settings.locale_catalog_dir == catalog_dir
         mock_register.assert_called_once_with(catalog_dir)
 
@@ -322,7 +322,7 @@ class TestImportRecords:
 
         import_records([], dataset_id="test", config_path=config_path, locale_catalog_dir=kwarg_dir)
 
-        settings: AnnotationSettings = mock_fan_out.call_args[0][2]
+        settings: AnnotationSettings = mock_fan_out.call_args[0][1]
         assert settings.locale_catalog_dir == kwarg_dir
         mock_register.assert_called_once_with(kwarg_dir)
 
@@ -339,7 +339,7 @@ class TestImportRecords:
 
         import_records([], dataset_id="test", config_path=config_path)
 
-        settings: AnnotationSettings = mock_fan_out.call_args[0][2]
+        settings: AnnotationSettings = mock_fan_out.call_args[0][1]
         assert settings.locale_catalog_dir == config_dir
         mock_register.assert_called_once_with(config_dir)
 

--- a/tests/unit/core/annotation/test_fan_out_records.py
+++ b/tests/unit/core/annotation/test_fan_out_records.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from pragmata.core.annotation.record_builder import derive_record_uuid, fan_out_records
+from pragmata.core.annotation.record_builder import PartitionResult, derive_record_uuid, fan_out_records
 from pragmata.core.schemas.annotation_import import Chunk, PartitionManifestEntry, QueryResponsePair
 from pragmata.core.schemas.annotation_task import Task
 from pragmata.core.settings.annotation_settings import AnnotationSettings, TaskSettings, WorkspaceSettings
@@ -21,6 +21,18 @@ def _make_pair(query: str) -> QueryResponsePair:
         answer="A.",
         chunks=[Chunk(chunk_id=f"c-{query}", doc_id="d", chunk_rank=1, text="t")],
         context_set="ctx",
+    )
+
+
+def _partition(
+    records: list[QueryResponsePair],
+    assignments: dict[str, PartitionManifestEntry],
+) -> PartitionResult:
+    """Build a PartitionResult mirroring what assign_partitions would produce."""
+    return PartitionResult(
+        assignments=assignments,
+        pairs_by_rid={derive_record_uuid(p): p for p in records},
+        calibration_fraction={t: 0.5 for t in Task},
     )
 
 
@@ -109,7 +121,7 @@ def patched_create_dataset(fake_dataset_factory):
 class TestFanOutRecords:
     def test_empty_records_returns_empty_counts(self, patched_create_dataset) -> None:
         client = MagicMock()
-        result = fan_out_records(client, records=[], settings=_settings(), assignments={})
+        result = fan_out_records(client, _settings(), partition=_partition([], {}))
         assert result == {}
 
     def test_production_only_logs_to_production_datasets(self, patched_create_dataset) -> None:
@@ -118,7 +130,7 @@ class TestFanOutRecords:
         records = [_make_pair(f"q{i}") for i in range(3)]
         assignments = _assignments_with_uniform_calibration(records, is_cal=False)
 
-        result = fan_out_records(client, records=records, settings=_settings(), assignments=assignments)
+        result = fan_out_records(client, _settings(), partition=_partition(records, assignments))
 
         # One production dataset per task; no calibration datasets created.
         assert all(ds_name.endswith("_production_run1") for (_, ds_name) in created)
@@ -132,7 +144,7 @@ class TestFanOutRecords:
         records = [_make_pair(f"q{i}") for i in range(2)]
         assignments = _assignments_with_uniform_calibration(records, is_cal=True)
 
-        result = fan_out_records(client, records=records, settings=_settings(), assignments=assignments)
+        result = fan_out_records(client, _settings(), partition=_partition(records, assignments))
 
         assert all(ds_name.endswith("_calibration_run1") for (_, ds_name) in created)
         assert len(result) == 3
@@ -144,7 +156,7 @@ class TestFanOutRecords:
         # First two records calibration, last two production (uniform across tasks/chunks).
         assignments = _assignments_split_by_index(records, cal_threshold=2)
 
-        fan_out_records(client, records=records, settings=_settings(), assignments=assignments)
+        fan_out_records(client, _settings(), partition=_partition(records, assignments))
 
         purposes = {ds_name.split("_")[-2] for (_, ds_name) in created}
         assert purposes == {"calibration", "production"}
@@ -159,9 +171,8 @@ class TestFanOutRecords:
         with pytest.raises(RuntimeError, match="topology disables calibration"):
             fan_out_records(
                 client,
-                records=records,
-                settings=_settings(calibration_enabled=False),
-                assignments=assignments,
+                _settings(calibration_enabled=False),
+                partition=_partition(records, assignments),
             )
 
     def test_dataset_counts_reflect_per_dataset_record_counts(self, patched_create_dataset) -> None:
@@ -170,7 +181,7 @@ class TestFanOutRecords:
         # Three calibration, two production - uniform per task.
         assignments = _assignments_split_by_index(records, cal_threshold=3)
 
-        result = fan_out_records(client, records=records, settings=_settings(), assignments=assignments)
+        result = fan_out_records(client, _settings(), partition=_partition(records, assignments))
 
         # Each task contributes one production count and one calibration count;
         # each grouping reflects the assignment split.
@@ -193,7 +204,7 @@ class TestFanOutRecords:
         assignments = _assignments_with_uniform_calibration(records, is_cal=False)
 
         with caplog.at_level("WARNING"):
-            result = fan_out_records(client, records=records, settings=partial_settings, assignments=assignments)
+            result = fan_out_records(client, partial_settings, partition=_partition(records, assignments))
 
         # Only retrieval gets a dataset; grounding and generation are skipped with a warning.
         assert len(result) == 1
@@ -227,7 +238,7 @@ class TestFanOutRecords:
             )
         }
 
-        fan_out_records(client, records=[pair], settings=_settings(), assignments=assignments)
+        fan_out_records(client, _settings(), partition=_partition([pair], assignments))
 
         # Both retrieval datasets must exist (some chunks in cal, some in prod).
         ret_purposes = {ds_name.split("_")[-2] for (ws, ds_name) in created if ws == "retrieval"}
@@ -294,7 +305,7 @@ class TestImportLocaleConflict:
 
         with patch("pragmata.core.annotation.record_builder.create_dataset", side_effect=_create):
             with caplog.at_level("WARNING", logger="pragmata.core.annotation.record_builder"):
-                result = fan_out_records(MagicMock(), records=records, settings=settings_de, assignments=assignments)
+                result = fan_out_records(MagicMock(), settings_de, partition=_partition(records, assignments))
 
         # Records were appended (no error raised), and a warning was logged.
         # Assert against locale .name rather than the %r-formatted .value so the

--- a/tests/unit/core/annotation/test_partition.py
+++ b/tests/unit/core/annotation/test_partition.py
@@ -98,10 +98,10 @@ class TestAssignPartitions:
     def test_full_fraction_all_calibration(self, empty_manifest: PartitionManifest) -> None:
         settings = _default_settings(calibration_fraction=1.0)
         pairs = [_make_pair(f"q{i}") for i in range(5)]
-        result = assign_partitions(pairs, manifest=empty_manifest, settings=settings, import_id="imp1")
+        partition = assign_partitions(pairs, manifest=empty_manifest, settings=settings, import_id="imp1")
 
-        assert len(result) == 5
-        for entry in result.values():
+        assert len(partition.assignments) == 5
+        for entry in partition.assignments.values():
             # Every task: every unit is calibration
             assert entry.grounding_generation_calibration[Task.GROUNDING] is True
             assert entry.grounding_generation_calibration[Task.GENERATION] is True
@@ -110,9 +110,9 @@ class TestAssignPartitions:
     def test_zero_fraction_all_production(self, empty_manifest: PartitionManifest) -> None:
         settings = _default_settings(calibration_fraction=0.0)
         pairs = [_make_pair(f"q{i}", n_chunks=3) for i in range(5)]
-        result = assign_partitions(pairs, manifest=empty_manifest, settings=settings, import_id="imp1")
+        partition = assign_partitions(pairs, manifest=empty_manifest, settings=settings, import_id="imp1")
 
-        for entry in result.values():
+        for entry in partition.assignments.values():
             assert entry.grounding_generation_calibration[Task.GROUNDING] is False
             assert entry.grounding_generation_calibration[Task.GENERATION] is False
             assert not any(entry.retrieval_chunk_calibration.values())
@@ -122,12 +122,12 @@ class TestAssignPartitions:
         settings = _default_settings(calibration_fraction=0.5)
         # 50 pairs × 4 chunks each = 200 retrieval units at fraction 0.5
         pairs = [_make_pair(f"q{i}", n_chunks=4) for i in range(50)]
-        result = assign_partitions(pairs, manifest=empty_manifest, settings=settings, import_id="imp1")
+        partition = assign_partitions(pairs, manifest=empty_manifest, settings=settings, import_id="imp1")
 
         # Some pairs should have a mixed retrieval calibration set (not all True or all False).
         mixed = sum(
             1
-            for entry in result.values()
+            for entry in partition.assignments.values()
             if 0 < sum(entry.retrieval_chunk_calibration.values()) < len(entry.retrieval_chunk_calibration)
         )
         assert mixed > 0, "no pairs had per-chunk mixing - partition might still be per-record"
@@ -146,11 +146,11 @@ class TestAssignPartitions:
             assigned_at=datetime.now(timezone.utc),
         )
 
-        result = assign_partitions([pair], manifest=empty_manifest, settings=settings, import_id="imp2")
+        partition = assign_partitions([pair], manifest=empty_manifest, settings=settings, import_id="imp2")
 
         # Existing assignment preserved despite fraction=1.0 in new settings.
-        assert result[rid].grounding_generation_calibration[Task.GROUNDING] is False
-        assert result[rid].import_id == "prior"
+        assert partition.assignments[rid].grounding_generation_calibration[Task.GROUNDING] is False
+        assert partition.assignments[rid].import_id == "prior"
 
     def test_new_records_stamp_per_task_fraction(self, empty_manifest: PartitionManifest) -> None:
         """Per-task fractions are stamped on each new entry."""
@@ -166,9 +166,9 @@ class TestAssignPartitions:
             },
         )
         pair = _make_pair("q0")
-        result = assign_partitions([pair], manifest=empty_manifest, settings=settings, import_id="imp1")
+        partition = assign_partitions([pair], manifest=empty_manifest, settings=settings, import_id="imp1")
         rid = derive_record_uuid(pair)
-        entry = result[rid]
+        entry = partition.assignments[rid]
 
         assert entry.calibration_fraction_at_import[Task.RETRIEVAL] == 0.1
         assert entry.calibration_fraction_at_import[Task.GROUNDING] == 0.5
@@ -183,7 +183,7 @@ class TestAssignPartitions:
         before = empty_manifest.assignments[rid]
         again = assign_partitions([pair], manifest=empty_manifest, settings=settings, import_id="imp2")
 
-        assert again[rid] is before  # same object - no rebuild, provenance intact
+        assert again.assignments[rid] is before  # same object - no rebuild, provenance intact
 
     def test_backfills_task_added_to_topology(self, empty_manifest: PartitionManifest) -> None:
         """A task gained by the topology backfills existing records via the same digest."""
@@ -195,8 +195,9 @@ class TestAssignPartitions:
             workspaces={"r": WorkspaceSettings(tasks={Task.RETRIEVAL: TaskSettings()})},
         )
         first = assign_partitions([pair], manifest=empty_manifest, settings=retrieval_only, import_id="imp1")
-        assert first[rid].grounding_generation_calibration == {}  # tasks not yet in topology
-        retrieval_flags = dict(first[rid].retrieval_chunk_calibration)
+        first_entry = first.assignments[rid]
+        assert first_entry.grounding_generation_calibration == {}  # tasks not yet in topology
+        retrieval_flags = dict(first_entry.retrieval_chunk_calibration)
 
         expanded = AnnotationSettings(
             calibration_fraction=0.5,
@@ -206,7 +207,8 @@ class TestAssignPartitions:
                 "x": WorkspaceSettings(tasks={Task.GENERATION: TaskSettings()}),
             },
         )
-        backfilled = assign_partitions([pair], manifest=empty_manifest, settings=expanded, import_id="imp2")[rid]
+        reimport = assign_partitions([pair], manifest=empty_manifest, settings=expanded, import_id="imp2")
+        backfilled = reimport.assignments[rid]
 
         # Retrieval untouched (manifest lock); provenance preserved; new tasks now assigned.
         assert backfilled.retrieval_chunk_calibration == retrieval_flags
@@ -223,7 +225,7 @@ class TestAssignPartitions:
             partition_seed=empty_manifest.partition_seed,
             assignments={},
         )
-        fresh = assign_partitions([pair], manifest=fresh_manifest, settings=expanded, import_id="imp3")[rid]
+        fresh = assign_partitions([pair], manifest=fresh_manifest, settings=expanded, import_id="imp3").assignments[rid]
         assert backfilled.grounding_generation_calibration == fresh.grounding_generation_calibration
 
 

--- a/tests/unit/core/annotation/test_partition.py
+++ b/tests/unit/core/annotation/test_partition.py
@@ -173,6 +173,35 @@ class TestAssignPartitions:
         assert entry.calibration_fraction_at_import[Task.RETRIEVAL] == 0.1
         assert entry.calibration_fraction_at_import[Task.GROUNDING] == 0.5
 
+    def test_calibration_fraction_resolves_per_task(self, empty_manifest: PartitionManifest) -> None:
+        """PartitionResult.calibration_fraction resolves task → workspace → deployment."""
+        settings = AnnotationSettings(
+            calibration_fraction=0.1,
+            workspaces={
+                "retrieval": WorkspaceSettings(
+                    tasks={Task.RETRIEVAL: TaskSettings(calibration_fraction=0.4)},
+                ),
+                "grounding": WorkspaceSettings(tasks={Task.GROUNDING: TaskSettings()}),
+                "generation": WorkspaceSettings(tasks={Task.GENERATION: TaskSettings()}),
+            },
+        )
+
+        partition = assign_partitions([], manifest=empty_manifest, settings=settings, import_id="imp1")
+
+        assert partition.calibration_fraction[Task.RETRIEVAL] == 0.4  # task override
+        assert partition.calibration_fraction[Task.GROUNDING] == 0.1  # deployment default
+        assert partition.calibration_fraction[Task.GENERATION] == 0.1
+
+    def test_calibration_fraction_zero_for_absent_task(self, empty_manifest: PartitionManifest) -> None:
+        """Tasks absent from the topology resolve to 0.0."""
+        settings = AnnotationSettings(
+            workspaces={"retrieval": WorkspaceSettings(tasks={Task.RETRIEVAL: TaskSettings()})},
+        )
+        partition = assign_partitions([], manifest=empty_manifest, settings=settings, import_id="imp1")
+
+        assert partition.calibration_fraction[Task.GROUNDING] == 0.0
+        assert partition.calibration_fraction[Task.GENERATION] == 0.0
+
     def test_reimport_same_topology_leaves_entry_untouched(self, empty_manifest: PartitionManifest) -> None:
         """No backfill when the topology is unchanged - existing entry is reused as-is."""
         settings = _default_settings(calibration_fraction=0.5)
@@ -275,7 +304,7 @@ class TestSummarizePartitions:
     """Per-task partition reporting derived in core (formerly inline in api/)."""
 
     def test_counts_chunks_for_retrieval_records_for_others(self) -> None:
-        settings = _default_settings(calibration_fraction=0.5)
+        configured_fraction = {t: 0.5 for t in Task}
         now = datetime.now(timezone.utc)
         # One record: grounding cal, generation prod; 3 retrieval chunks, 2 cal.
         entry = PartitionManifestEntry(
@@ -286,7 +315,7 @@ class TestSummarizePartitions:
             assigned_at=now,
         )
 
-        summary = summarize_partitions([entry], settings)
+        summary = summarize_partitions([entry], configured_fraction)
 
         assert summary.calibration_count[Task.RETRIEVAL] == 2
         assert summary.total_count[Task.RETRIEVAL] == 3
@@ -297,14 +326,13 @@ class TestSummarizePartitions:
         assert summary.total_count[Task.GENERATION] == 1
 
     def test_realised_fraction_zero_when_no_units(self) -> None:
-        settings = _default_settings(calibration_fraction=0.3)
-        summary = summarize_partitions([], settings)
+        summary = summarize_partitions([], {t: 0.3 for t in Task})
 
         assert all(summary.realised_fraction[t] == 0.0 for t in Task)
         assert all(summary.total_count[t] == 0 for t in Task)
 
     def test_realised_fraction_reflects_actual_split(self) -> None:
-        settings = _default_settings(calibration_fraction=0.5)
+        configured_fraction = {t: 0.5 for t in Task}
         now = datetime.now(timezone.utc)
         entries = [
             PartitionManifestEntry(
@@ -317,34 +345,14 @@ class TestSummarizePartitions:
             for i in range(4)
         ]
 
-        summary = summarize_partitions(entries, settings)
+        summary = summarize_partitions(entries, configured_fraction)
 
         # 1 of 4 grounding records calibration.
         assert summary.realised_fraction[Task.GROUNDING] == pytest.approx(0.25)
 
-    def test_configured_fraction_resolves_per_task(self) -> None:
-        settings = AnnotationSettings(
-            calibration_fraction=0.1,
-            workspaces={
-                "retrieval": WorkspaceSettings(
-                    tasks={Task.RETRIEVAL: TaskSettings(calibration_fraction=0.4)},
-                ),
-                "grounding": WorkspaceSettings(tasks={Task.GROUNDING: TaskSettings()}),
-                "generation": WorkspaceSettings(tasks={Task.GENERATION: TaskSettings()}),
-            },
-        )
+    def test_configured_fraction_carried_through_unchanged(self) -> None:
+        configured_fraction = {Task.RETRIEVAL: 0.4, Task.GROUNDING: 0.1, Task.GENERATION: 0.1}
 
-        summary = summarize_partitions([], settings)
+        summary = summarize_partitions([], configured_fraction)
 
-        assert summary.configured_fraction[Task.RETRIEVAL] == 0.4  # task override
-        assert summary.configured_fraction[Task.GROUNDING] == 0.1  # deployment default
-        assert summary.configured_fraction[Task.GENERATION] == 0.1
-
-    def test_configured_fraction_zero_for_absent_task(self) -> None:
-        settings = AnnotationSettings(
-            workspaces={"retrieval": WorkspaceSettings(tasks={Task.RETRIEVAL: TaskSettings()})},
-        )
-        summary = summarize_partitions([], settings)
-
-        assert summary.configured_fraction[Task.GROUNDING] == 0.0
-        assert summary.configured_fraction[Task.GENERATION] == 0.0
+        assert summary.configured_fraction == configured_fraction


### PR DESCRIPTION
**Stack (4 PRs):** #226 → #227 → #228 → #229 (companion to standalone IAA fix #225)

**Chain goal:** Switch calibration vs production assignment from per-`record_uuid` to per annotation item (chunk for retrieval, record for grounding / generation), with inheritable per-task fraction and absolute cap.

**This PR (3/4):** Pure refactor with no behaviour change. Tightens the api / core seam introduced in #227 so per-task fraction reporting and per-pair `record_uuid` derivation are each computed exactly once.

---

## Scope

- `core/annotation/record_builder.py`: introduce `PartitionResult(assignments, pairs_by_rid, calibration_fraction)`. `assign_partitions` now returns this bundle; `fan_out_records(client, settings, *, partition)` consumes it and `_build_batches(pairs_by_rid, assignments)` iterates the rid map instead of recomputing `derive_record_uuid(pair)` per pair.
- `core/annotation/record_builder.py`: replace `count_calibration_per_task` (returning `dict[Task, int]`) with `count_units_per_task` returning a `TaskUnitCounts(calibration, total)` frozen dataclass so the api layer gets both tallies in a single pass.
- `api/annotation_import.py`: drop `_total_units_per_task` and `_resolve_per_task_fraction`. The api now reads `partition.calibration_fraction` directly and uses the merged `count_units_per_task` helper.

## Why

After #227 lands, the api layer recomputes per-task fraction via its own workspace walk (`_resolve_per_task_fraction`), and `_build_batches` recomputes `record_uuid` for every pair even though `assign_partitions` already derived it. Both are wasted work; the natural fix is to surface the precomputed values via a bundle return type. This also unblocks the cap-related fields in #229 - `PartitionResult` is the obvious place to carry per-task cap resolution.

Reviewer sanity check: assertions in `test_partition.py` move from `result[rid]` to `partition.assignments[rid]`; the values they check are unchanged.

## Test plan
- [x] `uv run python -m pytest tests/unit` (770 passing)