### PR TITLE
feat(querygen): add frozen selected-blueprints checkpoint artifact

### DIFF
--- a/src/pragmata/core/querygen/assembly.py
+++ b/src/pragmata/core/querygen/assembly.py
@@ -8,6 +8,7 @@ from pragmata.core.schemas.querygen_input import QueryGenSpec
 from pragmata.core.schemas.querygen_output import (
     PlanningBatchArtifact,
     PlanningSummaryArtifact,
+    SelectedBlueprintsArtifact,
     SyntheticQueriesMeta,
     SyntheticQueryRow,
 )
@@ -144,6 +145,54 @@ def assemble_planning_batch_artifact(
         candidate_ids=candidate_ids,
         blueprints=blueprints,
         planning_summary_state=planning_summary_state,
+        created_at=datetime.now(UTC),
+    )
+
+
+def assemble_selected_blueprints_artifact(
+    *,
+    spec_fingerprint: str,
+    llm_fingerprint: str,
+    source_run_id: str,
+    n_queries: int,
+    batch_size: int,
+    near_duplicate_tolerance: float,
+    enable_planning_memory: bool,
+    embedding_model: str,
+    blueprints: list[QueryBlueprint],
+) -> SelectedBlueprintsArtifact:
+    """Assemble the frozen Stage 1 result artifact, stamping provenance.
+
+    Args:
+        spec_fingerprint: Fingerprint of the resolved querygen spec.
+        llm_fingerprint: Fingerprint of the output-shaping LLM settings; a
+            change invalidates the checkpoint.
+        source_run_id: Run identifier that produced this result.
+        n_queries: Total queries requested for the run.
+        batch_size: Configured batch size for the run.
+        near_duplicate_tolerance: Tolerance used for the deduplication that
+            produced ``blueprints``.
+        enable_planning_memory: Whether planning memory was enabled (a change
+            invalidates the frozen result, since it shapes the blueprints).
+        embedding_model: Embedding model checkpoint used for deduplication
+            (recorded for provenance).
+        blueprints: Final post-deduplication selected blueprints.
+
+    Returns:
+        A validated ``SelectedBlueprintsArtifact`` with internally stamped
+        ``pragmata_version`` and ``created_at``.
+    """
+    return SelectedBlueprintsArtifact(
+        spec_fingerprint=spec_fingerprint,
+        pragmata_version=importlib.metadata.version("pragmata"),
+        llm_fingerprint=llm_fingerprint,
+        source_run_id=source_run_id,
+        n_queries=n_queries,
+        batch_size=batch_size,
+        near_duplicate_tolerance=near_duplicate_tolerance,
+        enable_planning_memory=enable_planning_memory,
+        embedding_model=embedding_model,
+        blueprints=blueprints,
         created_at=datetime.now(UTC),
     )
 

--- a/src/pragmata/core/querygen/export.py
+++ b/src/pragmata/core/querygen/export.py
@@ -8,6 +8,7 @@ from pragmata.core.csv_io import write_csv
 from pragmata.core.schemas.querygen_output import (
     PlanningBatchArtifact,
     PlanningSummaryArtifact,
+    SelectedBlueprintsArtifact,
     SyntheticQueriesMeta,
     SyntheticQueryRow,
 )
