### PR TITLE
feat(annotation): configurable per-field markdown rendering

### DIFF
--- a/docs/decisions/0009-annotation-schema-configurability.md
+++ b/docs/decisions/0009-annotation-schema-configurability.md
@@ -31,3 +31,10 @@ Any future schema change is a breaking design decision requiring a new ADR and n
 - Schema definitions should live in a dedicated module, not inline with orchestration logic, to make the fork-and-modify path obvious
 - Any schema change requires updating/reviewing the annotation-related ADRs first (metrics taxonomy + annotation tasks + presentation), then updating the code implementation
 - See [Annotation Protocol](../methodology/annotation-protocol.md) and [Annotation Interface](../design/annotation-interface.md) for current schema definitions
+
+
+## Addendum: rendering flags are operational, not schema
+
+Rendering flags on existing fields — `use_markdown` on `rg.TextField`, `v-html` vs. text interpolation in CustomField templates — are operational, not schema. They do not affect the labels collected, the export format, or comparability across deployments; they only change how existing content is presented in the annotator UI.
+
+They are therefore configurable via `AnnotationSettings.field_render_mode` (deployment / workspace / task scopes, sparse-dict overlay), in the same operational layer as `min_submitted`, `constraint_severity`, and `locale`. This does not relax the hardcoded constraint on which fields, questions, and labels exist.

