### PR TITLE
feat(querygen): add planning-batch checkpoint artifact and read engine

### DIFF
--- a/src/pragmata/core/querygen/assembly.py
+++ b/src/pragmata/core/querygen/assembly.py
@@ -1,10 +1,16 @@
 """Assembly of synthetic query generation output."""
 
+import importlib.metadata
 from datetime import UTC, datetime
 
 from pragmata.core.querygen.planning_summary import fingerprint_querygen_spec
 from pragmata.core.schemas.querygen_input import QueryGenSpec
-from pragmata.core.schemas.querygen_output import PlanningSummaryArtifact, SyntheticQueriesMeta, SyntheticQueryRow
+from pragmata.core.schemas.querygen_output import (
+    PlanningBatchArtifact,
+    PlanningSummaryArtifact,
+    SyntheticQueriesMeta,
+    SyntheticQueryRow,
+)
 from pragmata.core.schemas.querygen_plan import QueryBlueprint
 from pragmata.core.schemas.querygen_realize import RealizedQuery
 from pragmata.core.schemas.querygen_summary import PlanningSummaryState
@@ -90,6 +96,55 @@ def assemble_queries_meta(
         model_provider=model_provider,
         planning_model=planning_model,
         realization_model=realization_model,
+    )
+
+
+def assemble_planning_batch_artifact(
+    *,
+    spec_fingerprint: str,
+    llm_fingerprint: str,
+    source_run_id: str,
+    n_queries: int,
+    batch_size: int,
+    batch_idx: int,
+    candidate_ids: list[str],
+    blueprints: list[QueryBlueprint],
+    planning_summary_state: PlanningSummaryState | None,
+    enable_planning_memory: bool,
+) -> PlanningBatchArtifact:
+    """Assemble a Stage 1 planning-batch artifact, stamping version + time.
+
+    Args:
+        spec_fingerprint: Fingerprint of the resolved querygen spec.
+        llm_fingerprint: Fingerprint of the output-shaping LLM settings; a
+            change invalidates the checkpoint.
+        source_run_id: Run identifier that produced this batch.
+        n_queries: Total queries requested for the run.
+        batch_size: Configured batch size for the run.
+        batch_idx: Zero-based index of this planning batch.
+        candidate_ids: Candidate IDs assigned to this batch.
+        blueprints: Blueprints produced for this batch.
+        planning_summary_state: Planning-summary state after this batch, if any.
+        enable_planning_memory: Whether planning memory was enabled (a change
+            invalidates the checkpoint, since it shapes the blueprints).
+
+    Returns:
+        A validated ``PlanningBatchArtifact`` with internally stamped
+        ``pragmata_version`` and ``created_at``.
+    """
+    return PlanningBatchArtifact(
+        spec_fingerprint=spec_fingerprint,
+        pragmata_version=importlib.metadata.version("pragmata"),
+        llm_fingerprint=llm_fingerprint,
+        source_run_id=source_run_id,
+        n_queries=n_queries,
+        batch_size=batch_size,
+        batch_idx=batch_idx,
+        enable_planning_memory=enable_planning_memory,
+        candidate_ids=candidate_ids,
+        blueprints=blueprints,
+        planning_summary_state=planning_summary_state,
+        created_at=datetime.now(UTC),
     )
 
 