@@ -68,5 +69,19 @@ def export_planning_batch_artifact(
     Args:
         artifact: Validated planning-batch artifact to persist.
         path: Destination path (``planning_batches/batch_NNNN.json``).
+    """
+    _atomic_write_json(data=artifact.model_dump(mode="json"), path=path)
+
+
+def export_selected_blueprints(
+    *,
+    artifact: SelectedBlueprintsArtifact,
+    path: Path,
+) -> None:
+    """Atomically persist the frozen Stage 1 result artifact as JSON.
+
+    Args:
+        artifact: Validated selected-blueprints artifact to persist.
+        path: Destination path (``selected_blueprints.json``).
     """
     _atomic_write_json(data=artifact.model_dump(mode="json"), path=path)

--- a/src/pragmata/core/querygen/selected_blueprints.py
+++ b/src/pragmata/core/querygen/selected_blueprints.py
@@ -1,0 +1,43 @@
+"""Read helper for the frozen Stage 1 result artifact (``selected_blueprints.json``)."""
+
+from pathlib import Path
+
+from pragmata.core.querygen.checkpoint_read import DriftedField, read_checkpoint_artifact
+from pragmata.core.schemas.querygen_output import SelectedBlueprintsArtifact
+
+
+def read_selected_blueprints_artifact(
+    *,
+    path: Path,
+    expected_spec_fingerprint: str,
+    expected_source_run_id: str,
+    expected_n_queries: int,
+    expected_batch_size: int,
+    expected_near_duplicate_tolerance: float,
+    expected_enable_planning_memory: bool,
+    expected_llm_fingerprint: str,
+) -> tuple[SelectedBlueprintsArtifact | None, list[DriftedField]]:
+    """Load the frozen Stage 1 result at ``path`` and report drift.
+
+    Returns ``(artifact, [])`` when the frozen result is reusable, ``(None, [])``
+    when the file is absent, and ``(None, drifted)`` when its header differs
+    from the current run (spec fingerprint, running pragmata version, LLM-config
+    fingerprint, source run id, n_queries, batch_size, near_duplicate_tolerance,
+    enable_planning_memory). ``embedding_model`` is recorded for provenance but
+    intentionally NOT compared. Raises ``json.JSONDecodeError`` /
+    ``UnicodeDecodeError`` / ``pydantic.ValidationError`` on a malformed or torn
+    file (self-heal case). See :func:`read_checkpoint_artifact`.
+    """
+    return read_checkpoint_artifact(
+        path=path,
+        model_cls=SelectedBlueprintsArtifact,
+        expected_header={
+            "spec_fingerprint": expected_spec_fingerprint,
+            "source_run_id": expected_source_run_id,
+            "n_queries": expected_n_queries,
+            "batch_size": expected_batch_size,
+            "near_duplicate_tolerance": expected_near_duplicate_tolerance,
+            "enable_planning_memory": expected_enable_planning_memory,
+            "llm_fingerprint": expected_llm_fingerprint,
+        },
+    )

--- a/src/pragmata/core/schemas/querygen_output.py
+++ b/src/pragmata/core/schemas/querygen_output.py
@@ -88,3 +88,31 @@ class PlanningBatchArtifact(BaseModel):
         if len(self.candidate_ids) != len(self.blueprints):
             raise ValueError("candidate_ids and blueprints must have equal length")
         return self
+
+
+class SelectedBlueprintsArtifact(BaseModel):
+    """Persisted frozen result of Stage 1 (post-filter, post-deduplication).
+
+    Written atomically to ``<run_dir>/selected_blueprints.json`` once, after the
+    Stage 1 loop and deduplication complete. Its presence is the authoritative
+    "Stage 1 is done" marker: on a matching rerun the planning loop and
+    deduplication are skipped and Stage 2 chunks this immutable list.
+
+    ``near_duplicate_tolerance`` is part of the validated header because the
+    deduplicated set is a function of it. ``embedding_model`` is recorded for
+    provenance/diagnosis but is intentionally NOT validated on read.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    spec_fingerprint: NonEmptyStr
+    pragmata_version: NonEmptyStr
+    llm_fingerprint: NonEmptyStr
+    source_run_id: NonEmptyStr
+    n_queries: PositiveInt
+    batch_size: PositiveInt
+    near_duplicate_tolerance: float
+    enable_planning_memory: bool
+    embedding_model: NonEmptyStr
+    blueprints: list[QueryBlueprint]
+    created_at: datetime

--- a/tests/unit/core/querygen/test_selected_blueprints.py
+++ b/tests/unit/core/querygen/test_selected_blueprints.py
@@ -1,0 +1,158 @@
+"""Tests for the frozen Stage 1 result read helper."""
+
+import importlib.metadata
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from pragmata.core.querygen.assembly import assemble_selected_blueprints_artifact
+from pragmata.core.querygen.export import export_selected_blueprints
+from pragmata.core.querygen.selected_blueprints import read_selected_blueprints_artifact
+from pragmata.core.schemas.querygen_output import SelectedBlueprintsArtifact
+from pragmata.core.schemas.querygen_plan import QueryBlueprint
+
+
+def _blueprint(candidate_id: str) -> QueryBlueprint:
+    return QueryBlueprint(
+        candidate_id=candidate_id,
+        domain="d",
+        role="r",
+        language="german",
+        topic="t",
+        intent="i",
+        task="k",
+        user_scenario="scenario",
+        information_need="need",
+    )
+
+
+_EXPECTED = {
+    "expected_spec_fingerprint": "fp-1",
+    "expected_source_run_id": "run-1",
+    "expected_n_queries": 10,
+    "expected_batch_size": 5,
+    "expected_near_duplicate_tolerance": 0.95,
+    "expected_enable_planning_memory": True,
+    "expected_llm_fingerprint": "llm-fp-1",
+}
+
+
+def _write_valid(path: Path) -> None:
+    artifact = assemble_selected_blueprints_artifact(
+        spec_fingerprint="fp-1",
+        llm_fingerprint="llm-fp-1",
+        source_run_id="run-1",
+        n_queries=10,
+        batch_size=5,
+        near_duplicate_tolerance=0.95,
+        enable_planning_memory=True,
+        embedding_model="all-MiniLM-L6-v2",
+        blueprints=[_blueprint("c001"), _blueprint("c003")],
+    )
+    export_selected_blueprints(artifact=artifact, path=path)
+
+
+def test_read_selected_blueprints_roundtrip_via_export(tmp_path: Path) -> None:
+    """A written frozen result reads back with matching content and no drift."""
+    path = tmp_path / "selected_blueprints.json"
+    _write_valid(path)
+
+    artifact, drifted = read_selected_blueprints_artifact(path=path, **_EXPECTED)
+
+    assert drifted == []
+    assert artifact is not None
+    assert [bp.candidate_id for bp in artifact.blueprints] == ["c001", "c003"]
+    assert artifact.embedding_model == "all-MiniLM-L6-v2"
+
+
+def test_read_selected_blueprints_returns_none_for_missing_path(tmp_path: Path) -> None:
+    """A missing frozen result reads as ``(None, [])`` -- nothing to resume, no drift."""
+    artifact, drifted = read_selected_blueprints_artifact(path=tmp_path / "absent.json", **_EXPECTED)
+
+    assert artifact is None
+    assert drifted == []
+
+
+@pytest.mark.parametrize(
+    ("override_key", "override_value"),
+    [
+        ("expected_spec_fingerprint", "fp-other"),
+        ("expected_source_run_id", "run-other"),
+        ("expected_n_queries", 20),
+        ("expected_batch_size", 7),
+        ("expected_near_duplicate_tolerance", 0.80),
+        ("expected_enable_planning_memory", False),
+        ("expected_llm_fingerprint", "llm-other"),
+    ],
+)
+def test_read_selected_blueprints_reports_drift_for_header_mismatch(
+    tmp_path: Path,
+    override_key: str,
+    override_value: object,
+) -> None:
+    """A mismatch on any validated header field is reported as drift, not reused."""
+    path = tmp_path / "selected_blueprints.json"
+    _write_valid(path)
+
+    expected = {**_EXPECTED, override_key: override_value}
+    artifact, drifted = read_selected_blueprints_artifact(path=path, **expected)
+
+    assert artifact is None
+    assert override_key.removeprefix("expected_") in {field.field for field in drifted}
+
+
+def test_read_selected_blueprints_ignores_embedding_model_for_validation(tmp_path: Path) -> None:
+    """embedding_model is recorded for provenance but not used to detect drift."""
+    path = tmp_path / "selected_blueprints.json"
+    artifact = SelectedBlueprintsArtifact(
+        spec_fingerprint="fp-1",
+        pragmata_version=importlib.metadata.version("pragmata"),
+        llm_fingerprint="llm-fp-1",
+        source_run_id="run-1",
+        n_queries=10,
+        batch_size=5,
+        near_duplicate_tolerance=0.95,
+        enable_planning_memory=True,
+        embedding_model="some-other-embedding-model",
+        blueprints=[_blueprint("c001")],
+        created_at=datetime.now(UTC),
+    )
+    path.write_text(json.dumps(artifact.model_dump(mode="json")), encoding="utf-8")
+
+    result, drifted = read_selected_blueprints_artifact(path=path, **_EXPECTED)
+    assert drifted == []
+    assert result is not None
+    assert result.embedding_model == "some-other-embedding-model"
+
+
+def test_read_selected_blueprints_reports_drift_for_pragmata_version_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A frozen result written by a different pragmata version is reported as drift."""
+    path = tmp_path / "selected_blueprints.json"
+    _write_valid(path)
+
+    real_version = importlib.metadata.version
+
+    def fake_version(name: str) -> str:
+        if name == "pragmata":
+            return "0.0.0-other"
+        return real_version(name)
+
+    monkeypatch.setattr("pragmata.core.querygen.checkpoint_read.importlib.metadata.version", fake_version)
+    artifact, drifted = read_selected_blueprints_artifact(path=path, **_EXPECTED)
+
+    assert artifact is None
+    assert "pragmata_version" in {field.field for field in drifted}
+
+
+def test_read_selected_blueprints_raises_for_malformed_json(tmp_path: Path) -> None:
+    """Malformed file content raises a JSON decode error."""
+    path = tmp_path / "selected_blueprints.json"
+    path.write_text("{not json", encoding="utf-8")
+
+    with pytest.raises(json.JSONDecodeError):
+        read_selected_blueprints_artifact(path=path, **_EXPECTED)


### PR DESCRIPTION
**Stack (6 open PRs):** #236 → #237 → #238 → #239 → #240 → #241 → #242 

**Chain goal:** Add per-batch checkpoint/resume to querygen so a re-run with the same `run_id` skips already-completed work. Nests resumable state under `<run_dir>/checkpoints/`, writes a frozen Stage 1 result (planning + dedup) plus per-batch Stage 1 and Stage 2 artifacts, and orchestrates resume behind a fail-fast config-drift gate (`--force` overrides) so checkpoints are never silently reused under changed settings.

**This PR (4/6):** Second of three vertical artifact slices. Adds the **frozen Stage 1 result** — the immutable handoff written once after dedup. Its presence is the "Stage 1 done" marker that lets a rerun skip planning + dedup + the embedding-model load entirely, and lets Stage 2 chunk an immutable set.

---

## What
- `SelectedBlueprintsArtifact` schema — header includes `near_duplicate_tolerance` (the dedup is a function of it) and `enable_planning_memory` (shapes the blueprints); `embedding_model` recorded for provenance but **not** validated.
- `assemble_selected_blueprints_artifact` + `export_selected_blueprints` (atomic, indented JSON).
- `read_selected_blueprints_artifact` — thin typed wrapper over the #239 engine; documents that `embedding_model` is intentionally not part of the drift check.

## Why
The frozen result is the pivot of the whole resume design: writing it once after dedup means a same-`run_id` rerun never has to re-plan, re-dedup, or reload the embedding model, and Stage 2 always chunks a stable, ordered set. `embedding_model` stays out of the drift check because the artifact already captures the dedup output — re-validating the model would force a recompute that the frozen result exists precisely to avoid.

## Test plan
- [x] `tests/unit/core/querygen/test_selected_blueprints.py` — round-trip, header-mismatch per field, version-mismatch, malformed JSON, and the `embedding_model` is-ignored-on-read invariant.
