### PR TITLE
fix(annotation): decouple partition_scope from dataset_id

### DIFF
--- a/src/pragmata/api/annotation_import.py
+++ b/src/pragmata/api/annotation_import.py
@@ -75,6 +75,7 @@ def import_records(
     api_key: str | Unset = UNSET,
     format: str = "auto",
     dataset_id: str | Unset = UNSET,
+    partition_scope: str | Unset = UNSET,
     base_dir: str | Path | Unset = UNSET,
     config_path: str | Path | Unset = UNSET,
     calibration_fraction: float | Unset = UNSET,
@@ -120,7 +121,11 @@ def import_records(
         api_key: Argilla API key.
         format: File format override — 'auto' (default), 'json', 'jsonl',
             or 'csv'. Only used for str/Path inputs.
-        dataset_id: Suffix appended to dataset names for run scoping.
+        dataset_id: Suffix appended to dataset names in Argilla (cosmetic).
+        partition_scope: Calibration-budget scope key. Defaults to
+            ``dataset_id`` when omitted. Set independently to share clean
+            Argilla dataset names across domains while keeping separate
+            calibration caps.
         base_dir: Workspace base directory. Defaults to cwd.
         config_path: Path to YAML config file for settings resolution.
         calibration_fraction: Deployment-level fraction of annotation items
@@ -160,6 +165,7 @@ def import_records(
         overrides={
             "argilla": {"api_url": api_url},
             "dataset_id": dataset_id,
+            "partition_scope": partition_scope,
             "base_dir": base_dir,
             "calibration_fraction": calibration_fraction,
             "calibration_max_records": calibration_max_records,
@@ -176,7 +182,7 @@ def import_records(
     client = resolve_argilla_client(settings.argilla.api_url, api_key)
     workspace = WorkspacePaths.from_base_dir(settings.base_dir)
     paths = resolve_annotation_paths(workspace=workspace).ensure_dirs()
-    import_paths = resolve_import_paths(workspace=workspace, dataset_id=settings.dataset_id).ensure_dirs()
+    import_paths = resolve_import_paths(workspace=workspace, partition_scope=settings.partition_scope).ensure_dirs()
 
     import_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%f")
 
@@ -187,7 +193,7 @@ def import_records(
 
         manifest = load_partition_manifest(
             import_paths.partition_manifest,
-            dataset_id=settings.dataset_id,
+            partition_scope=settings.partition_scope,
             partition_seed=settings.calibration_partition_seed,
         )
         if manifest.partition_seed != settings.calibration_partition_seed:

--- a/src/pragmata/core/annotation/record_builder.py
+++ b/src/pragmata/core/annotation/record_builder.py
@@ -176,25 +176,25 @@ def _calibration_digest(unit_id: str, task: Task, seed: int) -> int:
 # ---------------------------------------------------------------------------
 
 
-def load_partition_manifest(path: Path, *, dataset_id: str, partition_seed: int) -> PartitionManifest:
+def load_partition_manifest(path: Path, *, partition_scope: str, partition_seed: int) -> PartitionManifest:
     """Load an existing manifest from disk or create an empty one.
 
-    Raises if the on-disk manifest's dataset_id does not match the caller's,
+    Raises if the on-disk manifest's partition_scope does not match the caller's,
     which would indicate a base_dir or scope mispoint that could silently
     corrupt assignments across scopes.
     """
     if path.exists():
         manifest = PartitionManifest.model_validate_json(path.read_text(encoding="utf-8"))
-        if manifest.dataset_id != dataset_id:
+        if manifest.partition_scope != partition_scope:
             raise ValueError(
-                f"Partition manifest at {path} has dataset_id={manifest.dataset_id!r} "
-                f"but the current scope is {dataset_id!r}. Refusing to load to avoid "
+                f"Partition manifest at {path} has partition_scope={manifest.partition_scope!r} "
+                f"but the current scope is {partition_scope!r}. Refusing to load to avoid "
                 "cross-scope assignment corruption."
             )
         return manifest
     now = datetime.now(timezone.utc)
     return PartitionManifest(
-        dataset_id=dataset_id,
+        dataset_id=partition_scope,
         created_at=now,
         updated_at=now,
         partition_seed=partition_seed,
@@ -208,7 +208,7 @@ def write_partition_manifest(path: Path, manifest: PartitionManifest) -> None:
     The parent directory must already exist; path resolution and directory
     creation belong in core/paths/ (see AnnotationImportPaths.ensure_dirs).
     """
-    payload = json.dumps(manifest.model_dump(mode="json"), indent=2)
+    payload = json.dumps(manifest.model_dump(mode="json", by_alias=True), indent=2)
     tmp = path.with_suffix(path.suffix + ".tmp")
     tmp.write_text(payload, encoding="utf-8")
     tmp.replace(path)

--- a/src/pragmata/core/annotation/record_builder.py
+++ b/src/pragmata/core/annotation/record_builder.py
@@ -194,7 +194,7 @@ def load_partition_manifest(path: Path, *, partition_scope: str, partition_seed:
         return manifest
     now = datetime.now(timezone.utc)
     return PartitionManifest(
-        dataset_id=partition_scope,
+        partition_scope=partition_scope,
         created_at=now,
         updated_at=now,
         partition_seed=partition_seed,

--- a/src/pragmata/core/paths/annotation_paths.py
+++ b/src/pragmata/core/paths/annotation_paths.py
@@ -37,15 +37,15 @@ def resolve_annotation_paths(*, workspace: WorkspacePaths) -> AnnotationPaths:
 
 @dataclass(frozen=True, slots=True)
 class AnnotationImportPaths:
-    """Path bundle for an annotation import scope (one per ``dataset_id``).
+    """Path bundle for an annotation import scope (one per ``partition_scope``).
 
     Imports accumulate state across calls into the same logical scope, so the
-    bundle is keyed by ``dataset_id`` (persistent topology scope) rather than
-    a per-call identifier. The partition manifest sidecar tracks calibration
-    vs production assignment for every record imported into this scope.
+    bundle is keyed by ``partition_scope`` (persistent calibration-budget scope)
+    rather than a per-call identifier. The partition manifest sidecar tracks
+    calibration vs production assignment for every record imported into this scope.
 
     Attributes:
-        import_dir: Per-``dataset_id`` import directory.
+        import_dir: Per-``partition_scope`` import directory.
         partition_manifest: Partition manifest sidecar path.
     """
 
@@ -58,18 +58,18 @@ class AnnotationImportPaths:
         return self
 
 
-def resolve_import_paths(*, workspace: WorkspacePaths, dataset_id: str) -> AnnotationImportPaths:
+def resolve_import_paths(*, workspace: WorkspacePaths, partition_scope: str) -> AnnotationImportPaths:
     """Build the path bundle for an annotation import scope.
 
     Args:
         workspace: Workspace path bundle.
-        dataset_id: Topology scope. Empty string maps to the ``"default"``
-            directory so the layout is uniform across scopes.
+        partition_scope: Calibration-budget scope. Empty string maps to the
+            ``"default"`` directory so the layout is uniform across scopes.
 
     Returns:
         Path bundle for the import scope.
     """
-    scope = dataset_id or "default"
+    scope = partition_scope or "default"
     import_dir = workspace.tool_root("annotation") / "imports" / scope
     return AnnotationImportPaths(
         import_dir=import_dir,

--- a/src/pragmata/core/schemas/annotation_import.py
+++ b/src/pragmata/core/schemas/annotation_import.py
@@ -95,13 +95,15 @@ class PartitionManifestEntry(BaseModel):
 
 
 class PartitionManifest(BaseModel):
-    """Persistent record_uuid -> assignment map scoped to one ``dataset_id``.
+    """Persistent record_uuid -> assignment map scoped to one ``partition_scope``.
 
     Locks calibration vs production assignments across re-imports so growing
     or repeated batches never reshuffle records between Argilla datasets.
 
     Attributes:
-        dataset_id: Topology scope this manifest belongs to (empty string ok).
+        partition_scope: Calibration-budget scope this manifest belongs to
+            (empty string ok). Serialised as ``dataset_id`` for on-disk
+            backwards compatibility.
         created_at: First write timestamp.
         updated_at: Most recent write timestamp.
         partition_seed: Hash seed used for new-record assignments. Stored at
@@ -109,9 +111,9 @@ class PartitionManifest(BaseModel):
         assignments: Map of record_uuid -> PartitionManifestEntry.
     """
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
-    dataset_id: SafePathSegment
+    partition_scope: SafePathSegment = Field(alias="dataset_id")
     created_at: datetime
     updated_at: datetime
     partition_seed: int

--- a/src/pragmata/core/settings/annotation_settings.py
+++ b/src/pragmata/core/settings/annotation_settings.py
@@ -126,12 +126,6 @@ class AnnotationSettings(ResolveSettings):
     base_dir: Path = Field(default_factory=Path.cwd)
     dataset_id: SafePathSegment = ""
     partition_scope: SafePathSegment = ""
-
-    @model_validator(mode="after")
-    def _default_partition_scope(self) -> Self:
-        if not self.partition_scope:
-            self.partition_scope = self.dataset_id
-        return self
     production_min_submitted: PositiveInt = 1
     calibration_min_submitted: PositiveInt | None = 3
     locale: Locale = "en"
@@ -206,6 +200,12 @@ class AnnotationSettings(ResolveSettings):
             defaults = cls.model_fields["constraint_severity"].default_factory()
             data["constraint_severity"] = {**defaults, **data["constraint_severity"]}
         return data
+
+    @model_validator(mode="after")
+    def _default_partition_scope(self) -> Self:
+        if not self.partition_scope:
+            self.partition_scope = self.dataset_id
+        return self
 
     @model_validator(mode="after")
     def _validate_constraint_severity_keys(self) -> Self:

--- a/src/pragmata/core/settings/annotation_settings.py
+++ b/src/pragmata/core/settings/annotation_settings.py
@@ -125,6 +125,13 @@ class AnnotationSettings(ResolveSettings):
     argilla: ArgillaSettings = Field(default_factory=ArgillaSettings)
     base_dir: Path = Field(default_factory=Path.cwd)
     dataset_id: SafePathSegment = ""
+    partition_scope: SafePathSegment = ""
+
+    @model_validator(mode="after")
+    def _default_partition_scope(self) -> Self:
+        if not self.partition_scope:
+            self.partition_scope = self.dataset_id
+        return self
     production_min_submitted: PositiveInt = 1
     calibration_min_submitted: PositiveInt | None = 3
     locale: Locale = "en"

--- a/tests/integration/test_annotation_calibration.py
+++ b/tests/integration/test_annotation_calibration.py
@@ -438,9 +438,13 @@ class TestPartitionScopeDecoupling:
                 calibration_max_records=cal_max,
                 **_CREDS,
             )
-            cal_b = result_b.calibration_count.get(Task.RETRIEVAL, 0)
-            assert cal_b > 0, (
-                f"scope B got zero calibration records — partition_scope isolation is broken (scope B cal={cal_b})"
+            cal_b_retrieval = result_b.calibration_count.get(Task.RETRIEVAL, 0)
+            cal_b_grounding = result_b.calibration_count.get(Task.GROUNDING, 0)
+            assert cal_b_retrieval > 0, (
+                f"scope B retrieval got zero calibration — partition_scope isolation broken (cal={cal_b_retrieval})"
+            )
+            assert cal_b_grounding > 0, (
+                f"scope B grounding got zero calibration — partition_scope isolation broken (cal={cal_b_grounding})"
             )
         finally:
             teardown_resources(client, settings_a)

--- a/tests/integration/test_annotation_calibration.py
+++ b/tests/integration/test_annotation_calibration.py
@@ -51,10 +51,10 @@ def _make_raw_multi_chunk(i: int, *, n_chunks: int) -> dict:
     }
 
 
-def _manifest_path(base_dir: Path, dataset_id: str) -> Path:
+def _manifest_path(base_dir: Path, partition_scope: str) -> Path:
     """Resolve the partition manifest path the same way the import API does."""
     workspace = WorkspacePaths.from_base_dir(base_dir)
-    return resolve_import_paths(workspace=workspace, dataset_id=dataset_id).partition_manifest
+    return resolve_import_paths(workspace=workspace, partition_scope=partition_scope).partition_manifest
 
 
 @pytest.fixture(scope="module")
@@ -393,3 +393,55 @@ class TestPerWorkspaceMinSubmitted:
             assert grounding_prod.distribution.min_submitted == 1
         finally:
             teardown_resources(client, carved_settings)
+
+
+class TestPartitionScopeDecoupling:
+    """Regression tests for the dataset_id / partition_scope coupling bug.
+
+    Before the fix, two configs sharing dataset_id="" (or any common value)
+    would share a single calibration budget. The first import to hit
+    calibration_max_records would exhaust it, leaving subsequent imports in a
+    different domain with zero calibration records.
+    """
+
+    def test_independent_scopes_each_get_calibration(self, client: rg.Argilla, base_dir: Path) -> None:
+        """Two configs with empty dataset_id but different partition_scope each receive calibration records."""
+        scope_a = "reg_scope_a"
+        scope_b = "reg_scope_b"
+        cal_max = 30
+        settings_a = AnnotationSettings(partition_scope=scope_a, calibration_max_records=cal_max)
+        settings_b = AnnotationSettings(partition_scope=scope_b, calibration_max_records=cal_max)
+        teardown_resources(client, settings_a)
+        teardown_resources(client, settings_b)
+        setup_workspaces(client, settings_a)
+        setup_workspaces(client, settings_b)
+
+        try:
+            # Import enough records under scope A to hit the cap.
+            result_a = import_records(
+                [_make_raw(i) for i in range(181)],
+                partition_scope=scope_a,
+                base_dir=base_dir,
+                calibration_fraction=0.2,
+                calibration_max_records=cal_max,
+                **_CREDS,
+            )
+            cal_a = result_a.calibration_count.get(Task.RETRIEVAL, 0)
+            assert cal_a == cal_max, f"scope A should have hit cap ({cal_a} vs {cal_max})"
+
+            # Import under scope B - should get its own fresh calibration budget.
+            result_b = import_records(
+                [_make_raw(i) for i in range(500, 708)],
+                partition_scope=scope_b,
+                base_dir=base_dir,
+                calibration_fraction=0.2,
+                calibration_max_records=cal_max,
+                **_CREDS,
+            )
+            cal_b = result_b.calibration_count.get(Task.RETRIEVAL, 0)
+            assert cal_b > 0, (
+                f"scope B got zero calibration records — partition_scope isolation is broken (scope B cal={cal_b})"
+            )
+        finally:
+            teardown_resources(client, settings_a)
+            teardown_resources(client, settings_b)

--- a/tests/unit/api/test_annotation.py
+++ b/tests/unit/api/test_annotation.py
@@ -400,12 +400,12 @@ class TestImportRecordsManifestOrdering:
     """Manifest is written only after fan_out_records succeeds."""
 
     @staticmethod
-    def _manifest_path(base_dir: Path, dataset_id: str) -> Path:
+    def _manifest_path(base_dir: Path, partition_scope: str) -> Path:
         from pragmata.core.paths.annotation_paths import resolve_import_paths
         from pragmata.core.paths.paths import WorkspacePaths
 
         workspace = WorkspacePaths.from_base_dir(base_dir)
-        return resolve_import_paths(workspace=workspace, dataset_id=dataset_id).partition_manifest
+        return resolve_import_paths(workspace=workspace, partition_scope=partition_scope).partition_manifest
 
     @patch("pragmata.api.annotation_import.fan_out_records")
     def test_manifest_written_after_successful_fan_out(self, mock_fan_out: MagicMock, _isolate_base_dir: Path) -> None:

--- a/tests/unit/core/annotation/test_partition.py
+++ b/tests/unit/core/annotation/test_partition.py
@@ -87,7 +87,7 @@ class TestAssignPartitions:
     def empty_manifest(self) -> PartitionManifest:
         now = datetime.now(timezone.utc)
         return PartitionManifest(
-            dataset_id="test",
+            dataset_id="test",  # alias for partition_scope
             created_at=now,
             updated_at=now,
             partition_seed=0,
@@ -315,15 +315,15 @@ class TestAssignPartitions:
 class TestManifestIO:
     def test_load_empty_when_missing(self, tmp_path: Path) -> None:
         path = tmp_path / "partition.meta.json"
-        manifest = load_partition_manifest(path, dataset_id="test", partition_seed=42)
+        manifest = load_partition_manifest(path, partition_scope="test", partition_seed=42)
 
-        assert manifest.dataset_id == "test"
+        assert manifest.partition_scope == "test"
         assert manifest.partition_seed == 42
         assert manifest.assignments == {}
 
     def test_round_trip(self, tmp_path: Path) -> None:
         path = tmp_path / "partition.meta.json"
-        original = load_partition_manifest(path, dataset_id="test", partition_seed=7)
+        original = load_partition_manifest(path, partition_scope="test", partition_seed=7)
         original.assignments["uuid-1"] = PartitionManifestEntry(
             grounding_generation_calibration={Task.GROUNDING: True, Task.GENERATION: False},
             retrieval_chunk_calibration={"chunk-a": True, "chunk-b": False},
@@ -334,22 +334,33 @@ class TestManifestIO:
         )
 
         write_partition_manifest(path, original)
-        restored = load_partition_manifest(path, dataset_id="test", partition_seed=7)
+        restored = load_partition_manifest(path, partition_scope="test", partition_seed=7)
 
-        assert restored.dataset_id == original.dataset_id
+        assert restored.partition_scope == original.partition_scope
         assert restored.partition_seed == original.partition_seed
         assert restored.assignments["uuid-1"] == original.assignments["uuid-1"]
 
+    def test_on_disk_uses_dataset_id_key(self, tmp_path: Path) -> None:
+        """Serialised JSON uses 'dataset_id' key for backwards compat with existing manifests."""
+        path = tmp_path / "partition.meta.json"
+        manifest = load_partition_manifest(path, partition_scope="myproject", partition_seed=0)
+        write_partition_manifest(path, manifest)
+        import json
+
+        raw = json.loads(path.read_text())
+        assert raw["dataset_id"] == "myproject"
+        assert "partition_scope" not in raw
+
     def test_write_requires_existing_parent(self, tmp_path: Path) -> None:
         path = tmp_path / "nested" / "subdir" / "partition.meta.json"
-        manifest = load_partition_manifest(path, dataset_id="x", partition_seed=0)
+        manifest = load_partition_manifest(path, partition_scope="x", partition_seed=0)
         with pytest.raises(FileNotFoundError):
             write_partition_manifest(path, manifest)
 
-    def test_load_rejects_dataset_id_mismatch(self, tmp_path: Path) -> None:
+    def test_load_rejects_scope_mismatch(self, tmp_path: Path) -> None:
         path = tmp_path / "partition.meta.json"
-        original = load_partition_manifest(path, dataset_id="scope-a", partition_seed=0)
+        original = load_partition_manifest(path, partition_scope="scope-a", partition_seed=0)
         write_partition_manifest(path, original)
 
         with pytest.raises(ValueError, match="scope-a"):
-            load_partition_manifest(path, dataset_id="scope-b", partition_seed=0)
+            load_partition_manifest(path, partition_scope="scope-b", partition_seed=0)

--- a/tests/unit/core/paths/test_annotation_paths.py
+++ b/tests/unit/core/paths/test_annotation_paths.py
@@ -84,30 +84,30 @@ class TestAnnotationExportPaths:
 
 class TestAnnotationImportPaths:
     def test_import_dir_under_imports_scope(self, workspace: WorkspacePaths) -> None:
-        paths = resolve_import_paths(workspace=workspace, dataset_id="run1")
+        paths = resolve_import_paths(workspace=workspace, partition_scope="run1")
         expected = workspace.tool_root("annotation") / "imports" / "run1"
         assert paths.import_dir == expected
 
-    def test_empty_dataset_id_maps_to_default_scope(self, workspace: WorkspacePaths) -> None:
-        paths = resolve_import_paths(workspace=workspace, dataset_id="")
+    def test_empty_partition_scope_maps_to_default_scope(self, workspace: WorkspacePaths) -> None:
+        paths = resolve_import_paths(workspace=workspace, partition_scope="")
         expected = workspace.tool_root("annotation") / "imports" / "default"
         assert paths.import_dir == expected
 
     def test_partition_manifest_under_import_dir(self, workspace: WorkspacePaths) -> None:
-        paths = resolve_import_paths(workspace=workspace, dataset_id="run1")
+        paths = resolve_import_paths(workspace=workspace, partition_scope="run1")
         assert paths.partition_manifest == paths.import_dir / "partition.meta.json"
 
     def test_ensure_dirs_creates_import_dir(self, workspace: WorkspacePaths) -> None:
-        paths = resolve_import_paths(workspace=workspace, dataset_id="run1")
+        paths = resolve_import_paths(workspace=workspace, partition_scope="run1")
         assert not paths.import_dir.exists()
         paths.ensure_dirs()
         assert paths.import_dir.exists()
 
     def test_ensure_dirs_returns_self(self, workspace: WorkspacePaths) -> None:
-        paths = resolve_import_paths(workspace=workspace, dataset_id="run1")
+        paths = resolve_import_paths(workspace=workspace, partition_scope="run1")
         assert paths.ensure_dirs() is paths
 
     def test_frozen(self, workspace: WorkspacePaths, tmp_path: Path) -> None:
-        paths = resolve_import_paths(workspace=workspace, dataset_id="run1")
+        paths = resolve_import_paths(workspace=workspace, partition_scope="run1")
         with pytest.raises((AttributeError, TypeError)):
             paths.import_dir = tmp_path  # type: ignore[misc]

--- a/tests/unit/core/schemas/test_annotation_import.py
+++ b/tests/unit/core/schemas/test_annotation_import.py
@@ -157,7 +157,7 @@ def valid_entry_kwargs():
 @pytest.fixture()
 def valid_manifest_kwargs():
     return {
-        "dataset_id": "run1",
+        "dataset_id": "run1",  # on-disk key (alias for partition_scope)
         "created_at": _ENTRY_NOW,
         "updated_at": _ENTRY_NOW,
         "partition_seed": 0,
@@ -217,13 +217,13 @@ class TestPartitionManifest:
         with pytest.raises(ValidationError):
             PartitionManifest(**valid_manifest_kwargs, surprise="bad")  # type: ignore[call-arg]
 
-    def test_dataset_id_can_be_empty_string(self, valid_manifest_kwargs):
+    def test_partition_scope_can_be_empty_string(self, valid_manifest_kwargs):
         valid_manifest_kwargs["dataset_id"] = ""
         manifest = PartitionManifest(**valid_manifest_kwargs)
-        assert manifest.dataset_id == ""
+        assert manifest.partition_scope == ""
 
     @pytest.mark.parametrize("bad", ["a/b", "..", "foo..bar", " run", "run\\sub"])
-    def test_unsafe_dataset_id_rejected(self, valid_manifest_kwargs, bad):
+    def test_unsafe_partition_scope_rejected(self, valid_manifest_kwargs, bad):
         valid_manifest_kwargs["dataset_id"] = bad
         with pytest.raises(ValidationError):
             PartitionManifest(**valid_manifest_kwargs)

--- a/tests/unit/core/schemas/test_annotation_import.py
+++ b/tests/unit/core/schemas/test_annotation_import.py
@@ -210,7 +210,7 @@ class TestPartitionManifest:
     def test_assignments_round_trip(self, valid_manifest_kwargs, valid_entry_kwargs):
         entry = PartitionManifestEntry(**valid_entry_kwargs)
         manifest = PartitionManifest(**valid_manifest_kwargs, assignments={"uuid-1": entry})
-        restored = PartitionManifest.model_validate_json(manifest.model_dump_json())
+        restored = PartitionManifest.model_validate_json(manifest.model_dump_json(by_alias=True))
         assert restored == manifest
 
     def test_extra_fields_rejected(self, valid_manifest_kwargs):


### PR DESCRIPTION
## Summary

- Introduces `partition_scope: SafePathSegment` on `AnnotationSettings`, defaulting to `dataset_id` (for backwards compatibility, but also as a sensible default)
- `resolve_import_paths()` and `load_partition_manifest()` now key off `partition_scope`; `dataset_name()` (Argilla naming) continues using `dataset_id`
- `PartitionManifest.dataset_id` renamed to `partition_scope` in Python, serialised as `"dataset_id"` via Pydantic alias — existing on-disk manifests load without migration
- `import_records()` API gains an optional `partition_scope` kwarg

## Problem fixed

Two annotation configs sharing `dataset_id: ""` would share one partition manifest, so the first config to hit `calibration_max_records` would exhaust the cap for all subsequent imports in the same run — even across unrelated domains with different workspaces.

## Backwards compat / future palns

- No changes required for existing callers. When `partition_scope` is not set, it defaults to `dataset_id`, preserving the exact previous behaviour. Existing `partition.meta.json` files on disk are unaffected (JSON key stays `"dataset_id"`).
- Plan to refactor how datasets can be named with dataset_id (currently, has to be a suffix, but this is needless constraint now we have partition_scope)

## Test plan

- [x] 807 unit tests pass (`uv run pytest tests/unit/`)
- [x] New integration regression test `TestPartitionScopeDecoupling::test_independent_scopes_each_get_calibration` — two configs with `dataset_id: ""`, distinct `partition_scope`, `calibration_max_records: 30`; asserts scope B gets > 0 calibration records after scope A hits the cap
- [x] Existing integration tests (`tests/integration/test_annotation_calibration.py`) unchanged in behaviour