--- a/src/pragmata/core/querygen/checkpoint_read.py
+++ b/src/pragmata/core/querygen/checkpoint_read.py
@@ -1,0 +1,82 @@
+"""Shared loader for querygen checkpoint artifacts (read + drift detection)."""
+
+import importlib.metadata
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TypeVar
+
+from pydantic import BaseModel
+
+ArtifactT = TypeVar("ArtifactT", bound=BaseModel)
+
+
+@dataclass(frozen=True, slots=True)
+class DriftedField:
+    """One header field whose stored value no longer matches the current run.
+
+    Attributes:
+        field: Header attribute name that drifted.
+        stored: Value recorded in the checkpoint (the "old" value).
+        expected: Value the current run requires (the "new" value).
+    """
+
+    field: str
+    stored: object
+    expected: object
+
+
+def read_checkpoint_artifact(
+    *,
+    path: Path,
+    model_cls: type[ArtifactT],
+    expected_header: dict[str, object],
+) -> tuple[ArtifactT | None, list[DriftedField]]:
+    """Load a checkpoint artifact and report any configuration drift.
+
+    Args:
+        path: Checkpoint file path.
+        model_cls: Pydantic artifact schema to validate against.
+        expected_header: Mapping of artifact attribute name -> value the current
+            run requires. The running ``pragmata`` version is compared
+            automatically in addition to these.
+
+    Returns:
+        A ``(artifact, drifted)`` pair:
+
+        - ``(artifact, [])`` -- the file is present and every header value (and
+          the running pragmata version) matches; the checkpoint is reusable.
+        - ``(None, [])`` -- the file is absent (nothing to resume here).
+        - ``(None, drifted)`` -- the file is present but one or more fields
+          differ; ``drifted`` lists each as a :class:`DriftedField` (stored vs
+          expected), including ``pragmata_version`` when the running version
+          differs. The api layer fails fast on a non-empty ``drifted`` unless
+          the run opts into ``force``.
+
+    Raises:
+        json.JSONDecodeError: The file content is not valid JSON.
+        UnicodeDecodeError: The file is not valid UTF-8 (e.g. torn mid-write).
+        pydantic.ValidationError: The JSON does not match ``model_cls``.
+
+    These exceptions signal a damaged (not merely drifted) checkpoint; the api
+    layer treats them as a self-heal case and recomputes silently, distinct from
+    the deliberate-config-change drift reported via the return value.
+    """
+    if not path.exists():
+        return None, []
+
+    artifact = model_cls.model_validate(json.loads(path.read_text(encoding="utf-8")))
+
+    # The running pragmata version is always part of the expected header: a
+    # version change can alter prompt templates or schemas without touching the
+    # spec, so a checkpoint written by another version must not be reused.
+    expected = {**expected_header, "pragmata_version": importlib.metadata.version("pragmata")}
+    drifted = [
+        DriftedField(field=attribute, stored=getattr(artifact, attribute), expected=value)
+        for attribute, value in expected.items()
+        if getattr(artifact, attribute) != value
+    ]
+
+    if drifted:
+        return None, drifted
+    return artifact, []

