### PR TITLE
fix(annotation): topology-vs-manifest guard + bounded fraction at all scopes

### DIFF
--- a/src/pragmata/api/annotation_import.py
+++ b/src/pragmata/api/annotation_import.py
@@ -209,7 +209,9 @@ def import_records(
 
         # Manifest is written only after fan-out succeeds. On failure, the
         # in-memory assignments are dropped; a retry with the same corpus + seed
-        # re-derives identical buckets (deterministic per-unit hashing).
+        # re-derives identical buckets under the fraction-only path. Under a
+        # binding cap, retries are order-dependent (see
+        # ``test_cap_under_split_imports_is_order_dependent_by_design``).
         dataset_counts = fan_out_records(client, settings, partition=partition)
         write_partition_manifest(import_paths.partition_manifest, manifest)
 

--- a/src/pragmata/core/annotation/record_builder.py
+++ b/src/pragmata/core/annotation/record_builder.py
@@ -684,8 +684,15 @@ def fan_out_records(
             continue
         ws_base = task_to_ws.get(task)
         if ws_base is None:
-            logger.warning("Task %r not in workspaces topology - skipping", task)
-            continue
+            # Manifest entries exist for a task absent from the current topology -
+            # silently skipping would drop data on disk. Force the operator to
+            # re-add the task or clear the affected partition manifest.
+            raise RuntimeError(
+                f"Task {task.value!r} has {len(rg_records)} records assigned via the "
+                f"partition manifest, but the current workspaces topology does not "
+                f"include this task. Re-add the task to the topology, or clear the "
+                f"partition manifest at the affected dataset scope."
+            )
         resolved = settings.resolved_task(ws_base, task)
         if calibration:
             if resolved.calibration_min_submitted is None:

--- a/tests/integration/test_annotation_calibration.py
+++ b/tests/integration/test_annotation_calibration.py
@@ -41,6 +41,19 @@ def _make_raw(i: int, *, n_chunks: int = 1) -> dict:
     }
 
 
+def _make_raw_multi_chunk(i: int, *, n_chunks: int) -> dict:
+    return {
+        "query": f"Question {i}?",
+        "answer": f"Answer {i}.",
+        "chunks": [
+            {"chunk_id": f"c{i}-{k}", "doc_id": "d1", "chunk_rank": k + 1, "text": f"Chunk {i}-{k}."}
+            for k in range(n_chunks)
+        ],
+        "context_set": "ctx-001",
+        "language": "en",
+    }
+
+
 def _manifest_path(base_dir: Path, dataset_id: str) -> Path:
     """Resolve the partition manifest path the same way the import API does."""
     workspace = WorkspacePaths.from_base_dir(base_dir)
@@ -275,6 +288,60 @@ def test_calibration_max_items_caps_grounding(client: rg.Argilla, base_dir: Path
         assert cal_ds is not None and prod_ds is not None
         assert len(list(cal_ds.records)) == 3
         assert len(list(prod_ds.records)) == 27
+    finally:
+        teardown_resources(client, auto_settings)
+
+
+def test_per_chunk_retrieval_routing_to_argilla(client: rg.Argilla, base_dir: Path) -> None:
+    """Different chunks of one record can land in different retrieval datasets on Argilla."""
+    auto_id = "testperchunk"
+    auto_settings = AnnotationSettings(dataset_id=auto_id)
+    teardown_resources(client, auto_settings)
+    setup_workspaces(client, auto_settings)
+
+    try:
+        # 30 records × 4 chunks = 120 retrieval units at fraction=0.5; per-chunk
+        # independence means some pairs end up with a mixed retrieval bucket set.
+        records = [_make_raw_multi_chunk(i, n_chunks=4) for i in range(30)]
+        import_records(records, dataset_id=auto_id, base_dir=base_dir, calibration_fraction=0.5, **_CREDS)
+
+        manifest_path = _manifest_path(base_dir, auto_id)
+        manifest = PartitionManifest.model_validate_json(manifest_path.read_text())
+
+        mixed = sum(
+            1
+            for entry in manifest.assignments.values()
+            if 0 < sum(entry.retrieval_chunk_calibration.values()) < len(entry.retrieval_chunk_calibration)
+        )
+        assert mixed > 0, "per-chunk independence not realised - no pair had a mixed retrieval bucket"
+
+        cal_ds = client.datasets(
+            dataset_name(Task.RETRIEVAL, calibration=True, dataset_id=auto_id),
+            workspace="retrieval",
+        )
+        prod_ds = client.datasets(
+            dataset_name(Task.RETRIEVAL, calibration=False, dataset_id=auto_id),
+            workspace="retrieval",
+        )
+        assert cal_ds is not None and prod_ds is not None
+
+        expected_cal_chunks = {
+            chunk_id
+            for entry in manifest.assignments.values()
+            for chunk_id, is_cal in entry.retrieval_chunk_calibration.items()
+            if is_cal
+        }
+        expected_prod_chunks = {
+            chunk_id
+            for entry in manifest.assignments.values()
+            for chunk_id, is_cal in entry.retrieval_chunk_calibration.items()
+            if not is_cal
+        }
+        cal_chunk_ids = {r.metadata["chunk_id"] for r in cal_ds.records}
+        prod_chunk_ids = {r.metadata["chunk_id"] for r in prod_ds.records}
+        assert cal_chunk_ids == expected_cal_chunks
+        assert prod_chunk_ids == expected_prod_chunks
+        assert cal_chunk_ids.isdisjoint(prod_chunk_ids)
     finally:
         teardown_resources(client, auto_settings)
 

--- a/tests/unit/core/annotation/test_fan_out_records.py
+++ b/tests/unit/core/annotation/test_fan_out_records.py
@@ -192,11 +192,11 @@ class TestFanOutRecords:
         assert cal_total == 3 * 3  # 3 cal records * 3 tasks
         assert prod_total == 2 * 3  # 2 prod records * 3 tasks
 
-    def test_skips_tasks_not_in_workspaces_topology(self, patched_create_dataset, caplog) -> None:
+    def test_records_for_task_absent_from_topology_raises(self, patched_create_dataset) -> None:
         client = MagicMock()
-        _, created = patched_create_dataset
 
-        # Topology only declares retrieval; grounding/generation are absent.
+        # Topology only declares retrieval; grounding / generation are absent
+        # but the partition manifest has assignments for them.
         partial_settings = AnnotationSettings(
             dataset_id="run1",
             workspaces={"retrieval": WorkspaceSettings(tasks={Task.RETRIEVAL: TaskSettings()})},
@@ -204,13 +204,8 @@ class TestFanOutRecords:
         records = [_make_pair("q0")]
         assignments = _assignments_with_uniform_calibration(records, is_cal=False)
 
-        with caplog.at_level("WARNING"):
-            result = fan_out_records(client, partial_settings, partition=_partition(records, assignments))
-
-        # Only retrieval gets a dataset; grounding and generation are skipped with a warning.
-        assert len(result) == 1
-        assert any(ds_name.startswith("retrieval_") for (_, ds_name) in created)
-        assert "not in workspaces topology" in caplog.text
+        with pytest.raises(RuntimeError, match="not include this task"):
+            fan_out_records(client, partial_settings, partition=_partition(records, assignments))
 
     def test_per_chunk_retrieval_routing(self, patched_create_dataset) -> None:
         """Different chunks of one record can route to different retrieval buckets."""


### PR DESCRIPTION
**Follow-up to stack:** #226 → #227 → #228 → #229 (companion to standalone IAA fix #225)

**This PR:** Two small hardening fixes uncovered by audit on the per-item partition stack, plus per-chunk integration coverage.

---

## Scope

- `core/annotation/record_builder.py`: `fan_out_records` now raises `RuntimeError` when the partition manifest assigns records to a task absent from the current workspaces topology. Previously it warned and continued, silently dropping data on disk if an operator reshaped their workspaces between imports.
- `core/settings/annotation_settings.py`: workspace- and task-scoped `calibration_fraction` now constrained to `[0.0, 1.0]` via a shared `CalibrationFraction = Annotated[float, Field(ge=0.0, le=1.0)]` alias. The deployment-scope guard already had this range check; the new alias closes the gap so a YAML setting of `workspaces.x.calibration_fraction: 1.5` is rejected at load.
- `api/annotation_import.py`: clarify the manifest-write-ordering comment - a retry under a binding cap is order-dependent (the cap-vs-existing logic is documented in `test_cap_under_split_imports_is_order_dependent_by_design`).
- Tests: `test_records_for_task_absent_from_topology_raises` replaces the prior warn-and-skip test. Locale-mismatch test gets a complete 3-task topology so the topology guard isn't tripped incidentally.
- Integration: `test_per_chunk_retrieval_routing_to_argilla` verifies per-chunk independence end-to-end against a live Argilla dataset (assignments in the manifest match the chunk_ids actually present in each retrieval dataset).

## Why

1. The topology-vs-manifest path was silent data loss. If a user removed a task from their workspace topology while old manifest entries for that task existed, `fan_out_records` quietly skipped them with a `logger.warning`. Promoting to `RuntimeError` forces the operator to address the inconsistency (either re-add the task or clear the affected partition manifest).

2. The deployment-level `calibration_fraction` field had `Field(ge=0.0, le=1.0)`, but the workspace and task variants were typed `float | Inherit` with no range check. A YAML setting of `workspaces.x.calibration_fraction: 1.5` validated, then resolved to a value `>= 1.0`, then routed 100% to calibration. The bounded alias closes that gap consistently across scopes.

## Test plan
- [x] `uv run python -m pytest tests/unit` (770 passing)
- [x] `uv run python -m pytest tests/integration/test_annotation_calibration.py -m "integration and annotation"` (8/9 passing; 1 pre-existing failure in `TestPerWorkspaceMinSubmitted::test_workspace_carve_out_creates_correct_dataset_min_submitted` exists on `main` already)