### PR TITLE
feat(querygen): add realization-batch checkpoint artifact

### DIFF
--- a/src/pragmata/core/querygen/assembly.py
+++ b/src/pragmata/core/querygen/assembly.py
@@ -8,6 +8,7 @@ from pragmata.core.schemas.querygen_input import QueryGenSpec
 from pragmata.core.schemas.querygen_output import (
     PlanningBatchArtifact,
     PlanningSummaryArtifact,
+    RealizationBatchArtifact,
     SelectedBlueprintsArtifact,
     SyntheticQueriesMeta,
     SyntheticQueryRow,
@@ -193,6 +194,48 @@ def assemble_selected_blueprints_artifact(
         enable_planning_memory=enable_planning_memory,
         embedding_model=embedding_model,
         blueprints=blueprints,
+        created_at=datetime.now(UTC),
+    )
+
+
+def assemble_realization_batch_artifact(
+    *,
+    spec_fingerprint: str,
+    llm_fingerprint: str,
+    source_run_id: str,
+    n_queries: int,
+    batch_size: int,
+    batch_idx: int,
+    candidate_ids: list[str],
+    queries: list[RealizedQuery],
+) -> RealizationBatchArtifact:
+    """Assemble a Stage 2 realization-batch artifact, stamping version + time.
+
+    Args:
+        spec_fingerprint: Fingerprint of the resolved querygen spec.
+        llm_fingerprint: Fingerprint of the output-shaping LLM settings; a
+            change invalidates the checkpoint.
+        source_run_id: Run identifier that produced this batch.
+        n_queries: Total queries requested for the run.
+        batch_size: Configured batch size for the run.
+        batch_idx: Zero-based index of this realization batch.
+        candidate_ids: Candidate IDs of the blueprints realized in this batch.
+        queries: Realized queries produced for this batch.
+
+    Returns:
+        A validated ``RealizationBatchArtifact`` with internally stamped
+        ``pragmata_version`` and ``created_at``.
+    """
+    return RealizationBatchArtifact(
+        spec_fingerprint=spec_fingerprint,
+        pragmata_version=importlib.metadata.version("pragmata"),
+        llm_fingerprint=llm_fingerprint,
+        source_run_id=source_run_id,
+        n_queries=n_queries,
+        batch_size=batch_size,
+        batch_idx=batch_idx,
+        candidate_ids=candidate_ids,
+        queries=queries,
         created_at=datetime.now(UTC),
     )
 

--- a/src/pragmata/core/querygen/export.py
+++ b/src/pragmata/core/querygen/export.py
@@ -8,6 +8,7 @@ from pragmata.core.csv_io import write_csv
 from pragmata.core.schemas.querygen_output import (
     PlanningBatchArtifact,
     PlanningSummaryArtifact,
+    RealizationBatchArtifact,
     SelectedBlueprintsArtifact,
     SyntheticQueriesMeta,
     SyntheticQueryRow,
@@ -83,5 +84,19 @@ def export_selected_blueprints(
     Args:
         artifact: Validated selected-blueprints artifact to persist.
         path: Destination path (``selected_blueprints.json``).
+    """
+    _atomic_write_json(data=artifact.model_dump(mode="json"), path=path)
+
+
+def export_realization_batch_artifact(
+    *,
+    artifact: RealizationBatchArtifact,
+    path: Path,
+) -> None:
+    """Atomically persist a Stage 2 realization-batch artifact as JSON.
+
+    Args:
+        artifact: Validated realization-batch artifact to persist.
+        path: Destination path (``realization_batches/batch_NNNN.json``).
     """
     _atomic_write_json(data=artifact.model_dump(mode="json"), path=path)

--- a/src/pragmata/core/querygen/realization_batches.py
+++ b/src/pragmata/core/querygen/realization_batches.py
@@ -1,0 +1,42 @@
+"""Read helper for Stage 2 realization-batch checkpoint artifacts."""
+
+from pathlib import Path
+
+from pragmata.core.querygen.checkpoint_read import DriftedField, read_checkpoint_artifact
+from pragmata.core.schemas.querygen_output import RealizationBatchArtifact
+
+
+def read_realization_batch_artifact(
+    *,
+    path: Path,
+    expected_spec_fingerprint: str,
+    expected_source_run_id: str,
+    expected_n_queries: int,
+    expected_batch_size: int,
+    expected_candidate_ids: list[str],
+    expected_llm_fingerprint: str,
+) -> tuple[RealizationBatchArtifact | None, list[DriftedField]]:
+    """Load a Stage 2 realization-batch checkpoint at ``path`` and report drift.
+
+    Returns ``(artifact, [])`` when the checkpoint is reusable, ``(None, [])``
+    when the file is absent, and ``(None, drifted)`` when its header differs
+    from the current run (spec fingerprint, running pragmata version, LLM-config
+    fingerprint, source run id, n_queries, batch_size, or candidate_ids). The
+    candidate_ids check is what binds a checkpoint to the exact frozen-result
+    chunk, so a stale checkpoint cannot realize a different blueprint. Raises
+    ``json.JSONDecodeError`` / ``UnicodeDecodeError`` / ``pydantic.ValidationError``
+    on a malformed or torn file (self-heal case). See
+    :func:`read_checkpoint_artifact`.
+    """
+    return read_checkpoint_artifact(
+        path=path,
+        model_cls=RealizationBatchArtifact,
+        expected_header={
+            "spec_fingerprint": expected_spec_fingerprint,
+            "source_run_id": expected_source_run_id,
+            "n_queries": expected_n_queries,
+            "batch_size": expected_batch_size,
+            "llm_fingerprint": expected_llm_fingerprint,
+            "candidate_ids": expected_candidate_ids,
+        },
+    )

--- a/src/pragmata/core/schemas/querygen_output.py
+++ b/src/pragmata/core/schemas/querygen_output.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from pydantic import BaseModel, ConfigDict, NonNegativeInt, PositiveInt, model_validator
 
 from pragmata.core.schemas.querygen_plan import QueryBlueprint
+from pragmata.core.schemas.querygen_realize import RealizedQuery
 from pragmata.core.schemas.querygen_summary import PlanningSummaryState
 from pragmata.core.types import NonEmptyStr
 
@@ -116,3 +117,33 @@ class SelectedBlueprintsArtifact(BaseModel):
     embedding_model: NonEmptyStr
     blueprints: list[QueryBlueprint]
     created_at: datetime
+
+
+class RealizationBatchArtifact(BaseModel):
+    """Persisted result of one Stage 2 realization batch.
+
+    Written atomically to ``<run_dir>/realization_batches/batch_NNNN.json``
+    after each successful Stage 2 batch. Stage 2 batches are independent, so a
+    rerun resumes any batch whose header and ``candidate_ids`` still match the
+    current frozen ``selected_blueprints`` chunk -- no contiguity requirement.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    spec_fingerprint: NonEmptyStr
+    pragmata_version: NonEmptyStr
+    llm_fingerprint: NonEmptyStr
+    source_run_id: NonEmptyStr
+    n_queries: PositiveInt
+    batch_size: PositiveInt
+    batch_idx: NonNegativeInt
+    candidate_ids: list[NonEmptyStr]
+    queries: list[RealizedQuery]
+    created_at: datetime
+
+    @model_validator(mode="after")
+    def validate_query_count(self) -> "RealizationBatchArtifact":
+        """Enforce a 1:1 mapping between batch candidate IDs and realized queries."""
+        if len(self.candidate_ids) != len(self.queries):
+            raise ValueError("candidate_ids and queries must have equal length")
+        return self

--- a/tests/unit/core/querygen/test_realization_batches.py
+++ b/tests/unit/core/querygen/test_realization_batches.py
@@ -1,0 +1,135 @@
+"""Tests for the Stage 2 realization-batch checkpoint read helper."""
+
+import importlib.metadata
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from pragmata.core.querygen.assembly import assemble_realization_batch_artifact
+from pragmata.core.querygen.export import export_realization_batch_artifact
+from pragmata.core.querygen.realization_batches import read_realization_batch_artifact
+from pragmata.core.schemas.querygen_realize import RealizedQuery
+
+
+def _realized(candidate_id: str) -> RealizedQuery:
+    return RealizedQuery(candidate_id=candidate_id, query=f"query for {candidate_id}")
+
+
+_EXPECTED = {
+    "expected_spec_fingerprint": "fp-1",
+    "expected_source_run_id": "run-1",
+    "expected_n_queries": 10,
+    "expected_batch_size": 5,
+    "expected_candidate_ids": ["c001", "c002"],
+    "expected_llm_fingerprint": "llm-fp-1",
+}
+
+
+def _write_valid(path: Path) -> None:
+    artifact = assemble_realization_batch_artifact(
+        spec_fingerprint="fp-1",
+        llm_fingerprint="llm-fp-1",
+        source_run_id="run-1",
+        n_queries=10,
+        batch_size=5,
+        batch_idx=0,
+        candidate_ids=["c001", "c002"],
+        queries=[_realized("c001"), _realized("c002")],
+    )
+    export_realization_batch_artifact(artifact=artifact, path=path)
+
+
+def test_read_realization_batch_artifact_roundtrip_via_export(tmp_path: Path) -> None:
+    """A written artifact reads back with matching content, no drift, no leftover tempfile."""
+    path = tmp_path / "batch_0000.json"
+    _write_valid(path)
+
+    artifact, drifted = read_realization_batch_artifact(path=path, **_EXPECTED)
+
+    assert drifted == []
+    assert artifact is not None
+    assert [q.candidate_id for q in artifact.queries] == ["c001", "c002"]
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_read_realization_batch_artifact_returns_none_for_missing_path(tmp_path: Path) -> None:
+    """A missing checkpoint reads as ``(None, [])`` -- nothing to resume, no drift."""
+    artifact, drifted = read_realization_batch_artifact(path=tmp_path / "absent.json", **_EXPECTED)
+
+    assert artifact is None
+    assert drifted == []
+
+
+@pytest.mark.parametrize(
+    ("override_key", "override_value"),
+    [
+        ("expected_spec_fingerprint", "fp-other"),
+        ("expected_source_run_id", "run-other"),
+        ("expected_n_queries", 20),
+        ("expected_batch_size", 7),
+        ("expected_candidate_ids", ["c001", "c999"]),
+        ("expected_llm_fingerprint", "llm-other"),
+    ],
+)
+def test_read_realization_batch_artifact_reports_drift_for_header_mismatch(
+    tmp_path: Path,
+    override_key: str,
+    override_value: object,
+) -> None:
+    """A mismatch on any validated header field is reported as drift, not reused."""
+    path = tmp_path / "batch_0000.json"
+    _write_valid(path)
+
+    expected = {**_EXPECTED, override_key: override_value}
+    artifact, drifted = read_realization_batch_artifact(path=path, **expected)
+
+    assert artifact is None
+    assert override_key.removeprefix("expected_") in {field.field for field in drifted}
+
+
+def test_read_realization_batch_artifact_reports_drift_for_pragmata_version_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A checkpoint written by a different pragmata version is reported as drift."""
+    path = tmp_path / "batch_0000.json"
+    _write_valid(path)
+
+    real_version = importlib.metadata.version
+
+    def fake_version(name: str) -> str:
+        if name == "pragmata":
+            return "0.0.0-other"
+        return real_version(name)
+
+    monkeypatch.setattr("pragmata.core.querygen.checkpoint_read.importlib.metadata.version", fake_version)
+    artifact, drifted = read_realization_batch_artifact(path=path, **_EXPECTED)
+
+    assert artifact is None
+    assert "pragmata_version" in {field.field for field in drifted}
+
+
+def test_read_realization_batch_artifact_raises_for_malformed_json(tmp_path: Path) -> None:
+    """Malformed file content raises a JSON decode error."""
+    path = tmp_path / "batch_0000.json"
+    path.write_text("{not json", encoding="utf-8")
+
+    with pytest.raises(json.JSONDecodeError):
+        read_realization_batch_artifact(path=path, **_EXPECTED)
+
+
+def test_realization_batch_artifact_rejects_candidate_query_length_mismatch() -> None:
+    """The schema enforces a 1:1 candidate_ids/queries mapping."""
+    with pytest.raises(ValidationError):
+        assemble_realization_batch_artifact(
+            spec_fingerprint="fp-1",
+            llm_fingerprint="llm-fp-1",
+            source_run_id="run-1",
+            n_queries=10,
+            batch_size=5,
+            batch_idx=0,
+            candidate_ids=["c001", "c002"],
+            queries=[_realized("c001")],
+        )


### PR DESCRIPTION
**Stack (6 open PRs):** #236 → #237 → #238 → #239 → #240 → #241 → #242 

**Chain goal:** Add per-batch checkpoint/resume to querygen so a re-run with the same `run_id` skips already-completed work. Nests resumable state under `<run_dir>/checkpoints/`, writes a frozen Stage 1 result (planning + dedup) plus per-batch Stage 1 and Stage 2 artifacts, and orchestrates resume behind a fail-fast config-drift gate (`--force` overrides) so checkpoints are never silently reused under changed settings.

**This PR (5/6):** Third and final vertical artifact slice. Adds per-batch checkpointing for Stage 2 realization. Stage 2 batches are independent (no chained state), so each batch resumes on its own merits — the `candidate_ids` header field binds each checkpoint to its exact frozen-result chunk.

---

## What
- `RealizationBatchArtifact` schema with `extra="forbid"` + `1:1 candidate_ids/queries` model_validator.
- `assemble_realization_batch_artifact` + `export_realization_batch_artifact` (atomic).
- `read_realization_batch_artifact` — thin typed wrapper over the #239 engine.

## Why
Stage 2 has no chained state between batches, so each realization batch is checkpointed independently — a rerun replays only the batches that didn't complete. Binding the checkpoint to its `candidate_ids` chunk means a re-chunked frozen result can't silently reuse a stale realization.

## Test plan
- [x] `tests/unit/core/querygen/test_realization_batches.py` — round-trip, header-mismatch per field, version-mismatch, malformed JSON, length-validator.