--- a/src/pragmata/core/querygen/export.py
+++ b/src/pragmata/core/querygen/export.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from pragmata.core.atomic_io import atomic_write_text
 from pragmata.core.csv_io import write_csv
 from pragmata.core.schemas.querygen_output import (
+    PlanningBatchArtifact,
     PlanningSummaryArtifact,
     SyntheticQueriesMeta,
     SyntheticQueryRow,
@@ -55,3 +56,17 @@ def export_planning_summary(
         artifact_path: Destination path for the JSON artifact.
     """
     _atomic_write_json(data=artifact.model_dump(mode="json"), path=artifact_path)
+
+
+def export_planning_batch_artifact(
+    *,
+    artifact: PlanningBatchArtifact,
+    path: Path,
+) -> None:
+    """Atomically persist a Stage 1 planning-batch artifact as JSON.
+
+    Args:
+        artifact: Validated planning-batch artifact to persist.
+        path: Destination path (``planning_batches/batch_NNNN.json``).
+    """
+    _atomic_write_json(data=artifact.model_dump(mode="json"), path=path)

--- a/src/pragmata/core/querygen/planning_batches.py
+++ b/src/pragmata/core/querygen/planning_batches.py
@@ -1,0 +1,42 @@
+"""Read helper for Stage 1 planning-batch checkpoint artifacts."""
+
+from pathlib import Path
+
+from pragmata.core.querygen.checkpoint_read import DriftedField, read_checkpoint_artifact
+from pragmata.core.schemas.querygen_output import PlanningBatchArtifact
+
+
+def read_planning_batch_artifact(
+    *,
+    path: Path,
+    expected_spec_fingerprint: str,
+    expected_source_run_id: str,
+    expected_n_queries: int,
+    expected_batch_size: int,
+    expected_candidate_ids: list[str],
+    expected_enable_planning_memory: bool,
+    expected_llm_fingerprint: str,
+) -> tuple[PlanningBatchArtifact | None, list[DriftedField]]:
+    """Load a Stage 1 planning-batch checkpoint at ``path`` and report drift.
+
+    Returns ``(artifact, [])`` when the checkpoint is reusable, ``(None, [])``
+    when the file is absent, and ``(None, drifted)`` when its header differs
+    from the current run (spec fingerprint, running pragmata version, LLM-config
+    fingerprint, source run id, n_queries, batch_size, enable_planning_memory,
+    or candidate_ids). Raises ``json.JSONDecodeError`` / ``UnicodeDecodeError``
+    / ``pydantic.ValidationError`` on a malformed or torn file (self-heal case).
+    See :func:`read_checkpoint_artifact`.
+    """
+    return read_checkpoint_artifact(
+        path=path,
+        model_cls=PlanningBatchArtifact,
+        expected_header={
+            "spec_fingerprint": expected_spec_fingerprint,
+            "source_run_id": expected_source_run_id,
+            "n_queries": expected_n_queries,
+            "batch_size": expected_batch_size,
+            "enable_planning_memory": expected_enable_planning_memory,
+            "llm_fingerprint": expected_llm_fingerprint,
+            "candidate_ids": expected_candidate_ids,
+        },
+    )

--- a/src/pragmata/core/schemas/querygen_output.py
+++ b/src/pragmata/core/schemas/querygen_output.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, NonNegativeInt, PositiveInt, model_validator
 
+from pragmata.core.schemas.querygen_plan import QueryBlueprint
 from pragmata.core.schemas.querygen_summary import PlanningSummaryState
 from pragmata.core.types import NonEmptyStr
 
@@ -55,3 +56,35 @@ class PlanningSummaryArtifact(BaseModel):
     source_run_id: NonEmptyStr
     created_at: datetime
     state: PlanningSummaryState
+
+
+class PlanningBatchArtifact(BaseModel):
+    """Persisted result of one Stage 1 planning batch.
+
+    Written atomically to ``<run_dir>/planning_batches/batch_NNNN.json`` after
+    each successful Stage 1 batch. Lets a rerun of the same ``source_run_id``
+    skip already-planned batches when the header fields and ``candidate_ids``
+    still match.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    spec_fingerprint: NonEmptyStr
+    pragmata_version: NonEmptyStr
+    llm_fingerprint: NonEmptyStr
+    source_run_id: NonEmptyStr
+    n_queries: PositiveInt
+    batch_size: PositiveInt
+    batch_idx: NonNegativeInt
+    enable_planning_memory: bool
+    candidate_ids: list[NonEmptyStr]
+    blueprints: list[QueryBlueprint]
+    planning_summary_state: PlanningSummaryState | None
+    created_at: datetime
+
+    @model_validator(mode="after")
+    def validate_blueprint_count(self) -> "PlanningBatchArtifact":
+        """Enforce a 1:1 mapping between batch candidate IDs and blueprints."""
+        if len(self.candidate_ids) != len(self.blueprints):
+            raise ValueError("candidate_ids and blueprints must have equal length")
+        return self

--- a/tests/unit/core/querygen/test_planning_batches.py
+++ b/tests/unit/core/querygen/test_planning_batches.py
@@ -1,0 +1,172 @@
+"""Tests for the Stage 1 planning-batch checkpoint read helper."""
+
+import importlib.metadata
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from pragmata.core.querygen.assembly import assemble_planning_batch_artifact
+from pragmata.core.querygen.export import export_planning_batch_artifact
+from pragmata.core.querygen.planning_batches import read_planning_batch_artifact
+from pragmata.core.schemas.querygen_plan import QueryBlueprint
+
+
+def _blueprint(candidate_id: str) -> QueryBlueprint:
+    return QueryBlueprint(
+        candidate_id=candidate_id,
+        domain="d",
+        role="r",
+        language="german",
+        topic="t",
+        intent="i",
+        task="k",
+        user_scenario="scenario",
+        information_need="need",
+    )
+
+
+_EXPECTED = {
+    "expected_spec_fingerprint": "fp-1",
+    "expected_source_run_id": "run-1",
+    "expected_n_queries": 10,
+    "expected_batch_size": 5,
+    "expected_candidate_ids": ["c001", "c002"],
+    "expected_enable_planning_memory": True,
+    "expected_llm_fingerprint": "llm-fp-1",
+}
+
+
+def _write_valid(path: Path) -> None:
+    artifact = assemble_planning_batch_artifact(
+        spec_fingerprint="fp-1",
+        llm_fingerprint="llm-fp-1",
+        source_run_id="run-1",
+        n_queries=10,
+        batch_size=5,
+        batch_idx=0,
+        candidate_ids=["c001", "c002"],
+        blueprints=[_blueprint("c001"), _blueprint("c002")],
+        planning_summary_state=None,
+        enable_planning_memory=True,
+    )
+    export_planning_batch_artifact(artifact=artifact, path=path)
+
+
+def test_read_planning_batch_artifact_roundtrip_via_export(tmp_path: Path) -> None:
+    """A written artifact reads back with matching content and no drift."""
+    path = tmp_path / "batch_0000.json"
+    _write_valid(path)
+
+    artifact, drifted = read_planning_batch_artifact(path=path, **_EXPECTED)
+
+    assert drifted == []
+    assert artifact is not None
+    assert [bp.candidate_id for bp in artifact.blueprints] == ["c001", "c002"]
+    assert artifact.batch_idx == 0
+
+
+def test_export_planning_batch_artifact_leaves_no_tmp_on_success(tmp_path: Path) -> None:
+    """No uniquified tempfile remains after a successful atomic write."""
+    path = tmp_path / "batch_0000.json"
+    _write_valid(path)
+
+    assert path.exists()
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_read_planning_batch_artifact_returns_none_for_missing_path(tmp_path: Path) -> None:
+    """A missing checkpoint reads as ``(None, [])`` -- nothing to resume, no drift."""
+    artifact, drifted = read_planning_batch_artifact(path=tmp_path / "absent.json", **_EXPECTED)
+
+    assert artifact is None
+    assert drifted == []
+
+
+@pytest.mark.parametrize(
+    ("override_key", "override_value"),
+    [
+        ("expected_spec_fingerprint", "fp-other"),
+        ("expected_source_run_id", "run-other"),
+        ("expected_n_queries", 20),
+        ("expected_batch_size", 7),
+        ("expected_candidate_ids", ["c001", "c999"]),
+        ("expected_enable_planning_memory", False),
+        ("expected_llm_fingerprint", "llm-other"),
+    ],
+)
+def test_read_planning_batch_artifact_reports_drift_for_header_mismatch(
+    tmp_path: Path,
+    override_key: str,
+    override_value: object,
+) -> None:
+    """A mismatch on any validated header field is reported as drift, not reused."""
+    path = tmp_path / "batch_0000.json"
+    _write_valid(path)
+
+    expected = {**_EXPECTED, override_key: override_value}
+    artifact, drifted = read_planning_batch_artifact(path=path, **expected)
+
+    assert artifact is None
+    assert override_key.removeprefix("expected_") in {field.field for field in drifted}
+
+
+def test_read_planning_batch_artifact_reports_drift_for_pragmata_version_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A checkpoint written by a different pragmata version is reported as drift."""
+    path = tmp_path / "batch_0000.json"
+    _write_valid(path)
+
+    real_version = importlib.metadata.version
+
+    def fake_version(name: str) -> str:
+        if name == "pragmata":
+            return "0.0.0-other"
+        return real_version(name)
+
+    monkeypatch.setattr("pragmata.core.querygen.checkpoint_read.importlib.metadata.version", fake_version)
+    artifact, drifted = read_planning_batch_artifact(path=path, **_EXPECTED)
+
+    assert artifact is None
+    assert "pragmata_version" in {field.field for field in drifted}
+
+
+def test_read_planning_batch_artifact_raises_for_extra_field(tmp_path: Path) -> None:
+    """An unknown field fails schema validation (extra=forbid)."""
+    path = tmp_path / "batch_0000.json"
+    _write_valid(path)
+    payload = path.read_text(encoding="utf-8")
+    path.write_text(payload.replace("{", '{"unexpected": 1,', 1), encoding="utf-8")
+
+    with pytest.raises(ValidationError):
+        read_planning_batch_artifact(path=path, **_EXPECTED)
+
+
+def test_read_planning_batch_artifact_raises_for_malformed_json(tmp_path: Path) -> None:
+    """Malformed file content raises a JSON decode error."""
+    import json
+
+    path = tmp_path / "batch_0000.json"
+    path.write_text("{not json", encoding="utf-8")
+
+    with pytest.raises(json.JSONDecodeError):
+        read_planning_batch_artifact(path=path, **_EXPECTED)
+
+
+def test_planning_batch_artifact_rejects_candidate_blueprint_length_mismatch() -> None:
+    """The schema enforces a 1:1 candidate_ids/blueprints mapping."""
+    with pytest.raises(ValidationError):
+        assemble_planning_batch_artifact(
+            spec_fingerprint="fp-1",
+            llm_fingerprint="llm-fp-1",
+            source_run_id="run-1",
+            n_queries=10,
+            batch_size=5,
+            batch_idx=0,
+            candidate_ids=["c001", "c002"],
+            blueprints=[_blueprint("c001")],
+            planning_summary_state=None,
+            enable_planning_memory=True,
+        )


### PR DESCRIPTION
**Stack (6 open PRs):** #236 → #237 → #238 → #239 → #240 → #241 → #242

**Chain goal:** Add per-batch checkpoint/resume to querygen so a re-run with the same `run_id` skips already-completed work. Nests resumable state under `<run_dir>/checkpoints/`, writes a frozen Stage 1 result (planning + dedup) plus per-batch Stage 1 and Stage 2 artifacts, and orchestrates resume behind a fail-fast config-drift gate (`--force` overrides) so checkpoints are never silently reused under changed settings.

**This PR (3/6):** First of three vertical artifact slices. Adds per-batch checkpointing for Stage 1 planning, plus the **generic read engine** all three artifact readers (this PR's, #240's, #241's) delegate to.

---

## What
- `PlanningBatchArtifact` schema (`querygen_output.py`) with `extra="forbid"` + `1:1 candidate_ids/blueprints` model_validator.
- `assemble_planning_batch_artifact` stamps `pragmata_version` + `created_at` internally.
- `export_planning_batch_artifact` — atomic JSON write via the helper from #237.
- `read_checkpoint_artifact` (engine): returns `(artifact, list[DriftedField])` — `(artifact, [])` reusable, `(None, [])` absent, `(None, drifted)` config-drifted; raises on damaged file (caller self-heals).
- `DriftedField` — `@dataclass(frozen=True, slots=True)` with `field`/`stored`/`expected`, in line with core's frozen-dataclass container convention.
- `read_planning_batch_artifact` — thin typed wrapper over the engine (matches the existing `read_planning_summary_artifact` per-artifact typed-reader house pattern).

## Why
The read engine is the reusable core of the whole stack: every checkpoint read (#240's frozen result, #241's realization batches, #242's orchestration) goes through `read_checkpoint_artifact`, so the drift/absent/damaged trichotomy is defined once here and the later PRs only add typed wrappers.

## Test plan
- [x] `tests/unit/core/querygen/test_planning_batches.py` — schema, round-trip, header-mismatch (drift) per field, version-mismatch, malformed/extra-field, length-validator.
