### PR TITLE
feat(querygen): add checkpoint run-dir paths and per-stage fingerprints

### DIFF
--- a/src/pragmata/core/atomic_io.py
+++ b/src/pragmata/core/atomic_io.py
@@ -1,0 +1,43 @@
+"""Atomic file-write helper shared across pragmata subsystems."""
+
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TextIO
+from uuid import uuid4
+
+
+@contextmanager
+def atomic_write_text(path: Path) -> Iterator[TextIO]:
+    """Yield a text handle whose contents replace ``path`` atomically on success.
+
+    Writes to a uniquified temp file in the same directory and ``Path.replace``s
+    it into place when the ``with`` block exits cleanly; on any exception the
+    temp file is removed and ``path`` is left untouched. The temp name carries
+    the PID and a random suffix so concurrent writers to the same target cannot
+    clobber each other's temp file.
+
+    No fsync (matches the repo's existing atomic-write idiom): a torn or
+    unflushed file is never the result of a successful rename, and callers that
+    validate-on-read treat a corrupt final file as drift and recompute.
+
+    The handle is opened in text mode with ``encoding="utf-8"`` and
+    ``newline=""`` (the latter so callers writing CSV via :mod:`csv` get correct
+    line endings; harmless for JSON/text). The parent directory must already
+    exist.
+
+    Args:
+        path: Final destination path; replaced atomically on clean exit.
+
+    Yields:
+        A writable text file handle for the temp file.
+    """
+    tmp_path = path.with_name(f"{path.name}.{os.getpid()}.{uuid4().hex}.tmp")
+    try:
+        with tmp_path.open("w", encoding="utf-8", newline="") as handle:
+            yield handle
+        tmp_path.replace(path)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise

--- a/src/pragmata/core/paths/querygen_paths.py
+++ b/src/pragmata/core/paths/querygen_paths.py
@@ -17,6 +17,16 @@ class QueryGenRunPaths:
        synthetic_queries_csv: Output path for the generated query rows CSV.
        synthetic_queries_meta_json: Output path for the dataset metadata.
        planning_summary_artifact_json: Output path for the planning-summary artifact.
+       checkpoints_dir: Directory holding all resumable intermediate state for
+           the run (the per-batch checkpoints and the frozen Stage 1 result),
+           kept separate from the final deliverables in ``run_dir``.
+       planning_batches_dir: Directory for per-batch Stage 1 planning checkpoints
+           (under ``checkpoints_dir``).
+       selected_blueprints_json: Path for the frozen post-deduplication Stage 1
+           result (the "Stage 1 done" marker / Stage 2 input), under
+           ``checkpoints_dir``.
+       realization_batches_dir: Directory for per-batch Stage 2 realization
+           checkpoints (under ``checkpoints_dir``).
     """
 
     tool_root: Path
@@ -24,12 +34,18 @@ class QueryGenRunPaths:
     synthetic_queries_csv: Path
     synthetic_queries_meta_json: Path
     planning_summary_artifact_json: Path
+    checkpoints_dir: Path
+    planning_batches_dir: Path
+    selected_blueprints_json: Path
+    realization_batches_dir: Path
 
     def ensure_dirs(
         self,
     ) -> Self:
         """Create the run directory scaffold."""
         self.run_dir.mkdir(parents=True, exist_ok=True)
+        self.planning_batches_dir.mkdir(parents=True, exist_ok=True)
+        self.realization_batches_dir.mkdir(parents=True, exist_ok=True)
         return self
 
 
@@ -51,6 +67,7 @@ def resolve_querygen_paths(
     """
     tool_root = workspace.tool_root("querygen")
     run_dir = workspace.run_root(tool="querygen", run_id=run_id)
