### PR TITLE
feat(querygen): orchestrate checkpoint resume with drift gate

### DIFF
--- a/src/pragmata/api/querygen.py
+++ b/src/pragmata/api/querygen.py
@@ -1,27 +1,48 @@
 """API orchestration for the synthetic query generation workflow."""
 
+import json
 import logging
+from collections.abc import Callable
 from itertools import islice
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar
 
-from pydantic import BaseModel, ConfigDict, PositiveInt
+from pydantic import BaseModel, ConfigDict, PositiveInt, ValidationError
 
 from pragmata.api._error_log import error_log
 from pragmata.core.paths.paths import WorkspacePaths
 from pragmata.core.paths.querygen_paths import QueryGenRunPaths, resolve_querygen_paths
-from pragmata.core.querygen.assembly import assemble_planning_summary, assemble_queries_meta, assemble_query_rows
+from pragmata.core.querygen.assembly import (
+    assemble_planning_batch_artifact,
+    assemble_planning_summary,
+    assemble_queries_meta,
+    assemble_query_rows,
+    assemble_realization_batch_artifact,
+    assemble_selected_blueprints_artifact,
+)
 from pragmata.core.querygen.batching import build_candidate_ids, chunk_blueprints, iter_batch_sizes
-from pragmata.core.querygen.deduplication import deduplicate_blueprints
-from pragmata.core.querygen.export import export_planning_summary, export_queries
+from pragmata.core.querygen.checkpoint_read import DriftedField, QueryGenDriftError
+from pragmata.core.querygen.deduplication import EMBEDDING_MODEL_CHECKPOINT, deduplicate_blueprints
+from pragmata.core.querygen.export import (
+    export_planning_batch_artifact,
+    export_planning_summary,
+    export_queries,
+    export_realization_batch_artifact,
+    export_selected_blueprints,
+)
 from pragmata.core.querygen.filtering import filter_aligned_candidate_ids
 from pragmata.core.querygen.planning import run_planning_stage
+from pragmata.core.querygen.planning_batches import read_planning_batch_artifact
 from pragmata.core.querygen.planning_summary import (
+    fingerprint_planning_llm_settings,
     fingerprint_querygen_spec,
+    fingerprint_realization_llm_settings,
     read_planning_summary_artifact,
     run_planning_summary,
 )
 from pragmata.core.querygen.realization import run_realization_stage
+from pragmata.core.querygen.realization_batches import read_realization_batch_artifact
+from pragmata.core.querygen.selected_blueprints import read_selected_blueprints_artifact
 from pragmata.core.schemas.querygen_plan import QueryBlueprint
 from pragmata.core.schemas.querygen_realize import RealizedQuery
 from pragmata.core.schemas.querygen_summary import PlanningSummaryState
@@ -43,6 +64,284 @@ class QueryGenRunResult(BaseModel):
 
     settings: QueryGenRunSettings
     paths: QueryGenRunPaths
