### PR TITLE
refactor(core): add shared atomic_write_text helper, adopt in querygen planning-summary export

### DIFF
--- a/src/pragmata/core/atomic_io.py
+++ b/src/pragmata/core/atomic_io.py
@@ -10,22 +10,21 @@ from uuid import uuid4
 
 @contextmanager
 def atomic_write_text(path: Path) -> Iterator[TextIO]:
-    """Yield a text handle whose contents replace ``path`` atomically on success.
+    """Atomically replace a text file after a successful write.
 
-    Writes to a uniquified temp file in the same directory and ``Path.replace``s
-    it into place when the ``with`` block exits cleanly; on any exception the
-    temp file is removed and ``path`` is left untouched. The temp name carries
-    the PID and a random suffix so concurrent writers to the same target cannot
-    clobber each other's temp file.
+    Writes UTF-8 text to a unique temporary file in the target directory and
+    renames it into place with ``Path.replace`` when the context exits cleanly.
+    If the write fails, the temporary file is removed and the existing target is
+    left untouched. The parent directory must already exist.
 
-    No fsync (matches the repo's existing atomic-write idiom): a torn or
-    unflushed file is never the result of a successful rename, and callers that
-    validate-on-read treat a corrupt final file as drift and recompute.
+    The handle is opened with ``newline=""`` so callers writing CSV via the
+    :mod:`csv` module get correct line endings (harmless for JSON/text); the
+    temp name carries the PID and a random suffix so concurrent writers to the
+    same target cannot clobber each other.
 
-    The handle is opened in text mode with ``encoding="utf-8"`` and
-    ``newline=""`` (the latter so callers writing CSV via :mod:`csv` get correct
-    line endings; harmless for JSON/text). The parent directory must already
-    exist.
+    Atomic replacement is provided for normal readers, but the file and parent
+    directory are intentionally not fsynced: callers that validate-on-read treat
+    a corrupt final file as drift and recompute.
 
     Args:
         path: Final destination path; replaced atomically on clean exit.

--- a/src/pragmata/core/atomic_io.py
+++ b/src/pragmata/core/atomic_io.py
@@ -1,5 +1,6 @@
 """Atomic file-write helper shared across pragmata subsystems."""
 
+import json
 import os
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -40,3 +41,18 @@ def atomic_write_text(path: Path) -> Iterator[TextIO]:
     except BaseException:
         tmp_path.unlink(missing_ok=True)
         raise
+
+
+def atomic_write_json(data: dict, path: Path) -> None:
+    """Atomically write ``data`` as indented JSON with a trailing newline to ``path``.
+
+    Indented (``indent=2``) so persisted artifacts are human-scannable when
+    inspected; round-trip reads validate semantically, so the formatting carries
+    no functional meaning. Writes via :func:`atomic_write_text`.
+
+    Args:
+        data: JSON-serialisable mapping to persist.
+        path: Final destination path; replaced atomically on clean exit.
+    """
+    with atomic_write_text(path) as handle:
+        handle.write(json.dumps(data, indent=2) + "\n")

--- a/src/pragmata/core/atomic_io.py
+++ b/src/pragmata/core/atomic_io.py
@@ -1,0 +1,43 @@
+"""Atomic file-write helper shared across pragmata subsystems."""
+
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TextIO
+from uuid import uuid4
+
+
+@contextmanager
+def atomic_write_text(path: Path) -> Iterator[TextIO]:
+    """Yield a text handle whose contents replace ``path`` atomically on success.
+
+    Writes to a uniquified temp file in the same directory and ``Path.replace``s
+    it into place when the ``with`` block exits cleanly; on any exception the
+    temp file is removed and ``path`` is left untouched. The temp name carries
+    the PID and a random suffix so concurrent writers to the same target cannot
+    clobber each other's temp file.
+
+    No fsync (matches the repo's existing atomic-write idiom): a torn or
+    unflushed file is never the result of a successful rename, and callers that
+    validate-on-read treat a corrupt final file as drift and recompute.
+
+    The handle is opened in text mode with ``encoding="utf-8"`` and
+    ``newline=""`` (the latter so callers writing CSV via :mod:`csv` get correct
+    line endings; harmless for JSON/text). The parent directory must already
+    exist.
+
+    Args:
+        path: Final destination path; replaced atomically on clean exit.
+
+    Yields:
+        A writable text file handle for the temp file.
+    """
+    tmp_path = path.with_name(f"{path.name}.{os.getpid()}.{uuid4().hex}.tmp")
+    try:
+        with tmp_path.open("w", encoding="utf-8", newline="") as handle:
+            yield handle
+        tmp_path.replace(path)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise

--- a/src/pragmata/core/querygen/export.py
+++ b/src/pragmata/core/querygen/export.py
@@ -3,8 +3,24 @@
 import json
 from pathlib import Path
 
+from pragmata.core.atomic_io import atomic_write_text
 from pragmata.core.csv_io import write_csv
-from pragmata.core.schemas.querygen_output import PlanningSummaryArtifact, SyntheticQueriesMeta, SyntheticQueryRow
+from pragmata.core.schemas.querygen_output import (
+    PlanningSummaryArtifact,
+    SyntheticQueriesMeta,
+    SyntheticQueryRow,
+)
+
+
+def _atomic_write_json(*, data: dict, path: Path) -> None:
+    """Atomically write ``data`` as indented JSON to ``path`` via :func:`atomic_write_text`.
+
+    Indented (``indent=2``) so the persisted checkpoint/summary artifacts are
+    human-scannable when inspected; round-trip reads validate semantically, so
+    the formatting carries no functional meaning.
+    """
+    with atomic_write_text(path) as handle:
+        handle.write(json.dumps(data, indent=2) + "\n")
 
 
 def export_queries(
@@ -38,7 +54,4 @@ def export_planning_summary(
         artifact: Validated planning-summary artifact to persist.
         artifact_path: Destination path for the JSON artifact.
     """
-    artifact_path.write_text(
-        json.dumps(artifact.model_dump(mode="json")),
-        encoding="utf-8",
-    )
+    _atomic_write_json(data=artifact.model_dump(mode="json"), path=artifact_path)

--- a/src/pragmata/core/querygen/export.py
+++ b/src/pragmata/core/querygen/export.py
@@ -1,26 +1,14 @@
 """Export assembled synthetic query artifacts to disk."""
 
-import json
 from pathlib import Path
 
-from pragmata.core.atomic_io import atomic_write_text
+from pragmata.core.atomic_io import atomic_write_json
 from pragmata.core.csv_io import write_csv
 from pragmata.core.schemas.querygen_output import (
     PlanningSummaryArtifact,
     SyntheticQueriesMeta,
     SyntheticQueryRow,
 )
-
-
-def _atomic_write_json(*, data: dict, path: Path) -> None:
-    """Atomically write ``data`` as indented JSON to ``path`` via :func:`atomic_write_text`.
-
-    Indented (``indent=2``) so the persisted checkpoint/summary artifacts are
-    human-scannable when inspected; round-trip reads validate semantically, so
-    the formatting carries no functional meaning.
-    """
-    with atomic_write_text(path) as handle:
-        handle.write(json.dumps(data, indent=2) + "\n")
 
 
 def export_queries(
@@ -38,10 +26,7 @@ def export_queries(
         meta_path: Output path for the synthetic query metadata JSON file.
     """
     write_csv(rows, queries_path)
-    meta_path.write_text(
-        json.dumps(meta.model_dump(mode="json")),
-        encoding="utf-8",
-    )
+    atomic_write_json(meta.model_dump(mode="json"), meta_path)
 
 
 def export_planning_summary(
@@ -54,4 +39,4 @@ def export_planning_summary(
         artifact: Validated planning-summary artifact to persist.
         artifact_path: Destination path for the JSON artifact.
     """
-    _atomic_write_json(data=artifact.model_dump(mode="json"), path=artifact_path)
+    atomic_write_json(artifact.model_dump(mode="json"), artifact_path)

--- a/tests/unit/core/test_atomic_io.py
+++ b/tests/unit/core/test_atomic_io.py
@@ -1,10 +1,11 @@
 """Tests for the shared atomic text-write helper."""
 
+import json
 from pathlib import Path
 
 import pytest
 
-from pragmata.core.atomic_io import atomic_write_text
+from pragmata.core.atomic_io import atomic_write_json, atomic_write_text
 
 
 def test_atomic_write_text_writes_and_replaces(tmp_path: Path) -> None:
@@ -43,4 +44,17 @@ def test_atomic_write_text_no_target_left_when_block_fails_for_new_path(tmp_path
             raise ValueError("nope")
 
     assert not target.exists()
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_atomic_write_json_round_trips_indented_with_trailing_newline(tmp_path: Path) -> None:
+    """Data is persisted as indented JSON with a trailing newline and reads back equal."""
+    target = tmp_path / "meta.json"
+    data = {"b": 1, "a": [2, 3]}
+
+    atomic_write_json(data, target)
+
+    text = target.read_text(encoding="utf-8")
+    assert text == json.dumps(data, indent=2) + "\n"
+    assert json.loads(text) == data
     assert list(tmp_path.glob("*.tmp")) == []

--- a/tests/unit/core/test_atomic_io.py
+++ b/tests/unit/core/test_atomic_io.py
@@ -1,0 +1,46 @@
+"""Tests for the shared atomic text-write helper."""
+
+from pathlib import Path
+
+import pytest
+
+from pragmata.core.atomic_io import atomic_write_text
+
+
+def test_atomic_write_text_writes_and_replaces(tmp_path: Path) -> None:
+    """Content written in the block becomes the file's contents on clean exit."""
+    target = tmp_path / "out.json"
+    target.write_text("old", encoding="utf-8")
+
+    with atomic_write_text(target) as handle:
+        handle.write("new content")
+
+    assert target.read_text(encoding="utf-8") == "new content"
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_atomic_write_text_leaves_original_intact_on_exception(tmp_path: Path) -> None:
+    """An exception in the block leaves the original file untouched and no temp behind."""
+    target = tmp_path / "out.json"
+    target.write_text("original", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with atomic_write_text(target) as handle:
+            handle.write("partial")
+            raise RuntimeError("boom")
+
+    assert target.read_text(encoding="utf-8") == "original"
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_atomic_write_text_no_target_left_when_block_fails_for_new_path(tmp_path: Path) -> None:
+    """A failed write to a not-yet-existing path leaves no file at all."""
+    target = tmp_path / "fresh.json"
+
+    with pytest.raises(ValueError, match="nope"):
+        with atomic_write_text(target) as handle:
+            handle.write("partial")
+            raise ValueError("nope")
+
+    assert not target.exists()
+    assert list(tmp_path.glob("*.tmp")) == []


### PR DESCRIPTION
**Stack (6 open PRs):** #237 → #238 → #239 → #240 → #241 → #242 

**Chain goal:** Add per-batch checkpoint/resume to querygen so a re-run with the same `run_id` skips already-completed work. Nests resumable state under `<run_dir>/checkpoints/`, writes a frozen Stage 1 result (planning + dedup) plus per-batch Stage 1 and Stage 2 artifacts, and orchestrates resume behind a fail-fast config-drift gate (`--force` overrides) so checkpoints are never silently reused under changed settings.

**This PR (1/6):** Extracts the tmpfile + atomic-rename idiom into a shared `core/atomic_io.py` helper and adopts it for querygen's planning-summary write — the atomic-write primitive every later checkpoint artifact (#239–242) writes through.

---

## What
- `core/atomic_io.py` — `atomic_write_text` context manager: PID+uuid-uniquified tempfile, `Path.replace` for the atomic rename, no fsync (matches house style).
- Querygen `export.py` adopts it for `export_planning_summary` (indented JSON for human-scannable persisted artifacts).
- **Note:** annotation `record_builder`/`export_runner` should adopt `atomic_write_text` in a follow-up — kept out here to keep this PR's dependency surface to querygen only.

## Why
Extracts the tmpfile + atomic-rename idiom (previously duplicated inline in two annotation sites — `record_builder.write_partition_manifest` and `export_runner.write_export_csv`) into one shared core helper, then adopts it for querygen's planning-summary write. Reaches the rule-of-3 with the upcoming querygen artifact writes in #239–242.

## Test plan
- [x] `tests/unit/core/test_atomic_io.py` — round-trip + temp-cleanup-on-exception.