--- a/src/pragmata/core/annotation/argilla_task_definitions.py
+++ b/src/pragmata/core/annotation/argilla_task_definitions.py
@@ -95,13 +95,16 @@ def _render_constraints_template(
 def build_task_settings(settings: AnnotationSettings) -> dict[Task, rg.Settings]:
     """Build Argilla Settings for each annotation task.
 
-    Not cached: result depends on ``settings`` (severity resolution per task's
-    owning workspace). Callers should hold the returned dict for the duration
-    of an import operation rather than calling repeatedly. Deferred
-    construction: call after an Argilla client is connected (or with a mock
-    client in tests).
+    Not cached: result depends on ``settings`` (severity and render-mode
+    resolution per task's owning workspace). Callers should hold the returned
+    dict for the duration of an import operation rather than calling
+    repeatedly. Deferred construction: call after an Argilla client is
+    connected (or with a mock client in tests).
     """
     task_to_ws = settings.task_to_workspace()
+
+    def md(task: Task, name: str) -> bool:
+        return settings.resolved_render_mode(task_to_ws[task], task, name) == "markdown"
     template_text = files("pragmata.core.annotation").joinpath("collapsible_field.html").read_text(encoding="utf-8")
     discard_template = files("pragmata.core.annotation").joinpath("discard_flow.html").read_text(encoding="utf-8")
     constraints_template = (
@@ -239,8 +242,8 @@ def build_task_settings(settings: AnnotationSettings) -> dict[Task, rg.Settings]
         Task.RETRIEVAL: lambda: assemble(
             Task.RETRIEVAL,
             content_fields=[
-                rg.TextField(name="query", title="Query", required=True),
-                rg.TextField(name="chunk", title="Chunk", required=True),
+                rg.TextField(name="query", title="Query", required=True, use_markdown=md(Task.RETRIEVAL, "query")),
+                rg.TextField(name="chunk", title="Chunk", required=True, use_markdown=md(Task.RETRIEVAL, "chunk")),
                 _collapsible_field("generated_answer", "Generated answer", template_text),
             ],
             questions=retrieval_questions,
@@ -256,8 +259,13 @@ def build_task_settings(settings: AnnotationSettings) -> dict[Task, rg.Settings]
         Task.GROUNDING: lambda: assemble(
             Task.GROUNDING,
             content_fields=[
-                rg.TextField(name="answer", title="Answer", required=True),
-                rg.TextField(name="context_set", title="Context set", required=True),
+                rg.TextField(name="answer", title="Answer", required=True, use_markdown=md(Task.GROUNDING, "answer")),
+                rg.TextField(
+                    name="context_set",
+                    title="Context set",
+                    required=True,
+                    use_markdown=md(Task.GROUNDING, "context_set"),
+                ),
                 _collapsible_field("query", "Query", template_text),
             ],
             questions=grounding_questions,
@@ -270,8 +278,8 @@ def build_task_settings(settings: AnnotationSettings) -> dict[Task, rg.Settings]
         Task.GENERATION: lambda: assemble(
             Task.GENERATION,
             content_fields=[
-                rg.TextField(name="query", title="Query", required=True),
-                rg.TextField(name="answer", title="Answer", required=True),
+                rg.TextField(name="query", title="Query", required=True, use_markdown=md(Task.GENERATION, "query")),
+                rg.TextField(name="answer", title="Answer", required=True, use_markdown=md(Task.GENERATION, "answer")),
                 _collapsible_field("context_set", "Context set", template_text),
             ],
             questions=generation_questions,

--- a/src/pragmata/core/annotation/collapsible_field.html
+++ b/src/pragmata/core/annotation/collapsible_field.html
@@ -28,7 +28,11 @@
 <script>
   var field = record.fields["$field_name"];
   var text = (typeof field === "object" && field !== null) ? (field.text || "") : (field || "");
-  document.getElementById("content").textContent = text;
+  // innerHTML so embedded HTML in pipeline-sourced content (e.g. publikationsbot
+  // output) renders rather than escapes. Trust assumption: record content comes
+  // from a first-party pipeline. Plain text in HTML context still renders as
+  // plain text — no double-conversion concerns.
+  document.getElementById("content").innerHTML = text;
 
   // Size iframe to match content height. scrollHeight is clamped
   // to >= viewport (iframe) height, so shrink to 0 first then

--- a/src/pragmata/core/schemas/annotation_task.py
+++ b/src/pragmata/core/schemas/annotation_task.py
@@ -1,6 +1,7 @@
 """Annotation task type enum, shared across import and export schemas."""
 
 from enum import StrEnum
+from typing import Literal
 
 
 class Task(StrEnum):
@@ -17,3 +18,28 @@ class DiscardReason(StrEnum):
     INVALID_OR_UNREALISTIC = "invalid_or_unrealistic"
     UNCLEAR = "unclear"
     OUTSIDE_REVIEWER_EXPERTISE = "outside_reviewer_expertise"
+
+
+type FieldRenderMode = Literal["plain", "markdown"]
+"""Rendering mode for a TextField in the Argilla UI.
+
+``markdown`` enables the markdown renderer, which also handles inline raw HTML
+(useful when content comes from a pipeline that emits HTML). ``plain`` (default)
+renders escaped text. Configurable per field via
+:class:`pragmata.core.settings.annotation_settings.AnnotationSettings.field_render_mode`.
+"""
+
+
+TEXT_FIELDS: dict[Task, frozenset[str]] = {
+    Task.RETRIEVAL: frozenset({"query", "chunk"}),
+    Task.GROUNDING: frozenset({"answer", "context_set"}),
+    Task.GENERATION: frozenset({"query", "answer"}),
+}
+"""Registry of ``rg.TextField`` names per task.
+
+Source of truth for which fields are eligible for
+:attr:`AnnotationSettings.field_render_mode` configuration. Drift against
+the actual ``rg.TextField(name=...)`` calls in
+:mod:`pragmata.core.annotation.argilla_task_definitions` is caught by a
+module-load assertion in that module.
+"""

--- a/src/pragmata/core/settings/annotation_settings.py
+++ b/src/pragmata/core/settings/annotation_settings.py
@@ -9,11 +9,11 @@ losslessly through ``model_dump()``). ``resolved_task(workspace_name, task)``
 returns the **computed** values after walking task, workspace, deployment
 (the CSS "computed value" analogy: first non-``INHERIT`` ancestor wins).
 
-Multi-key maps (e.g. ``constraint_severity: dict[str, Severity]``) use
-**sparse-dict overlay** rather than the ``INHERIT`` sentinel: user-supplied keys
-override the deployment default for that key only; omitted keys fall through.
-This is the natural mechanism for dict-shaped fields; INHERIT is reserved for
-single-value primitives.
+Multi-key maps (e.g. ``constraint_severity: dict[str, Severity]``,
+``field_render_mode: dict[str, FieldRenderMode]``) use **sparse-dict overlay**
+rather than the ``INHERIT`` sentinel: user-supplied keys override the deployment
+default for that key only; omitted keys fall through. This is the natural
+mechanism for dict-shaped fields; INHERIT is reserved for single-value primitives.
 """
 
 from dataclasses import dataclass, field
@@ -23,7 +23,7 @@ from typing import Literal, Self
 from pydantic import BaseModel, ConfigDict, Field, NonNegativeInt, PositiveInt, model_validator
 
 from pragmata.core.annotation.logical_constraints import CONSTRAINT_BY_ID, Severity
-from pragmata.core.schemas.annotation_task import Task
+from pragmata.core.schemas.annotation_task import TEXT_FIELDS, FieldRenderMode, Task
 from pragmata.core.settings.settings_base import INHERIT, Inherit, ResolveSettings
 from pragmata.core.types import SafePathSegment
 
@@ -37,12 +37,17 @@ class ArgillaSettings(BaseModel):
 
 
 class TaskSettings(BaseModel):
-    """Per-task overrides; inherited fields default to ``INHERIT`` (use workspace value)."""
+    """Per-task overrides; inherited fields default to ``INHERIT`` (use workspace value).
+
+    ``field_render_mode`` is a sparse override map: only listed field names
+    override the workspace/deployment value; omitted keys fall through.
+    """
 
     model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
 
     production_min_submitted: PositiveInt | Inherit = INHERIT
     calibration_min_submitted: PositiveInt | None | Inherit = INHERIT
+    field_render_mode: dict[str, FieldRenderMode] = Field(default_factory=dict)
 
 
 class WorkspaceSettings(BaseModel):
@@ -50,9 +55,9 @@ class WorkspaceSettings(BaseModel):
 
     Inherited fields default to ``INHERIT`` (use deployment value). ``None`` on
     ``calibration_min_submitted`` explicitly disables calibration for any task
-    that inherits from this workspace. ``constraint_severity`` is a sparse
-    constraint-id to severity map: only listed constraint_ids override the
-    deployment value; omitted constraint_ids fall through to the deployment map.
+    that inherits from this workspace. ``constraint_severity`` and
+    ``field_render_mode`` are sparse override maps: only listed keys override
+    the deployment value; omitted keys fall through to the deployment map.
     """
 
     model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
@@ -60,6 +65,7 @@ class WorkspaceSettings(BaseModel):
     production_min_submitted: PositiveInt | Inherit = INHERIT
     calibration_min_submitted: PositiveInt | None | Inherit = INHERIT
     constraint_severity: dict[str, Severity] = Field(default_factory=dict)
+    field_render_mode: dict[str, FieldRenderMode] = Field(default_factory=dict)
     tasks: dict[Task, TaskSettings]
 
 
@@ -88,6 +94,14 @@ class AnnotationSettings(ResolveSettings):
             Inherited by workspaces/tasks.
         calibration_fraction: Fraction of records routed to a separate
             calibration dataset for IAA (0.0 disables; deployment-level only).
+        field_render_mode: Sparse override map of TextField name (e.g.
+            ``"answer"``) to render mode (``"plain"`` or ``"markdown"``).
+            Markdown rendering also handles inline raw HTML, useful when
+            content comes from a pipeline that emits HTML. Per-workspace
+            overrides live on ``WorkspaceSettings.field_render_mode``;
+            ``resolved_render_mode(workspace_name, field_name)`` walks
+            workspace then deployment. Unknown keys raise at validation
+            time. Defaults populate every known field with ``"plain"``.
     """
 
     argilla: ArgillaSettings = Field(default_factory=ArgillaSettings)
@@ -105,6 +119,9 @@ class AnnotationSettings(ResolveSettings):
             "contradiction_requires_unsupported": "block",
             "fabricated_requires_cited": "block",
         }
+    )
+    field_render_mode: dict[str, FieldRenderMode] = Field(
+        default_factory=lambda: {name: "plain" for names in TEXT_FIELDS.values() for name in names}
     )
     workspaces: dict[str, WorkspaceSettings] = Field(
         default_factory=lambda: {
@@ -130,6 +147,22 @@ class AnnotationSettings(ResolveSettings):
         if constraint_id in ws.constraint_severity:
             return ws.constraint_severity[constraint_id]
         return self.constraint_severity[constraint_id]
+
+    def resolved_render_mode(self, workspace_name: str, task: Task, field_name: str) -> FieldRenderMode:
+        """Return the computed render mode for a TextField: task → workspace → deployment.
+
+        Walks all three scopes via sparse overlay (per-key, not whole-dict):
+        the first scope that lists ``field_name`` wins. Deployment defaults
+        are guaranteed complete by the merge validator on ``field_render_mode``,
+        so the workspace and task scopes only need to be sparse overrides.
+        Unknown ``field_name`` raises ``KeyError``.
+        """
+        ws = self.workspaces[workspace_name]
+        ts = ws.tasks[task]
+        for scope in (ts.field_render_mode, ws.field_render_mode, self.field_render_mode):
+            if field_name in scope:
+                return scope[field_name]
+        raise KeyError(field_name)
 
     def resolved_task(self, workspace_name: str, task: Task) -> ResolvedTaskSettings:
         """Return the computed task settings: task → workspace → deployment.
@@ -171,6 +204,19 @@ class AnnotationSettings(ResolveSettings):
             data["constraint_severity"] = {**defaults, **data["constraint_severity"]}
         return data
 
+    @model_validator(mode="before")
+    @classmethod
+    def _merge_field_render_mode_defaults(cls, data: object) -> object:
+        """Overlay user-provided deployment render modes onto the built-in defaults.
+
+        Users supply only the field names they want to override; the rest fall
+        through to the field's default (all ``"plain"``).
+        """
+        if isinstance(data, dict) and isinstance(data.get("field_render_mode"), dict):
+            defaults = cls.model_fields["field_render_mode"].default_factory()
+            data["field_render_mode"] = {**defaults, **data["field_render_mode"]}
+        return data
+
     @model_validator(mode="after")
     def _validate_constraint_severity_keys(self) -> Self:
         known = set(CONSTRAINT_BY_ID)
@@ -183,6 +229,42 @@ class AnnotationSettings(ResolveSettings):
                     f"{scope_name} constraint_severity references unknown constraint_id(s): "
                     f"{sorted(unknown)}. Known constraint_ids: {sorted(known)}."
                 )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_field_render_mode_keys(self) -> Self:
+        """Reject ``field_render_mode`` keys not declared in ``TEXT_FIELDS`` for the scope.
+
+        Deployment scope accepts any field name that exists in any task;
+        workspace and task scopes are constrained to the field names that
+        actually belong to that scope's tasks (so an ``"answer"`` override
+        on a retrieval-only workspace is caught at validation time).
+        """
+        all_fields = {name for names in TEXT_FIELDS.values() for name in names}
+        unknown = set(self.field_render_mode) - all_fields
+        if unknown:
+            raise ValueError(
+                f"deployment field_render_mode references unknown field name(s): "
+                f"{sorted(unknown)}. Known field names: {sorted(all_fields)}."
+            )
+        for ws_name, ws in self.workspaces.items():
+            ws_fields = {name for task in ws.tasks for name in TEXT_FIELDS[task]}
+            unknown = set(ws.field_render_mode) - ws_fields
+            if unknown:
+                raise ValueError(
+                    f"workspace {ws_name!r} field_render_mode references field(s) "
+                    f"not in any of its tasks: {sorted(unknown)}. "
+                    f"Allowed: {sorted(ws_fields)}."
+                )
+            for task, ts in ws.tasks.items():
+                task_fields = TEXT_FIELDS[task]
+                unknown = set(ts.field_render_mode) - task_fields
+                if unknown:
+                    raise ValueError(
+                        f"workspace {ws_name!r} task {task.value!r} field_render_mode "
+                        f"references field(s) not in this task: {sorted(unknown)}. "
+                        f"Allowed: {sorted(task_fields)}."
+                    )
         return self
 
     @model_validator(mode="after")

--- a/tests/unit/core/annotation/test_argilla_task_definitions.py
+++ b/tests/unit/core/annotation/test_argilla_task_definitions.py
@@ -7,8 +7,8 @@ from pragmata.core.annotation.argilla_task_definitions import (
     DATASET_NAMES,
     build_task_settings,
 )
-from pragmata.core.schemas.annotation_task import DiscardReason, Task
-from pragmata.core.settings.annotation_settings import AnnotationSettings
+from pragmata.core.schemas.annotation_task import TEXT_FIELDS, DiscardReason, Task
+from pragmata.core.settings.annotation_settings import AnnotationSettings, TaskSettings, WorkspaceSettings
 
 _TASK_SETTINGS = build_task_settings(AnnotationSettings())
 _RETRIEVAL = _TASK_SETTINGS[Task.RETRIEVAL]
@@ -337,3 +337,67 @@ class TestConstraintsFieldSeverityWireUp:
         task_settings = build_task_settings(settings)
         severities = self._payload_severities(_get_field(task_settings[Task.RETRIEVAL], "constraints_panel").template)
         assert severities["evidence_requires_relevance"] == "warn"
+
+
+class TestTextFieldsRegistryMatchesActualTextFields:
+    """``TEXT_FIELDS`` in schemas must match the names of ``rg.TextField``s actually constructed."""
+
+    def test_registry_matches_constructed_text_fields(self):
+        for task, expected_names in TEXT_FIELDS.items():
+            actual_names = {f.name for f in _TASK_SETTINGS[task].fields if isinstance(f, rg.TextField)}
+            assert actual_names == expected_names, (
+                f"TEXT_FIELDS[{task!r}] = {sorted(expected_names)} but the actual "
+                f"rg.TextField names for this task are {sorted(actual_names)}. "
+                f"Update TEXT_FIELDS or the build_task_settings TextField calls to match."
+            )
+
+
+class TestUseMarkdownWireUp:
+    """``use_markdown`` on each rg.TextField reflects the resolved render mode."""
+
+    def test_default_all_plain(self):
+        # Defaults populate every known field as "plain"
+        for task in (Task.RETRIEVAL, Task.GROUNDING, Task.GENERATION):
+            for name in TEXT_FIELDS[task]:
+                field = _get_field(_TASK_SETTINGS[task], name)
+                assert field.use_markdown is False, f"{task.value}.{name} expected plain by default"
+
+    def test_deployment_override_propagates(self):
+        settings = AnnotationSettings(field_render_mode={"answer": "markdown"})
+        task_settings = build_task_settings(settings)
+        # answer exists in grounding and generation
+        assert _get_field(task_settings[Task.GROUNDING], "answer").use_markdown is True
+        assert _get_field(task_settings[Task.GENERATION], "answer").use_markdown is True
+        # query/chunk still plain
+        assert _get_field(task_settings[Task.RETRIEVAL], "query").use_markdown is False
+        assert _get_field(task_settings[Task.RETRIEVAL], "chunk").use_markdown is False
+
+    def test_workspace_override_propagates(self):
+        settings = AnnotationSettings(
+            field_render_mode={"answer": "markdown"},
+            workspaces={
+                "retrieval": WorkspaceSettings(tasks={Task.RETRIEVAL: TaskSettings()}),
+                "grounding": WorkspaceSettings(tasks={Task.GROUNDING: TaskSettings()}),
+                "generation": WorkspaceSettings(
+                    field_render_mode={"answer": "plain"},
+                    tasks={Task.GENERATION: TaskSettings()},
+                ),
+            },
+        )
+        task_settings = build_task_settings(settings)
+        assert _get_field(task_settings[Task.GROUNDING], "answer").use_markdown is True
+        assert _get_field(task_settings[Task.GENERATION], "answer").use_markdown is False
+
+    def test_task_override_propagates(self):
+        settings = AnnotationSettings(
+            workspaces={
+                "retrieval": WorkspaceSettings(
+                    tasks={Task.RETRIEVAL: TaskSettings(field_render_mode={"chunk": "markdown"})},
+                ),
+                "grounding": WorkspaceSettings(tasks={Task.GROUNDING: TaskSettings()}),
+                "generation": WorkspaceSettings(tasks={Task.GENERATION: TaskSettings()}),
+            },
+        )
+        task_settings = build_task_settings(settings)
+        assert _get_field(task_settings[Task.RETRIEVAL], "chunk").use_markdown is True
+        assert _get_field(task_settings[Task.RETRIEVAL], "query").use_markdown is False

--- a/tests/unit/core/settings/test_annotation_settings.py
+++ b/tests/unit/core/settings/test_annotation_settings.py
@@ -5,7 +5,7 @@ import yaml
 from pydantic import ValidationError
 
 from pragmata.core.annotation.logical_constraints import CONSTRAINT_BY_ID
-from pragmata.core.schemas.annotation_task import Task
+from pragmata.core.schemas.annotation_task import TEXT_FIELDS, Task
 from pragmata.core.settings.annotation_settings import (
     AnnotationSettings,
     ArgillaSettings,
@@ -520,3 +520,196 @@ class TestUserSpec:
     def test_role_owner(self):
         u = UserSpec(username="admin", role="owner", workspaces=[])
         assert u.role == "owner"
+
+
+class TestFieldRenderModeDefaults:
+    """Deployment defaults for ``field_render_mode`` cover every name in ``TEXT_FIELDS``."""
+
+    def test_default_factory_covers_all_known_field_names(self):
+        s = AnnotationSettings()
+        known = {name for names in TEXT_FIELDS.values() for name in names}
+        assert set(s.field_render_mode) == known
+
+    def test_default_value_is_plain(self):
+        s = AnnotationSettings()
+        for mode in s.field_render_mode.values():
+            assert mode == "plain"
+
+    def test_user_subset_merges_with_defaults(self):
+        s = AnnotationSettings(field_render_mode={"answer": "markdown"})
+        assert s.field_render_mode["answer"] == "markdown"
+        assert s.field_render_mode["query"] == "plain"
+        assert s.field_render_mode["chunk"] == "plain"
+        assert s.field_render_mode["context_set"] == "plain"
+
+    def test_unknown_field_name_rejected(self):
+        with pytest.raises(
+            ValidationError, match=r"deployment field_render_mode references unknown field name"
+        ):
+            AnnotationSettings(field_render_mode={"nonexistent_field": "markdown"})
+
+    def test_yaml_subset_override(self):
+        data = yaml.safe_load(
+            """
+            field_render_mode:
+              answer: markdown
+              context_set: markdown
+            """
+        )
+        s = AnnotationSettings(**data)
+        assert s.field_render_mode["answer"] == "markdown"
+        assert s.field_render_mode["context_set"] == "markdown"
+        assert s.field_render_mode["query"] == "plain"
+
+
+class TestResolvedRenderMode:
+    """``resolved_render_mode()`` walks task → workspace → deployment, sparse per-key."""
+
+    def test_deployment_default_applies_to_all_tasks(self):
+        s = AnnotationSettings(field_render_mode={"answer": "markdown"})
+        # bare 'answer' applies wherever it exists
+        assert s.resolved_render_mode("grounding", Task.GROUNDING, "answer") == "markdown"
+        assert s.resolved_render_mode("generation", Task.GENERATION, "answer") == "markdown"
+        assert s.resolved_render_mode("retrieval", Task.RETRIEVAL, "chunk") == "plain"
+
+    def test_workspace_override_wins_over_deployment(self):
+        s = AnnotationSettings(
+            field_render_mode={"answer": "markdown"},
+            workspaces={
+                "retrieval": WorkspaceSettings(tasks={Task.RETRIEVAL: TaskSettings()}),
+                "grounding": WorkspaceSettings(tasks={Task.GROUNDING: TaskSettings()}),
+                "generation": WorkspaceSettings(
+                    field_render_mode={"answer": "plain"},
+                    tasks={Task.GENERATION: TaskSettings()},
+                ),
+            },
+        )
+        assert s.resolved_render_mode("grounding", Task.GROUNDING, "answer") == "markdown"
+        assert s.resolved_render_mode("generation", Task.GENERATION, "answer") == "plain"
+
+    def test_task_override_wins_over_workspace_and_deployment(self):
+        s = AnnotationSettings(
+            field_render_mode={"answer": "plain"},
+            workspaces={
+                "retrieval": WorkspaceSettings(tasks={Task.RETRIEVAL: TaskSettings()}),
+                "grounding": WorkspaceSettings(tasks={Task.GROUNDING: TaskSettings()}),
+                "generation": WorkspaceSettings(
+                    field_render_mode={"answer": "markdown"},
+                    tasks={Task.GENERATION: TaskSettings(field_render_mode={"answer": "plain"})},
+                ),
+            },
+        )
+        # task scope wins
+        assert s.resolved_render_mode("generation", Task.GENERATION, "answer") == "plain"
+
+    def test_unlisted_at_workspace_falls_through_to_deployment(self):
+        s = AnnotationSettings(
+            field_render_mode={"answer": "markdown"},
+            workspaces={
+                "retrieval": WorkspaceSettings(tasks={Task.RETRIEVAL: TaskSettings()}),
+                "grounding": WorkspaceSettings(
+                    field_render_mode={"context_set": "markdown"},
+                    tasks={Task.GROUNDING: TaskSettings()},
+                ),
+                "generation": WorkspaceSettings(tasks={Task.GENERATION: TaskSettings()}),
+            },
+        )
+        # workspace lists context_set, but not answer → answer falls through to deployment
+        assert s.resolved_render_mode("grounding", Task.GROUNDING, "answer") == "markdown"
+        assert s.resolved_render_mode("grounding", Task.GROUNDING, "context_set") == "markdown"
+
+
+class TestWorkspaceFieldRenderModeValidation:
+    """Workspace-scope keys must belong to one of the workspace's tasks."""
+
+    def test_field_not_in_any_workspace_task_rejected(self):
+        # 'answer' belongs to grounding/generation, not retrieval
+        with pytest.raises(
+            ValidationError,
+            match=r"workspace 'retrieval' field_render_mode references field\(s\) not in any of its tasks: \['answer'\]",
+        ):
+            AnnotationSettings(
+                workspaces={
+                    "retrieval": WorkspaceSettings(
+                        field_render_mode={"answer": "markdown"},
+                        tasks={Task.RETRIEVAL: TaskSettings()},
+                    ),
+                    "grounding": WorkspaceSettings(tasks={Task.GROUNDING: TaskSettings()}),
+                    "generation": WorkspaceSettings(tasks={Task.GENERATION: TaskSettings()}),
+                },
+            )
+
+    def test_completely_unknown_field_rejected(self):
+        with pytest.raises(
+            ValidationError, match=r"workspace 'retrieval' field_render_mode references field\(s\) not in"
+        ):
+            AnnotationSettings(
+                workspaces={
+                    "retrieval": WorkspaceSettings(
+                        field_render_mode={"nonsense": "markdown"},
+                        tasks={Task.RETRIEVAL: TaskSettings()},
+                    ),
+                    "grounding": WorkspaceSettings(tasks={Task.GROUNDING: TaskSettings()}),
+                    "generation": WorkspaceSettings(tasks={Task.GENERATION: TaskSettings()}),
+                },
+            )
+
+    def test_yaml_workspace_override(self):
+        data = yaml.safe_load(
+            """
+            workspaces:
+              retrieval:
+                tasks:
+                  retrieval: {}
+              grounding:
+                field_render_mode:
+                  answer: markdown
+                tasks:
+                  grounding: {}
+              generation:
+                tasks:
+                  generation: {}
+            """
+        )
+        s = AnnotationSettings(**data)
+        assert s.resolved_render_mode("grounding", Task.GROUNDING, "answer") == "markdown"
+
+
+class TestTaskFieldRenderModeValidation:
+    """Task-scope keys must belong to that specific task's TextFields."""
+
+    def test_field_not_in_task_rejected(self):
+        # 'chunk' belongs to retrieval, not grounding
+        with pytest.raises(
+            ValidationError,
+            match=r"workspace 'grounding' task 'grounding' field_render_mode references field\(s\) not in this task: \['chunk'\]",
+        ):
+            AnnotationSettings(
+                workspaces={
+                    "retrieval": WorkspaceSettings(tasks={Task.RETRIEVAL: TaskSettings()}),
+                    "grounding": WorkspaceSettings(
+                        tasks={Task.GROUNDING: TaskSettings(field_render_mode={"chunk": "markdown"})},
+                    ),
+                    "generation": WorkspaceSettings(tasks={Task.GENERATION: TaskSettings()}),
+                },
+            )
+
+    def test_yaml_task_override(self):
+        data = yaml.safe_load(
+            """
+            workspaces:
+              retrieval:
+                tasks:
+                  retrieval: {}
+              grounding:
+                tasks:
+                  grounding:
+                    field_render_mode:
+                      answer: markdown
+              generation:
+                tasks:
+                  generation: {}
+            """
+        )
+        s = AnnotationSettings(**data)
+        assert s.resolved_render_mode("grounding", Task.GROUNDING, "answer") == "markdown"


### PR DESCRIPTION
## Summary

Adds `AnnotationSettings.field_render_mode` (deployment / workspace / task scopes, sparse-dict overlay) controlling `use_markdown` on each `rg.TextField`. Lets a deployment opt selected fields into Argilla's markdown renderer — which also handles inline raw HTML — so content from pipelines that emit HTML (e.g. publikationsbot) displays as HTML in the annotator UI rather than escaping.

Mirrors the [`constraint_severity` pattern from #216](https://github.com/bertelsmannstift/pragmata/pull/216) very closely:

| | `constraint_severity` | `field_render_mode` |
|---|---|---|
| Shape | `dict[str, Severity]` | `dict[str, FieldRenderMode]` |
| Default factory | populated with all constraint IDs | populated with all known field names → `"plain"` |
| Merge validator | overlays user values onto defaults | overlays user values onto defaults |
| Key validator | rejects unknown constraint IDs | rejects unknown field names (scope-aware) |
| Resolver method | `resolved_severity(ws, constraint_id)` | `resolved_render_mode(ws, task, field_name)` |
| Scope | deployment + workspace | deployment + workspace + **task** |

The one difference: `field_render_mode` adds a per-task scope (`TaskSettings.field_render_mode`) since `\"answer\"` belongs to different tasks (grounding vs. generation) and a deployment might legitimately want them rendered differently. `constraint_severity` skips per-task because severity is per-constraint, not per-task — that reason doesn't apply here.

### Files changed

- `core/schemas/annotation_task.py` — adds `FieldRenderMode` type + `TEXT_FIELDS` registry
- `core/settings/annotation_settings.py` — adds `field_render_mode` to all 3 scope classes, plus `resolved_render_mode()`, `_merge_field_render_mode_defaults`, `_validate_field_render_mode_keys`
- `core/annotation/argilla_task_definitions.py` — local `md()` helper inside `build_task_settings`, wires `use_markdown=md(task, name)` into the 6 `rg.TextField` calls
- `core/annotation/collapsible_field.html` — flips record-content slot from `textContent` to `innerHTML` so the widget renders pipeline HTML consistently with the main TextField (trust assumption: first-party content)
- `docs/decisions/0009-annotation-schema-configurability.md` — addendum: rendering is operational, not schema (in the same layer as `min_submitted`, `constraint_severity`, `locale`); the hardcoded constraint on fields/questions/labels still holds
- Tests:
  - `tests/unit/core/settings/test_annotation_settings.py` — `TestFieldRenderModeDefaults`, `TestResolvedRenderMode`, `TestWorkspaceFieldRenderModeValidation`, `TestTaskFieldRenderModeValidation`
  - `tests/unit/core/annotation/test_argilla_task_definitions.py` — `TestTextFieldsRegistryMatchesActualTextFields` (drift check), `TestUseMarkdownWireUp` (propagation across 3 scopes)

### Example YAML

```yaml
# Deployment-wide: render HTML answers as markdown
field_render_mode:
  answer: markdown

# Or with per-workspace / per-task overrides:
workspaces:
  grounding:
    field_render_mode:
      context_set: markdown
    tasks:
      grounding:
        field_render_mode:
          answer: plain  # override the deployment default just here
```

## Dependency chain

Branched on `feat/annotation-logical-constraints/05-export-summary-by-id` (#217 head). Depends on #213 → #214 → #215 → #216 → #217 landing first. The work itself is independent of those changes' content but uses:
- `build_task_settings(settings)` signature from #215
- `task_to_workspace()` helper + sparse-dict-overlay pattern from #216

## Test plan

- [x] `pytest tests/unit/` — 754 pass, no regressions
- [ ] Manual: on a fresh test deployment, set `field_render_mode: {answer: markdown}` in YAML, run `pragmata annotation setup`, verify resulting Argilla datasets have `use_markdown=True` on grounding/generation answer fields (already demoed manually on a downstream demo branch).
- [ ] Manual: confirm collapsible widget renders embedded HTML correctly when fed pipeline content.