+
+
+def _shorten(value: object) -> str:
+    """Render a drift value compactly, truncating long strings such as fingerprints.
+
+    Short values (settings like n_queries/tolerance) print in full; 64-char hex
+    fingerprints are clipped to a scannable prefix so the message stays readable.
+    """
+    text = str(value)
+    return f"{text[:12]}..." if len(text) > 16 else text
+
+
+def _drift_message(*, run_id: str, checkpoint_path: Path, drifted: list[DriftedField]) -> str:
+    """Build the fail-fast message naming each drifted field as stored -> current."""
+    changes = "\n".join(
+        f"  - {field.field}: {_shorten(field.stored)} -> {_shorten(field.expected)}" for field in drifted
+    )
+    return (
+        f"Run {run_id} cannot resume: checkpoint {checkpoint_path.name} was produced with "
+        f"different settings.\nChanged (stored -> current):\n{changes}\n"
+        f"Re-run with --force to resume and recompute what changed, delete the run directory "
+        f"to rebuild from scratch, or use a new --run-id to start a separate run."
+    )
+
+
+_CheckpointT = TypeVar("_CheckpointT")
+
+
+def _read_reusable_checkpoint(
+    read: Callable[[], tuple[_CheckpointT | None, list[DriftedField]]],
+    *,
+    run_id: str,
+    checkpoint_path: Path,
+    force: bool,
+) -> _CheckpointT | None:
+    """Return a checkpoint only if it is reusable, else ``None`` (caller recomputes).
+
+    The single gate every checkpoint read goes through:
+
+    - damaged file (JSON/validation/UTF-8 error) -> self-heal: log and return
+      ``None`` so the caller recomputes;
+    - drifted checkpoint with ``force=False`` -> raise :class:`QueryGenDriftError`
+      (fail fast);
+    - drifted checkpoint with ``force=True`` -> log and return ``None`` to recompute;
+    - clean match -> return the artifact.
+
+    Args:
+        read: Zero-arg call returning ``(artifact, drifted)`` from a typed reader.
+        run_id: Run identifier, for the drift message.
+        checkpoint_path: Checkpoint path, for the drift/damage message.
+        force: When True, recompute drifted checkpoints instead of failing fast.
+    """
+    try:
+        artifact, drifted = read()
+    except (json.JSONDecodeError, ValidationError, UnicodeDecodeError) as exc:
+        logger.warning("Checkpoint %s is damaged (%s); recomputing", checkpoint_path.name, exc)
+        return None
+    if drifted and not force:
+        raise QueryGenDriftError(_drift_message(run_id=run_id, checkpoint_path=checkpoint_path, drifted=drifted))
+    if drifted:
+        logger.warning(
+            "Checkpoint %s drifted (%s); recomputing under --force",
+            checkpoint_path.name,
+            ", ".join(field.field for field in drifted),
+        )
+    return artifact
+
+
+def _resume_or_run_planning_batch(
+    *,
+    paths: QueryGenRunPaths,
+    settings: QueryGenRunSettings,
+    spec_fingerprint: str,
+    llm_fingerprint: str,
+    api_key: str,
+    batch_idx: int,
+    total_batches: int,
+    batch_candidate_ids: list[str],
+    planning_summary_state: PlanningSummaryState | None,
+    resume_exhausted: bool,
+    force: bool,
+) -> tuple[list[QueryBlueprint], PlanningSummaryState | None, bool]:
+    """Resume one Stage 1 batch from a valid checkpoint, or run it fresh and persist.
+
+    Returns ``(batch_blueprints, planning_summary_state, resume_exhausted)``.
+    ``resume_exhausted`` sticks True once any batch is recomputed: the
+    planning-summary chain then diverges from what later checkpoints recorded,
+    so every subsequent batch must also run fresh. This also keeps resume to a
+    contiguous prefix, so a missing or drifted checkpoint never causes a later
+    batch's stale state to be threaded forward.
+
+    Args:
+        paths: Resolved run paths (provides ``planning_batches_dir``).
+        settings: Resolved run settings.
+        spec_fingerprint: Fingerprint of the resolved spec for this run.
+        llm_fingerprint: Fingerprint of the output-shaping LLM settings for this run.
+        api_key: Provider API key.
+        batch_idx: Zero-based index of this planning batch.
+        total_batches: Total number of planning batches (for logging).
+        batch_candidate_ids: Candidate IDs assigned to this batch.
+        planning_summary_state: Planning-summary state seeding this batch.
+        resume_exhausted: Whether an earlier batch already ran fresh this run.
+        force: When True, recompute a drifted checkpoint instead of failing fast.
+
+    Raises:
+        QueryGenDriftError: The checkpoint exists but its settings drifted and
+            ``force`` is False.
+    """
+    checkpoint_path = paths.planning_batches_dir / f"batch_{batch_idx:04d}.json"
+
+    if not resume_exhausted:
+        artifact = _read_reusable_checkpoint(
+            lambda: read_planning_batch_artifact(
+                path=checkpoint_path,
+                expected_spec_fingerprint=spec_fingerprint,
+                expected_source_run_id=settings.run_id,
+                expected_n_queries=settings.n_queries,
+                expected_batch_size=settings.batch_size,
+                expected_candidate_ids=batch_candidate_ids,
+                expected_enable_planning_memory=settings.enable_planning_memory,
+                expected_llm_fingerprint=llm_fingerprint,
+            ),
+            run_id=settings.run_id,
+            checkpoint_path=checkpoint_path,
+            force=force,
+        )
+        if artifact is not None:
+            logger.info(
+                "Stage 1 batch %d/%d resumed from checkpoint for run %s",
+                batch_idx + 1,
+                total_batches,
+                settings.run_id,
+            )
+            return artifact.blueprints, artifact.planning_summary_state, False
+
+    logger.info(
+        "Stage 1 batch %d/%d: planning %d candidates for run %s",
+        batch_idx + 1,
+        total_batches,
+        len(batch_candidate_ids),
+        settings.run_id,
+    )
+    batch_blueprints = run_planning_stage(
+        spec=settings.spec,
+        llm_settings=settings.llm,
+        api_key=api_key,
+        batch_candidate_ids=batch_candidate_ids,
+        planning_summary=planning_summary_state,
+    )
+
+    if settings.enable_planning_memory:
+        planning_summary_state = run_planning_summary(
+            spec=settings.spec,
+            candidates=batch_blueprints,
+            llm_settings=settings.llm,
+            api_key=api_key,
+            prior_summary_state=planning_summary_state,
+        )
+
+    export_planning_batch_artifact(
+        artifact=assemble_planning_batch_artifact(
+            spec_fingerprint=spec_fingerprint,
+            source_run_id=settings.run_id,
+            n_queries=settings.n_queries,
+            batch_size=settings.batch_size,
+            batch_idx=batch_idx,
+            candidate_ids=batch_candidate_ids,
+            blueprints=batch_blueprints,
+            planning_summary_state=planning_summary_state,
+            enable_planning_memory=settings.enable_planning_memory,
+            llm_fingerprint=llm_fingerprint,
+        ),
+        path=checkpoint_path,
+    )
+    logger.info(
+        "Stage 1 batch %d/%d complete for run %s (%d blueprints)",
+        batch_idx + 1,
+        total_batches,
+        settings.run_id,
+        len(batch_blueprints),
+    )
+    return batch_blueprints, planning_summary_state, True
+
+
+def _resume_or_run_realization_batch(
+    *,
+    paths: QueryGenRunPaths,
+    settings: QueryGenRunSettings,
+    spec_fingerprint: str,
+    llm_fingerprint: str,
+    api_key: str,
+    batch_idx: int,
+    total_batches: int,
+    blueprint_batch: list[QueryBlueprint],
+    force: bool,
+) -> list[RealizedQuery]:
+    """Resume one Stage 2 batch from a valid checkpoint, or run it fresh and persist.
+
+    Stage 2 batches are independent (no chained state), so each batch resumes on
+    its own merits -- a missing or drifted batch does not force later batches to
+    re-run. The ``candidate_ids`` check on read guarantees a checkpoint is only
+    reused for the exact blueprints in this chunk of the frozen result.
+
+    Args:
+        paths: Resolved run paths (provides ``realization_batches_dir``).
+        settings: Resolved run settings.
+        spec_fingerprint: Fingerprint of the resolved spec for this run.
+        llm_fingerprint: Fingerprint of the output-shaping LLM settings for this run.
+        api_key: Provider API key.
+        batch_idx: Zero-based index of this realization batch.
+        total_batches: Total number of realization batches (for logging).
+        blueprint_batch: Selected blueprints to realize in this batch.
+        force: When True, recompute a drifted checkpoint instead of failing fast.
+
+    Raises:
+        QueryGenDriftError: The checkpoint exists but its settings drifted and
+            ``force`` is False.
+    """
+    checkpoint_path = paths.realization_batches_dir / f"batch_{batch_idx:04d}.json"
+    batch_candidate_ids = [blueprint.candidate_id for blueprint in blueprint_batch]
+
+    artifact = _read_reusable_checkpoint(
+        lambda: read_realization_batch_artifact(
+            path=checkpoint_path,
+            expected_spec_fingerprint=spec_fingerprint,
+            expected_source_run_id=settings.run_id,
+            expected_n_queries=settings.n_queries,
+            expected_batch_size=settings.batch_size,
+            expected_candidate_ids=batch_candidate_ids,
+            expected_llm_fingerprint=llm_fingerprint,
+        ),
+        run_id=settings.run_id,
+        checkpoint_path=checkpoint_path,
+        force=force,
+    )
+    if artifact is not None:
+        logger.info(
+            "Stage 2 batch %d/%d resumed from checkpoint for run %s",
+            batch_idx + 1,
+            total_batches,
+            settings.run_id,
+        )
+        return artifact.queries
+
+    logger.info(
+        "Stage 2 batch %d/%d: realizing %d candidates for run %s",
+        batch_idx + 1,
+        total_batches,
+        len(blueprint_batch),
+        settings.run_id,
+    )
+    realized_queries = run_realization_stage(
+        candidates=blueprint_batch,
+        llm_settings=settings.llm,
+        api_key=api_key,
+    )
+
+    export_realization_batch_artifact(
+        artifact=assemble_realization_batch_artifact(
+            spec_fingerprint=spec_fingerprint,
+            source_run_id=settings.run_id,
+            n_queries=settings.n_queries,
+            batch_size=settings.batch_size,
+            batch_idx=batch_idx,
+            candidate_ids=batch_candidate_ids,
+            queries=realized_queries,
+            llm_fingerprint=llm_fingerprint,
+        ),
+        path=checkpoint_path,
+    )
+    logger.info(
+        "Stage 2 batch %d/%d complete for run %s (%d realized)",
+        batch_idx + 1,
+        total_batches,
+        settings.run_id,
+        len(realized_queries),
+    )
+    return realized_queries
 
 
 def gen_queries(
@@ -72,6 +371,7 @@ def gen_queries(
     batch_size: PositiveInt | Unset = UNSET,
     near_duplicate_tolerance: float | Unset = UNSET,
     enable_planning_memory: bool | Unset = UNSET,
+    force: bool = False,
 ) -> QueryGenRunResult:
     """Generate synthetic chatbot queries from a query-generation specification.
 
@@ -113,6 +413,11 @@ def gen_queries(
             Defaults to True. When enabled, an additional LLM updates and persists a
             compact summary of prior blueprint generation across batches and compatible
             runs to reduce redundant or near-duplicate queries and improve diversity.
+        force: When True, resume past configuration drift by recomputing whatever
+            changed (reusing the rest). Defaults to False, i.e. fail fast with a
+            ``QueryGenDriftError`` naming the drifted fields if an existing
+            checkpoint was produced under different settings. To rebuild from
+            scratch, delete the run directory and re-run.
         run_id: Explicit run identifier. Defaults to an auto-generated UUID
             hex string.
         model_provider: Chat model provider to use. Defaults to "mistralai".
@@ -186,10 +491,16 @@ def gen_queries(
 
     api_key = resolve_api_key(settings.llm.model_provider)
 
+    spec_fingerprint = fingerprint_querygen_spec(settings.spec)
+    # Per-stage LLM fingerprints: a planning-model change re-runs Stage 1, while
+    # a realization-model change re-runs only Stage 2 (the frozen result and
+    # planning checkpoints stay valid).
+    planning_llm_fingerprint = fingerprint_planning_llm_settings(settings.llm)
+    realization_llm_fingerprint = fingerprint_realization_llm_settings(settings.llm)
     paths = resolve_querygen_paths(
         workspace=WorkspacePaths.from_base_dir(settings.base_dir),
         run_id=settings.run_id,
-        spec_fingerprint=fingerprint_querygen_spec(settings.spec),
+        spec_fingerprint=spec_fingerprint,
     ).ensure_dirs()
 
     logger.info(
@@ -203,70 +514,155 @@ def gen_queries(
         planning_summary_state: PlanningSummaryState | None = None
 
         if settings.enable_planning_memory:
-            planning_summary_artifact = read_planning_summary_artifact(
-                artifact_path=paths.planning_summary_artifact_json,
-                spec=settings.spec,
-            )
+            try:
+                planning_summary_artifact = read_planning_summary_artifact(
+                    artifact_path=paths.planning_summary_artifact_json,
+                    spec=settings.spec,
+                )
+            except (json.JSONDecodeError, ValidationError, UnicodeDecodeError) as exc:
+                logger.warning(
+                    "Cross-run planning summary %s is unreadable (%s); ignoring it",
+                    paths.planning_summary_artifact_json,
+                    exc,
+                )
+                planning_summary_artifact = None
             if planning_summary_artifact is not None:
                 planning_summary_state = planning_summary_artifact.state
 
-        # Stage 1: planning
-        candidate_ids = build_candidate_ids(settings.n_queries)
-        candidate_id_iter = iter(candidate_ids)
-        planning_outputs: list[QueryBlueprint] = []
+        # Stage 1: planning. Resume from the frozen result if present (skips the
+        # planning loop, deduplication, and embedding-model load); otherwise run
+        # the per-batch loop, deduplicate, persist cross-run memory, and freeze
+        # the result.
+        frozen_result = _read_reusable_checkpoint(
+            lambda: read_selected_blueprints_artifact(
+                path=paths.selected_blueprints_json,
+                expected_spec_fingerprint=spec_fingerprint,
+                expected_source_run_id=settings.run_id,
+                expected_n_queries=settings.n_queries,
+                expected_batch_size=settings.batch_size,
+                expected_near_duplicate_tolerance=settings.near_duplicate_tolerance,
+                expected_enable_planning_memory=settings.enable_planning_memory,
+                expected_llm_fingerprint=planning_llm_fingerprint,
+            ),
+            run_id=settings.run_id,
+            checkpoint_path=paths.selected_blueprints_json,
+            force=force,
+        )
 
-        for current_batch_size in iter_batch_sizes(
-            n_queries=settings.n_queries,
-            batch_size=settings.batch_size,
-        ):
-            batch_candidate_ids = list(islice(candidate_id_iter, current_batch_size))
-            batch_blueprints = run_planning_stage(
-                spec=settings.spec,
-                llm_settings=settings.llm,
-                api_key=api_key,
-                batch_candidate_ids=batch_candidate_ids,
-                planning_summary=planning_summary_state,
+        if frozen_result is not None:
+            selected_blueprints = frozen_result.blueprints
+            logger.info(
+                "Stage 1 result loaded from frozen artifact for run %s (%d selected); "
+                "skipping planning and deduplication",
+                settings.run_id,
+                len(selected_blueprints),
             )
-            planning_outputs.extend(batch_blueprints)
+        else:
+            candidate_ids = build_candidate_ids(settings.n_queries)
+            candidate_id_iter = iter(candidate_ids)
+            batch_candidate_id_lists = [
+                list(islice(candidate_id_iter, current_batch_size))
+                for current_batch_size in iter_batch_sizes(
+                    n_queries=settings.n_queries,
+                    batch_size=settings.batch_size,
+                )
+            ]
+            total_batches = len(batch_candidate_id_lists)
 
-            if settings.enable_planning_memory:
-                planning_summary_state = run_planning_summary(
-                    spec=settings.spec,
-                    candidates=batch_blueprints,
-                    llm_settings=settings.llm,
+            planning_outputs: list[QueryBlueprint] = []
+            resume_exhausted = False
+            for batch_idx, batch_candidate_ids in enumerate(batch_candidate_id_lists):
+                batch_blueprints, planning_summary_state, resume_exhausted = _resume_or_run_planning_batch(
+                    paths=paths,
+                    settings=settings,
+                    spec_fingerprint=spec_fingerprint,
+                    llm_fingerprint=planning_llm_fingerprint,
                     api_key=api_key,
-                    prior_summary_state=planning_summary_state,
+                    batch_idx=batch_idx,
+                    total_batches=total_batches,
+                    batch_candidate_ids=batch_candidate_ids,
+                    planning_summary_state=planning_summary_state,
+                    resume_exhausted=resume_exhausted,
+                    force=force,
+                )
+                planning_outputs.extend(batch_blueprints)
+
+            filtered_planning_outputs = filter_aligned_candidate_ids(
+                items=planning_outputs,
+                expected_candidate_ids=candidate_ids,
+            )
+
+            selected_blueprints = deduplicate_blueprints(
+                filtered_planning_outputs,
+                near_duplicate_tolerance=settings.near_duplicate_tolerance,
+            )
+
+            logger.info(
+                "Stage 1 (query planning) complete for run %s (%d planned -> %d selected)",
+                settings.run_id,
+                len(planning_outputs),
+                len(selected_blueprints),
+            )
+
+            # Persist cross-run planning memory now (end of Stage 1) so a later
+            # Stage 2 crash still leaves it available to seed future runs.
+            if settings.enable_planning_memory and planning_summary_state is not None:
+                export_planning_summary(
+                    artifact=assemble_planning_summary(
+                        spec=settings.spec,
+                        run_id=settings.run_id,
+                        state=planning_summary_state,
+                    ),
+                    artifact_path=paths.planning_summary_artifact_json,
                 )
 
-        filtered_planning_outputs = filter_aligned_candidate_ids(
-            items=planning_outputs,
-            expected_candidate_ids=candidate_ids,
-        )
+            # A freshly recomputed Stage 1 result supersedes any Stage 2
+            # checkpoints bound to a prior result (only reachable if the old
+            # frozen result was lost/invalid); discard them before realization.
+            for stale_checkpoint in paths.realization_batches_dir.glob("batch_*.json"):
+                stale_checkpoint.unlink()
 
-        selected_blueprints = deduplicate_blueprints(
-            filtered_planning_outputs,
-            near_duplicate_tolerance=settings.near_duplicate_tolerance,
-        )
+            # Freeze the Stage 1 result last: its presence is the "Stage 1 done"
+            # marker that lets a rerun skip everything above.
+            export_selected_blueprints(
+                artifact=assemble_selected_blueprints_artifact(
+                    spec_fingerprint=spec_fingerprint,
+                    llm_fingerprint=planning_llm_fingerprint,
+                    source_run_id=settings.run_id,
+                    n_queries=settings.n_queries,
+                    batch_size=settings.batch_size,
+                    near_duplicate_tolerance=settings.near_duplicate_tolerance,
+                    enable_planning_memory=settings.enable_planning_memory,
+                    embedding_model=EMBEDDING_MODEL_CHECKPOINT,
+                    blueprints=selected_blueprints,
+                ),
+                path=paths.selected_blueprints_json,
+            )
 
-        logger.info(
-            "Stage 1 (query planning) complete for run %s (%d planned -> %d selected)",
-            settings.run_id,
-            len(planning_outputs),
-            len(selected_blueprints),
+        # Stage 2: realization (with per-batch checkpointing). Batches are
+        # independent, so each resumes on its own; the final CSV is a
+        # deterministic projection of the frozen result + these outputs.
+        realization_batches = list(
+            chunk_blueprints(
+                blueprints=selected_blueprints,
+                chunk_size=settings.batch_size,
+            )
         )
+        total_realization_batches = len(realization_batches)
 
-        # Stage 2: realization
         realization_outputs: list[RealizedQuery] = []
-
-        for blueprint_batch in chunk_blueprints(
-            blueprints=selected_blueprints,
-            chunk_size=settings.batch_size,
-        ):
+        for batch_idx, blueprint_batch in enumerate(realization_batches):
             realization_outputs.extend(
-                run_realization_stage(
-                    candidates=blueprint_batch,
-                    llm_settings=settings.llm,
+                _resume_or_run_realization_batch(
+                    paths=paths,
+                    settings=settings,
+                    spec_fingerprint=spec_fingerprint,
+                    llm_fingerprint=realization_llm_fingerprint,
                     api_key=api_key,
+                    batch_idx=batch_idx,
+                    total_batches=total_realization_batches,
+                    blueprint_batch=blueprint_batch,
+                    force=force,
                 )
             )
 
@@ -281,6 +677,18 @@ def gen_queries(
             len(realization_outputs),
             len(filtered_realization_outputs),
         )
+
+        # The final CSV is a positional projection of the realized set. Warn (do
+        # not fail -- short results are tolerated) if realization is incomplete,
+        # since then row count and query_ids differ from the frozen blueprint set.
+        if len(filtered_realization_outputs) < len(selected_blueprints):
+            logger.warning(
+                "Stage 2 for run %s realized %d of %d selected blueprints; the CSV "
+                "reflects only realized queries and positional query_ids may shift",
+                settings.run_id,
+                len(filtered_realization_outputs),
+                len(selected_blueprints),
+            )
 
         # Assembly and export:
         rows = assemble_query_rows(
@@ -304,17 +712,6 @@ def gen_queries(
             queries_path=paths.synthetic_queries_csv,
             meta_path=paths.synthetic_queries_meta_json,
         )
-
-        if settings.enable_planning_memory and planning_summary_state is not None:
-            planning_summary_artifact = assemble_planning_summary(
-                spec=settings.spec,
-                run_id=settings.run_id,
-                state=planning_summary_state,
-            )
-            export_planning_summary(
-                artifact=planning_summary_artifact,
-                artifact_path=paths.planning_summary_artifact_json,
-            )
 
     logger.info(
         "Query generation run %s complete (%d returned queries)",

--- a/src/pragmata/cli/commands/querygen.py
+++ b/src/pragmata/cli/commands/querygen.py
@@ -70,29 +70,39 @@ def gen_queries_command(
         "--realization-model-kwargs",
         help="Additional realization-stage model keyword arguments. Accepts a JSON object.",
     ),
+    force: bool = typer.Option(
+        False,
+        "--force/--no-force",
+        help="Resume past config drift, recomputing whatever changed (default fails fast on drift).",
+    ),
 ) -> None:
     """Prepare a synthetic query generation run."""
-    result = querygen.gen_queries(
-        domains=parse_cli_value(domains),
-        roles=parse_cli_value(roles),
-        languages=parse_cli_value(languages),
-        topics=parse_cli_value(topics),
-        intents=parse_cli_value(intents),
-        tasks=parse_cli_value(tasks),
-        disallowed_topics=parse_cli_value(disallowed_topics),
-        difficulty=parse_cli_value(difficulty),
-        formats=parse_cli_value(formats),
-        base_dir=UNSET if base_dir is None else base_dir,
-        config_path=UNSET if config_path is None else config_path,
-        n_queries=UNSET if n_queries is None else n_queries,
-        run_id=UNSET if run_id is None else run_id,
-        model_provider=UNSET if model_provider is None else model_provider,
-        planning_model=UNSET if planning_model is None else planning_model,
-        realization_model=UNSET if realization_model is None else realization_model,
-        base_url=UNSET if base_url is None else base_url,
-        planning_model_kwargs=parse_cli_value(planning_model_kwargs),
-        realization_model_kwargs=parse_cli_value(realization_model_kwargs),
-    )
+    try:
+        result = querygen.gen_queries(
+            domains=parse_cli_value(domains),
+            roles=parse_cli_value(roles),
+            languages=parse_cli_value(languages),
+            topics=parse_cli_value(topics),
+            intents=parse_cli_value(intents),
+            tasks=parse_cli_value(tasks),
+            disallowed_topics=parse_cli_value(disallowed_topics),
+            difficulty=parse_cli_value(difficulty),
+            formats=parse_cli_value(formats),
+            base_dir=UNSET if base_dir is None else base_dir,
+            config_path=UNSET if config_path is None else config_path,
+            n_queries=UNSET if n_queries is None else n_queries,
+            run_id=UNSET if run_id is None else run_id,
+            model_provider=UNSET if model_provider is None else model_provider,
+            planning_model=UNSET if planning_model is None else planning_model,
+            realization_model=UNSET if realization_model is None else realization_model,
+            base_url=UNSET if base_url is None else base_url,
+            planning_model_kwargs=parse_cli_value(planning_model_kwargs),
+            realization_model_kwargs=parse_cli_value(realization_model_kwargs),
+            force=force,
+        )
+    except querygen.QueryGenDriftError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1) from exc
 
     typer.echo("Synthetic query generation run prepared.")
     typer.echo(f"run_id: {result.settings.run_id}")

--- a/src/pragmata/core/querygen/checkpoint_read.py
+++ b/src/pragmata/core/querygen/checkpoint_read.py
@@ -26,6 +26,16 @@ class DriftedField:
     expected: object
 
 
+class QueryGenDriftError(RuntimeError):
+    """Raised when a checkpoint was produced under settings that differ from the current run.
+
+    The run halts instead of silently reusing or recomputing the drifted work.
+    Resolve by re-running with ``force=True`` (CLI ``--force``) to resume and
+    recompute whatever changed, deleting the run directory to rebuild from
+    scratch, or a new ``run_id`` to start a separate run and keep this one.
+    """
+
+
 def read_checkpoint_artifact(
     *,
     path: Path,

--- a/src/pragmata/querygen/__init__.py
+++ b/src/pragmata/querygen/__init__.py
@@ -2,5 +2,6 @@
 
 from pragmata.api.querygen import QueryGenRunResult as QueryGenRunResult
 from pragmata.api.querygen import gen_queries as gen_queries
+from pragmata.core.querygen.checkpoint_read import QueryGenDriftError as QueryGenDriftError
 
-__all__ = ["gen_queries", "QueryGenRunResult"]
+__all__ = ["gen_queries", "QueryGenRunResult", "QueryGenDriftError"]

--- a/tests/unit/api/test_querygen.py
+++ b/tests/unit/api/test_querygen.py
@@ -394,6 +394,7 @@ def test_gen_queries_fingerprints_spec_before_resolving_paths(
 
         tool_root = tmp_path.resolve() / "querygen"
         run_dir = tool_root / "runs" / run_id
+        checkpoints_dir = run_dir / "checkpoints"
 
         return QueryGenRunPaths(
             tool_root=tool_root,
@@ -401,6 +402,10 @@ def test_gen_queries_fingerprints_spec_before_resolving_paths(
             synthetic_queries_csv=run_dir / "synthetic_queries.csv",
             synthetic_queries_meta_json=run_dir / "synthetic_queries.meta.json",
             planning_summary_artifact_json=tool_root / f"{spec_fingerprint}.json",
+            checkpoints_dir=checkpoints_dir,
+            planning_batches_dir=checkpoints_dir / "planning_batches",
+            selected_blueprints_json=checkpoints_dir / "selected_blueprints.json",
+            realization_batches_dir=checkpoints_dir / "realization_batches",
         )
 
     monkeypatch.setattr(querygen_api, "fingerprint_querygen_spec", fingerprint_querygen_spec)
@@ -1193,7 +1198,11 @@ def test_gen_queries_propagates_realization_failure_and_stops_downstream_work(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Realization failures propagate and prevent assembly and export."""
+    """Realization failures propagate and prevent query assembly and export.
+
+    The cross-run planning summary is persisted at the end of Stage 1 (before
+    realization), so it is intentionally NOT prevented by a Stage 2 failure.
+    """
     monkeypatch.setattr(
         querygen_api,
         "run_realization_stage",
@@ -1209,17 +1218,251 @@ def test_gen_queries_propagates_realization_failure_and_stops_downstream_work(
         "export_queries",
         lambda **kwargs: pytest.fail("export_queries must not run after realization failure"),
     )
-    monkeypatch.setattr(
-        querygen_api,
-        "export_planning_summary",
-        lambda **kwargs: pytest.fail("export_planning_summary must not run after realization failure"),
-    )
 
     with pytest.raises(RuntimeError, match="realization failed"):
         querygen_api.gen_queries(
             **_required_querygen_kwargs(tmp_path),
             run_id="realization-failure-check",
         )
+
+
+def test_gen_queries_writes_stage1_checkpoints_and_frozen_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A fresh run persists one checkpoint per Stage 1 batch and the frozen result."""
+    monkeypatch.setattr(querygen_api, "iter_batch_sizes", lambda n_queries, batch_size: iter([2, 1]))
+
+    result = querygen_api.gen_queries(
+        **_required_querygen_kwargs(tmp_path),
+        n_queries=3,
+        batch_size=2,
+        run_id="checkpoint-write",
+    )
+
+    assert (result.paths.planning_batches_dir / "batch_0000.json").exists()
+    assert (result.paths.planning_batches_dir / "batch_0001.json").exists()
+    assert result.paths.selected_blueprints_json.exists()
+
+
+def test_gen_queries_rerun_loads_frozen_result_and_skips_stage1(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A rerun with a valid frozen result skips the planning loop and deduplication."""
+    monkeypatch.setattr(querygen_api, "iter_batch_sizes", lambda n_queries, batch_size: iter([2, 1]))
+    kwargs = {
+        **_required_querygen_kwargs(tmp_path),
+        "n_queries": 3,
+        "batch_size": 2,
+        "run_id": "frozen-skip",
+    }
+
+    querygen_api.gen_queries(**kwargs)
+
+    planning_calls: list[list[str]] = []
+    dedup_calls: list[object] = []
+
+    def spy_planning(
+        *,
+        spec,  # noqa: ANN001
+        llm_settings,  # noqa: ANN001
+        api_key: str,
+        batch_candidate_ids: list[str],
+        planning_summary=None,  # noqa: ANN001
+    ) -> list[QueryBlueprint]:
+        planning_calls.append(batch_candidate_ids)
+        return [_make_blueprint(candidate_id) for candidate_id in batch_candidate_ids]
+
+    def spy_dedup(candidates, near_duplicate_tolerance=0.95):  # noqa: ANN001, ANN201
+        dedup_calls.append(candidates)
+        return candidates
+
+    monkeypatch.setattr(querygen_api, "run_planning_stage", spy_planning)
+    monkeypatch.setattr(querygen_api, "deduplicate_blueprints", spy_dedup)
+
+    querygen_api.gen_queries(**kwargs)
+
+    assert planning_calls == []
+    assert dedup_calls == []
+
+
+def test_gen_queries_resumes_stage1_from_checkpoint_after_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A batch that completed before a failure is resumed; only the rest re-runs."""
+    monkeypatch.setattr(querygen_api, "iter_batch_sizes", lambda n_queries, batch_size: iter([2, 1]))
+    kwargs = {
+        **_required_querygen_kwargs(tmp_path),
+        "n_queries": 3,
+        "batch_size": 2,
+        "run_id": "stage1-resume",
+    }
+
+    def failing_planning(
+        *,
+        spec,  # noqa: ANN001
+        llm_settings,  # noqa: ANN001
+        api_key: str,
+        batch_candidate_ids: list[str],
+        planning_summary=None,  # noqa: ANN001
+    ) -> list[QueryBlueprint]:
+        if "c003" in batch_candidate_ids:
+            raise RuntimeError("planning boom")
+        return [_make_blueprint(candidate_id) for candidate_id in batch_candidate_ids]
+
+    monkeypatch.setattr(querygen_api, "run_planning_stage", failing_planning)
+    with pytest.raises(RuntimeError, match="planning boom"):
+        querygen_api.gen_queries(**kwargs)
+
+    second_run_batches: list[list[str]] = []
+
+    def ok_planning(
+        *,
+        spec,  # noqa: ANN001
+        llm_settings,  # noqa: ANN001
+        api_key: str,
+        batch_candidate_ids: list[str],
+        planning_summary=None,  # noqa: ANN001
+    ) -> list[QueryBlueprint]:
+        second_run_batches.append(batch_candidate_ids)
+        return [_make_blueprint(candidate_id) for candidate_id in batch_candidate_ids]
+
+    monkeypatch.setattr(querygen_api, "run_planning_stage", ok_planning)
+    querygen_api.gen_queries(**kwargs)
+
+    # Batch 0 (c001, c002) resumed from its checkpoint; only batch 1 (c003) re-ran.
+    assert second_run_batches == [["c003"]]
+
+
+def test_gen_queries_persists_cross_run_summary_before_realization(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The cross-run planning summary is written at end of Stage 1, surviving a Stage 2 failure."""
+    summary_exports: list[dict[str, object]] = []
+
+    monkeypatch.setattr(
+        querygen_api,
+        "export_planning_summary",
+        lambda **kwargs: summary_exports.append(kwargs),
+    )
+    monkeypatch.setattr(
+        querygen_api,
+        "run_realization_stage",
+        lambda **kwargs: (_ for _ in ()).throw(RuntimeError("stage2 boom")),
+    )
+
+    with pytest.raises(RuntimeError, match="stage2 boom"):
+        querygen_api.gen_queries(
+            **_required_querygen_kwargs(tmp_path),
+            run_id="summary-before-stage2",
+        )
+
+    assert len(summary_exports) == 1
+
+
+def test_gen_queries_writes_stage2_checkpoints(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A fresh run persists one checkpoint per Stage 2 realization batch."""
+    monkeypatch.setattr(
+        querygen_api,
+        "chunk_blueprints",
+        lambda *, blueprints, chunk_size: iter([[blueprint] for blueprint in blueprints]),
+    )
+
+    result = querygen_api.gen_queries(
+        **_required_querygen_kwargs(tmp_path),
+        n_queries=2,
+        run_id="stage2-write",
+    )
+
+    assert (result.paths.realization_batches_dir / "batch_0000.json").exists()
+    assert (result.paths.realization_batches_dir / "batch_0001.json").exists()
+
+
+def test_gen_queries_resumes_stage2_from_checkpoint_after_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A realized batch is resumed after a failure; only the rest re-runs."""
+    monkeypatch.setattr(
+        querygen_api,
+        "chunk_blueprints",
+        lambda *, blueprints, chunk_size: iter([[blueprint] for blueprint in blueprints]),
+    )
+    kwargs = {
+        **_required_querygen_kwargs(tmp_path),
+        "n_queries": 2,
+        "run_id": "stage2-resume",
+    }
+
+    def failing_realization(
+        *,
+        candidates: list[QueryBlueprint],
+        llm_settings,  # noqa: ANN001
+        api_key: str,
+    ) -> list[RealizedQuery]:
+        if any(candidate.candidate_id == "c002" for candidate in candidates):
+            raise RuntimeError("realize boom")
+        return [_make_realized_query(candidate.candidate_id) for candidate in candidates]
+
+    monkeypatch.setattr(querygen_api, "run_realization_stage", failing_realization)
+    with pytest.raises(RuntimeError, match="realize boom"):
+        querygen_api.gen_queries(**kwargs)
+
+    second_run_batches: list[list[str]] = []
+
+    def ok_realization(
+        *,
+        candidates: list[QueryBlueprint],
+        llm_settings,  # noqa: ANN001
+        api_key: str,
+    ) -> list[RealizedQuery]:
+        second_run_batches.append([candidate.candidate_id for candidate in candidates])
+        return [_make_realized_query(candidate.candidate_id) for candidate in candidates]
+
+    monkeypatch.setattr(querygen_api, "run_realization_stage", ok_realization)
+    querygen_api.gen_queries(**kwargs)
+
+    # Stage 1 frozen result reused; only the unrealized batch (c002) re-ran.
+    assert second_run_batches == [["c002"]]
+
+
+def test_gen_queries_csv_projection_stable_across_partial_stage2_resume(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The projected CSV rows are identical whether Stage 2 ran fresh or partly resumed."""
+    from pragmata.core.querygen.assembly import assemble_query_rows as real_assemble_query_rows
+    from pragmata.core.querygen.filtering import filter_aligned_candidate_ids as real_filter
+
+    monkeypatch.setattr(
+        querygen_api,
+        "chunk_blueprints",
+        lambda *, blueprints, chunk_size: iter([[blueprint] for blueprint in blueprints]),
+    )
+    monkeypatch.setattr(querygen_api, "assemble_query_rows", real_assemble_query_rows)
+    monkeypatch.setattr(querygen_api, "filter_aligned_candidate_ids", real_filter)
+
+    captured_rows: list[list[SyntheticQueryRow]] = []
+    monkeypatch.setattr(querygen_api, "export_queries", lambda **kwargs: captured_rows.append(kwargs["rows"]))
+
+    kwargs = {
+        **_required_querygen_kwargs(tmp_path),
+        "n_queries": 3,
+        "run_id": "csv-projection",
+    }
+
+    result = querygen_api.gen_queries(**kwargs)
+    (result.paths.realization_batches_dir / "batch_0002.json").unlink()
+    querygen_api.gen_queries(**kwargs)
+
+    assert len(captured_rows) == 2
+    assert captured_rows[0] == captured_rows[1]
 
 
 def test_gen_queries_handles_empty_selected_blueprints_after_stage1(
@@ -1397,3 +1640,124 @@ def test_gen_queries_passes_near_duplicate_tolerance_to_deduplication(
         "candidate_ids": ["c001", "c002", "c003"],
         "near_duplicate_tolerance": 0.99,
     }
+
+
+def test_gen_queries_fails_fast_on_drift_without_force(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A completed run rerun with changed LLM settings fails fast, naming the drift."""
+    monkeypatch.setattr(
+        querygen_api,
+        "chunk_blueprints",
+        lambda *, blueprints, chunk_size: iter([[blueprint] for blueprint in blueprints]),
+    )
+    base = {**_required_querygen_kwargs(tmp_path), "n_queries": 2, "run_id": "drift-fail"}
+
+    querygen_api.gen_queries(**base, planning_model="planner-a")
+
+    with pytest.raises(querygen_api.QueryGenDriftError, match="llm_fingerprint"):
+        querygen_api.gen_queries(**base, planning_model="planner-b")
+
+
+def test_gen_queries_force_resumes_past_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With force=True a drifted run resumes, recomputing the drifted (planning) work."""
+    monkeypatch.setattr(
+        querygen_api,
+        "chunk_blueprints",
+        lambda *, blueprints, chunk_size: iter([[blueprint] for blueprint in blueprints]),
+    )
+    base = {**_required_querygen_kwargs(tmp_path), "n_queries": 2, "run_id": "drift-force"}
+
+    querygen_api.gen_queries(**base, planning_model="planner-a")
+
+    planning_calls: list[list[str]] = []
+
+    def spy_planning(*, batch_candidate_ids: list[str], **rest: object) -> list[QueryBlueprint]:
+        planning_calls.append(batch_candidate_ids)
+        return [_make_blueprint(candidate_id) for candidate_id in batch_candidate_ids]
+
+    monkeypatch.setattr(querygen_api, "run_planning_stage", spy_planning)
+
+    querygen_api.gen_queries(**base, planning_model="planner-b", force=True)
+
+    # llm_fingerprint is in the planning header, so a model change recomputes Stage 1.
+    assert planning_calls != []
+
+
+def test_gen_queries_force_tolerance_change_rededuplicates_but_reuses_planning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tolerance change under force re-deduplicates while reusing the planning batches."""
+    monkeypatch.setattr(querygen_api, "iter_batch_sizes", lambda n_queries, batch_size: iter([2, 1]))
+    base = {**_required_querygen_kwargs(tmp_path), "n_queries": 3, "batch_size": 2, "run_id": "tol-force"}
+
+    querygen_api.gen_queries(**base, near_duplicate_tolerance=0.95)
+
+    planning_calls: list[list[str]] = []
+    dedup_tolerances: list[float] = []
+
+    def spy_planning(*, batch_candidate_ids: list[str], **rest: object) -> list[QueryBlueprint]:
+        planning_calls.append(batch_candidate_ids)
+        return [_make_blueprint(candidate_id) for candidate_id in batch_candidate_ids]
+
+    def spy_dedup(
+        candidates: list[QueryBlueprint],
+        near_duplicate_tolerance: float = 0.95,
+    ) -> list[QueryBlueprint]:
+        dedup_tolerances.append(near_duplicate_tolerance)
+        return candidates
+
+    monkeypatch.setattr(querygen_api, "run_planning_stage", spy_planning)
+    monkeypatch.setattr(querygen_api, "deduplicate_blueprints", spy_dedup)
+
+    querygen_api.gen_queries(**base, near_duplicate_tolerance=0.80, force=True)
+
+    # Tolerance is not in the planning-batch header, so planning is reused...
+    assert planning_calls == []
+    # ...but the frozen result drifts, so dedup re-runs at the new tolerance.
+    assert dedup_tolerances == [0.80]
+
+
+def test_gen_queries_self_heals_corrupt_frozen_result(
+    tmp_path: Path,
+) -> None:
+    """A damaged frozen result is silently recomputed (self-heal), no force needed."""
+    import json
+
+    base = {**_required_querygen_kwargs(tmp_path), "n_queries": 2, "run_id": "self-heal"}
+
+    result = querygen_api.gen_queries(**base)
+    result.paths.selected_blueprints_json.write_text("{ corrupt", encoding="utf-8")
+
+    # No force and no error: corruption self-heals by recomputing Stage 1.
+    querygen_api.gen_queries(**base)
+
+    # The frozen result was rewritten and parses cleanly again.
+    json.loads(result.paths.selected_blueprints_json.read_text(encoding="utf-8"))
+
+
+def test_gen_queries_fails_fast_on_planning_batch_drift_without_force(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Drift is caught at a planning-batch checkpoint even before Stage 1 is frozen."""
+    monkeypatch.setattr(querygen_api, "iter_batch_sizes", lambda n_queries, batch_size: iter([2, 1]))
+    base = {**_required_querygen_kwargs(tmp_path), "n_queries": 3, "batch_size": 2, "run_id": "planning-drift"}
+
+    def failing_planning(*, batch_candidate_ids: list[str], **rest: object) -> list[QueryBlueprint]:
+        if "c003" in batch_candidate_ids:
+            raise RuntimeError("planning boom")
+        return [_make_blueprint(candidate_id) for candidate_id in batch_candidate_ids]
+
+    monkeypatch.setattr(querygen_api, "run_planning_stage", failing_planning)
+    with pytest.raises(RuntimeError, match="planning boom"):
+        querygen_api.gen_queries(**base, planning_model="planner-a")
+
+    # batch_0000 is on disk, no frozen result yet; a changed model is caught at that batch.
+    with pytest.raises(querygen_api.QueryGenDriftError, match="llm_fingerprint"):
+        querygen_api.gen_queries(**base, planning_model="planner-b")

--- a/tests/unit/cli/test_cli_querygen.py
+++ b/tests/unit/cli/test_cli_querygen.py
@@ -7,6 +7,7 @@ from typer.testing import CliRunner
 
 from pragmata.api import UNSET
 from pragmata.cli.app import app
+from pragmata.querygen import QueryGenDriftError
 
 runner = CliRunner()
 
@@ -38,7 +39,7 @@ def test_querygen_command_registered() -> None:
 
 
 def test_querygen_gen_queries_help_available() -> None:
-    result = runner.invoke(app, ["querygen", "gen-queries", "--help"], color=False)
+    result = runner.invoke(app, ["querygen", "gen-queries", "--help"], color=False, env={"COLUMNS": "200"})
     output = strip_ansi(result.output)
 
     assert result.exit_code == 0
@@ -118,7 +119,9 @@ def test_querygen_cli_maps_omitted_options_to_unset(monkeypatch) -> None:
     }
 
     assert result.exit_code == 0
-    assert set(captured) == expected_keys
+    # ``force`` is a direct bool control flag (default False), not a settings-resolved UNSET option.
+    assert set(captured) == expected_keys | {"force"}
+    assert captured["force"] is False
 
     for key in expected_keys:
         assert captured[key] is UNSET
@@ -138,3 +141,18 @@ def test_querygen_cli_prints_prepared_run_summary(monkeypatch) -> None:
     assert "run_directory:" in result.output
     assert "synthetic_queries.csv" in result.output
     assert "synthetic_queries.meta.json" in result.output
+
+
+def test_querygen_cli_translates_drift_error_to_clean_exit(monkeypatch) -> None:
+    """A QueryGenDriftError surfaces as a clean exit code + message, not a traceback."""
+
+    def fake_gen_queries(**kwargs):
+        raise QueryGenDriftError("Run r cannot resume: checkpoint drifted. Re-run with --force.")
+
+    monkeypatch.setattr("pragmata.querygen.gen_queries", fake_gen_queries)
+
+    result = runner.invoke(app, ["querygen", "gen-queries"])
+
+    assert result.exit_code == 1
+    assert "cannot resume" in result.output
+    assert result.exception is None or isinstance(result.exception, SystemExit)


### PR DESCRIPTION
**Stack (6 open PRs):** #236 → #237 → #238 → #239 → #240 → #241 → #242 

**Chain goal:** Add per-batch checkpoint/resume to querygen so a re-run with the same `run_id` skips already-completed work. Nests resumable state under `<run_dir>/checkpoints/`, writes a frozen Stage 1 result (planning + dedup) plus per-batch Stage 1 and Stage 2 artifacts, and orchestrates resume behind a fail-fast config-drift gate (`--force` overrides) so checkpoints are never silently reused under changed settings.

**This PR (6/6):** The orchestration layer that ties the foundation + three artifact slices together: per-batch resume for both stages, a frozen Stage 1 result that lets a same-`run_id` rerun skip all of Stage 1, and a **fail-fast-on-config-drift** gate (`--force` to override) that prevents silent reuse of checkpoints produced under different settings.

---

## What
- `gen_queries`: Stage 1 frozen-result skip + per-batch planning resume (contiguous-prefix; `resume_exhausted` sticks once any batch reruns); end-of-Stage-1 cross-run summary write; Stage 2 per-batch realization resume; CSV-as-projection of frozen result + realization artifacts.
- **Drift gate**: `_read_reusable_checkpoint` resolver is the single gate every checkpoint read goes through — clean match → reuse; drift + `force=False` → raise `QueryGenDriftError` (fail fast, message names old → current per field); drift + `force=True` → recompute; damaged file → self-heal (silent recompute).
- `QueryGenDriftError` re-exported on the public `pragmata.querygen` surface (advertised in the docstring; callers can `except querygen.QueryGenDriftError`).
- **CLI**: `--force/--no-force` flag (per-invocation control, not a settings field); translates `QueryGenDriftError` into a clean `typer.Exit(1)` with the message on stderr (not a Python traceback).
- Per-stage fingerprint threading (planning vs realization) so a realization-model change re-realizes **only** Stage 2.
- Wires #239's engine, #240's frozen-result, and #241's realization checkpoints together.

This PR is large (~+800 net) because the orchestration api and its integration tests are inseparable.

## Note on CLI scope
This PR adds **only** `--force` + the `QueryGenDriftError` → `typer.Exit` translation to the existing CLI. The unmerged #222 runtime-knobs block (`--requests-per-second` etc.) is intentionally **not** included — it is independent of this stack.

## Test plan
- [x] `tests/unit/api/test_querygen.py` — full resume + drift + force + self-heal + tolerance-rededup + planning-batch-drift integration tests.
- [x] `tests/unit/cli/test_cli_querygen.py` — drift → exit 1 + message (no traceback).
- [x] Full querygen+api+cli+paths+atomic_io suite: 202 pass on this branch (worktree, PYTHONPATH).