+    checkpoints_dir = run_dir / "checkpoints"
 
     return QueryGenRunPaths(
         tool_root=tool_root,
@@ -58,4 +75,8 @@ def resolve_querygen_paths(
         synthetic_queries_csv=run_dir / "synthetic_queries.csv",
         synthetic_queries_meta_json=run_dir / "synthetic_queries.meta.json",
         planning_summary_artifact_json=tool_root / f"{spec_fingerprint}.json",
+        checkpoints_dir=checkpoints_dir,
+        planning_batches_dir=checkpoints_dir / "planning_batches",
+        selected_blueprints_json=checkpoints_dir / "selected_blueprints.json",
+        realization_batches_dir=checkpoints_dir / "realization_batches",
     )

--- a/src/pragmata/core/querygen/deduplication.py
+++ b/src/pragmata/core/querygen/deduplication.py
@@ -15,6 +15,10 @@ from pragmata.core.schemas.querygen_plan import QueryBlueprint
 if TYPE_CHECKING:
     from sentence_transformers import SentenceTransformer
 
+# Embedding model used for semantic near-duplicate detection. Exposed so callers
+# that persist a deduplicated result can record which model produced it.
+EMBEDDING_MODEL_CHECKPOINT = "all-MiniLM-L6-v2"
+
 _BLUEPRINT_FIELD_ORDER: tuple[str, ...] = (
     "domain",
     "role",
@@ -84,7 +88,7 @@ def _select_non_duplicate_indices(
 
 
 @lru_cache(maxsize=1)
-def _load_embedding_model(checkpoint: str = "all-MiniLM-L6-v2") -> SentenceTransformer:
+def _load_embedding_model(checkpoint: str = EMBEDDING_MODEL_CHECKPOINT) -> SentenceTransformer:
     """Load the embedding model used for semantic blueprint deduplication."""
     try:
         from sentence_transformers import SentenceTransformer

--- a/src/pragmata/core/querygen/export.py
+++ b/src/pragmata/core/querygen/export.py
@@ -3,8 +3,24 @@
 import json
 from pathlib import Path
 
+from pragmata.core.atomic_io import atomic_write_text
 from pragmata.core.csv_io import write_csv
-from pragmata.core.schemas.querygen_output import PlanningSummaryArtifact, SyntheticQueriesMeta, SyntheticQueryRow
+from pragmata.core.schemas.querygen_output import (
+    PlanningSummaryArtifact,
+    SyntheticQueriesMeta,
+    SyntheticQueryRow,
+)
+
+
+def _atomic_write_json(*, data: dict, path: Path) -> None:
+    """Atomically write ``data`` as indented JSON to ``path`` via :func:`atomic_write_text`.
+
+    Indented (``indent=2``) so the persisted checkpoint/summary artifacts are
+    human-scannable when inspected; round-trip reads validate semantically, so
+    the formatting carries no functional meaning.
+    """
+    with atomic_write_text(path) as handle:
+        handle.write(json.dumps(data, indent=2) + "\n")
 
 
 def export_queries(
@@ -38,7 +54,4 @@ def export_planning_summary(
         artifact: Validated planning-summary artifact to persist.
         artifact_path: Destination path for the JSON artifact.
     """
-    artifact_path.write_text(
-        json.dumps(artifact.model_dump(mode="json")),
-        encoding="utf-8",
-    )
+    _atomic_write_json(data=artifact.model_dump(mode="json"), path=artifact_path)

--- a/src/pragmata/core/querygen/llm.py
+++ b/src/pragmata/core/querygen/llm.py
@@ -17,6 +17,12 @@ _RESERVED_MODEL_KWARGS = {
     "rate_limiter",
 }
 
+# Default per-request timeout (seconds) applied to every chat model so a stalled
+# response cannot hang a run indefinitely. Callers override it via
+# model_kwargs["timeout"] (not reserved). int, not float: ChatMistralAI declares
+# ``timeout: int`` and rejects floats; OpenAI/Azure accept both.
+_DEFAULT_REQUEST_TIMEOUT_SECONDS = 600
+
 
 class LlmInitializationError(RuntimeError):
     """Raised when the configured chat model cannot be initialized."""
@@ -72,6 +78,8 @@ def build_llm_runnable(
         max_bucket_size: Rate limiter burst size.
         base_url: Optional provider base URL.
         model_kwargs: Optional extra keyword arguments forwarded to model init.
+            A default request ``timeout`` of ``_DEFAULT_REQUEST_TIMEOUT_SECONDS``
+            is applied unless ``model_kwargs`` supplies its own ``timeout``.
 
     Returns:
         A composed LangChain runnable that accepts prompt variables and returns
@@ -89,6 +97,7 @@ def build_llm_runnable(
         "model": model,
         "model_provider": model_provider,
         "api_key": api_key,
+        "timeout": _DEFAULT_REQUEST_TIMEOUT_SECONDS,
         "rate_limiter": InMemoryRateLimiter(
             requests_per_second=requests_per_second,
             check_every_n_seconds=check_every_n_seconds,
@@ -99,6 +108,8 @@ def build_llm_runnable(
     if base_url is not None:
         init_kwargs["base_url"] = base_url
 
+    # Applied after the defaults so a caller-supplied model_kwargs["timeout"]
+    # overrides _DEFAULT_REQUEST_TIMEOUT_SECONDS.
     if model_kwargs:
         init_kwargs.update(model_kwargs)
 

--- a/src/pragmata/core/querygen/planning_summary.py
+++ b/src/pragmata/core/querygen/planning_summary.py
@@ -58,6 +58,70 @@ def fingerprint_querygen_spec(
     return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
 
 
+def _sha256_json(payload: object) -> str:
+    """Return a SHA-256 hex digest over the canonical JSON form of ``payload``.
+
+    Uses ``default=str`` so non-JSON values in model kwargs hash by their string
+    form rather than raising.
+    """
+    serialized = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False, default=str)
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def fingerprint_planning_llm_settings(
+    llm_settings: LlmSettings,
+) -> str:
+    """Return a fingerprint of the LLM settings that shape Stage 1 planning output.
+
+    Covers the inputs that determine the blueprints -- provider, planning model,
+    planning model kwargs (e.g. ``reasoning_effort``/``temperature``), and
+    ``base_url``. Excludes realization settings (which do not affect planning)
+    and the rate limiter (which only paces requests). Changing any of these on a
+    resume forces Stage 1 to recompute; changing only realization settings does
+    not, so planning work is reused.
+
+    Args:
+        llm_settings: Resolved LLM settings for the run.
+
+    Returns:
+        Stable SHA-256 hex digest over the planning-shaping LLM settings.
+    """
+    return _sha256_json(
+        {
+            "model_provider": llm_settings.model_provider,
+            "planning_model": llm_settings.planning_model,
+            "planning_model_kwargs": llm_settings.planning_model_kwargs,
+            "base_url": llm_settings.base_url,
+        }
+    )
+
+
+def fingerprint_realization_llm_settings(
+    llm_settings: LlmSettings,
+) -> str:
+    """Return a fingerprint of the LLM settings that shape Stage 2 realization output.
+
+    Covers the inputs that determine the realized queries -- provider,
+    realization model, realization model kwargs, and ``base_url``. Excludes
+    planning settings and the rate limiter. Changing any of these on a resume
+    forces only Stage 2 to recompute (the frozen Stage 1 result is reused).
+
+    Args:
+        llm_settings: Resolved LLM settings for the run.
+
+    Returns:
+        Stable SHA-256 hex digest over the realization-shaping LLM settings.
+    """
+    return _sha256_json(
+        {
+            "model_provider": llm_settings.model_provider,
+            "realization_model": llm_settings.realization_model,
+            "realization_model_kwargs": llm_settings.realization_model_kwargs,
+            "base_url": llm_settings.base_url,
+        }
+    )
+
+
 def read_planning_summary_artifact(
     artifact_path: Path,
     spec: QueryGenSpec,

--- a/tests/unit/core/paths/test_querygen_paths.py
+++ b/tests/unit/core/paths/test_querygen_paths.py
@@ -31,6 +31,7 @@ def test_resolve_querygen_paths_returns_expected_bundle(
     )
     expected_tool_root = workspace.base_dir / "querygen"
     expected_run_dir = workspace.base_dir / "querygen" / "runs" / run_id
+    expected_checkpoints_dir = expected_run_dir / "checkpoints"
 
     assert paths == QueryGenRunPaths(
         tool_root=expected_tool_root,
@@ -38,6 +39,10 @@ def test_resolve_querygen_paths_returns_expected_bundle(
         synthetic_queries_csv=expected_run_dir / "synthetic_queries.csv",
         synthetic_queries_meta_json=expected_run_dir / "synthetic_queries.meta.json",
         planning_summary_artifact_json=expected_tool_root / f"{spec_fingerprint}.json",
+        checkpoints_dir=expected_checkpoints_dir,
+        planning_batches_dir=expected_checkpoints_dir / "planning_batches",
+        selected_blueprints_json=expected_checkpoints_dir / "selected_blueprints.json",
+        realization_batches_dir=expected_checkpoints_dir / "realization_batches",
     )
 
 
@@ -59,6 +64,8 @@ def test_ensure_dirs_creates_run_directory_and_returns_self(
     assert returned is paths
     assert paths.tool_root.is_dir()
     assert paths.run_dir.is_dir()
+    assert paths.planning_batches_dir.is_dir()
+    assert paths.realization_batches_dir.is_dir()
 
 
 def test_planning_summary_artifact_path_is_fingerprint_specific_and_run_independent(

--- a/tests/unit/core/querygen/test_llm.py
+++ b/tests/unit/core/querygen/test_llm.py
@@ -151,6 +151,72 @@ def test_build_llm_runnable_inserts_optional_init_kwargs_conditionally(
     assert expected_absent.isdisjoint(init_kwargs.keys())
 
 
+def test_build_llm_runnable_applies_default_timeout(
+    mock_llm_setup: dict[str, Any],
+) -> None:
+    """A default request timeout is forwarded when the caller supplies none."""
+    build_llm_runnable(
+        system_text="s",
+        user_text="u",
+        model_provider="azure_openai",
+        model="gpt-5.4",
+        api_key="k",
+        output_schema=_DummyOutputSchema,
+        requests_per_second=1.0,
+        check_every_n_seconds=1.0,
+        max_bucket_size=1,
+        base_url=None,
+        model_kwargs={},
+    )
+
+    init_kwargs = mock_llm_setup["init"].call_args.kwargs
+    assert init_kwargs["timeout"] == 600
+
+
+def test_build_llm_runnable_default_timeout_is_int(
+    mock_llm_setup: dict[str, Any],
+) -> None:
+    """The default timeout is an int (ChatMistralAI rejects float timeouts)."""
+    build_llm_runnable(
+        system_text="s",
+        user_text="u",
+        model_provider="mistralai",
+        model="magistral-medium-latest",
+        api_key="k",
+        output_schema=_DummyOutputSchema,
+        requests_per_second=1.0,
+        check_every_n_seconds=1.0,
+        max_bucket_size=1,
+        base_url=None,
+        model_kwargs={},
+    )
+
+    init_kwargs = mock_llm_setup["init"].call_args.kwargs
+    assert isinstance(init_kwargs["timeout"], int)
+
+
+def test_build_llm_runnable_caller_timeout_overrides_default(
+    mock_llm_setup: dict[str, Any],
+) -> None:
+    """A caller-supplied model_kwargs['timeout'] overrides the default."""
+    build_llm_runnable(
+        system_text="s",
+        user_text="u",
+        model_provider="azure_openai",
+        model="gpt-5.4",
+        api_key="k",
+        output_schema=_DummyOutputSchema,
+        requests_per_second=1.0,
+        check_every_n_seconds=1.0,
+        max_bucket_size=1,
+        base_url=None,
+        model_kwargs={"timeout": 120},
+    )
+
+    init_kwargs = mock_llm_setup["init"].call_args.kwargs
+    assert init_kwargs["timeout"] == 120
+
+
 def test_build_llm_runnable_wraps_init_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/core/test_atomic_io.py
+++ b/tests/unit/core/test_atomic_io.py
@@ -1,0 +1,46 @@
+"""Tests for the shared atomic text-write helper."""
+
+from pathlib import Path
+
+import pytest
+
+from pragmata.core.atomic_io import atomic_write_text
+
+
+def test_atomic_write_text_writes_and_replaces(tmp_path: Path) -> None:
+    """Content written in the block becomes the file's contents on clean exit."""
+    target = tmp_path / "out.json"
+    target.write_text("old", encoding="utf-8")
+
+    with atomic_write_text(target) as handle:
+        handle.write("new content")
+
+    assert target.read_text(encoding="utf-8") == "new content"
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_atomic_write_text_leaves_original_intact_on_exception(tmp_path: Path) -> None:
+    """An exception in the block leaves the original file untouched and no temp behind."""
+    target = tmp_path / "out.json"
+    target.write_text("original", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with atomic_write_text(target) as handle:
+            handle.write("partial")
+            raise RuntimeError("boom")
+
+    assert target.read_text(encoding="utf-8") == "original"
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_atomic_write_text_no_target_left_when_block_fails_for_new_path(tmp_path: Path) -> None:
+    """A failed write to a not-yet-existing path leaves no file at all."""
+    target = tmp_path / "fresh.json"
+
+    with pytest.raises(ValueError, match="nope"):
+        with atomic_write_text(target) as handle:
+            handle.write("partial")
+            raise ValueError("nope")
+
+    assert not target.exists()
+    assert list(tmp_path.glob("*.tmp")) == []


### PR DESCRIPTION
**Stack (6 open PRs):** #236 → #237 → #238 → #239 → #240 → #241 → #242

**Chain goal:** Add per-batch checkpoint/resume to querygen so a re-run with the same `run_id` skips already-completed work. Nests resumable state under `<run_dir>/checkpoints/`, writes a frozen Stage 1 result (planning + dedup) plus per-batch Stage 1 and Stage 2 artifacts, and orchestrates resume behind a fail-fast config-drift gate (`--force` overrides) so checkpoints are never silently reused under changed settings.

**This PR (2/6):** Foundation. Adds the checkpoint path bundle, the per-stage fingerprint helpers used to detect config drift, and the embedding-model constant — all dormant at merge time (consumed by the later artifacts and orchestration).

---

## What
- `querygen_paths.py`: nests resumable state under `<run_dir>/checkpoints/` (`checkpoints_dir`, `planning_batches_dir`, `selected_blueprints_json`, `realization_batches_dir`). Separates the resumable working state from the deliverable CSV.
- `planning_summary.py`: `_sha256_json` shared helper; `fingerprint_planning_llm_settings` + `fingerprint_realization_llm_settings` (per-stage). A realization-model change re-runs **only Stage 2**; the frozen Stage 1 result and planning checkpoints stay valid.
- `deduplication.py`: `EMBEDDING_MODEL_CHECKPOINT` constant exposed for the dedup artifact's provenance field.

## Why
Foundation for the checkpoint/resume work that lands in #239–242. The path bundle, fingerprint helpers, and embedding-model constant land first so the later artifact and orchestration PRs are pure consumers — nothing here is wired into a live code path at merge.

## Test plan
- [x] `tests/unit/core/paths/test_querygen_paths.py` — checkpoints/ nesting expectations.
- [x] Existing planning-summary + deduplication tests still pass.
