### PR TITLE
feat(annotation): persist n_retrieved_chunks on retrieval records

### DIFF
--- a/src/pragmata/core/annotation/argilla_task_definitions.py
+++ b/src/pragmata/core/annotation/argilla_task_definitions.py
@@ -205,6 +205,7 @@ def build_task_settings(locale: Locale = "en") -> dict[Task, rg.Settings]:
                 rg.TermsMetadataProperty("chunk_id", visible_for_annotators=False),
                 rg.TermsMetadataProperty("doc_id", visible_for_annotators=False),
                 rg.IntegerMetadataProperty("chunk_rank", min=1, visible_for_annotators=False),
+                rg.IntegerMetadataProperty("n_retrieved_chunks", min=1, visible_for_annotators=False),
             ],
             guidelines=t(Task.RETRIEVAL, "guidelines", ""),
         ),

--- a/src/pragmata/core/annotation/export_fetcher.py
+++ b/src/pragmata/core/annotation/export_fetcher.py
@@ -64,6 +64,7 @@ def _build_row(
             chunk_id=metadata.get("chunk_id", ""),
             doc_id=metadata.get("doc_id", ""),
             chunk_rank=metadata.get("chunk_rank", 0),
+            n_retrieved_chunks=metadata.get("n_retrieved_chunks", 0),
             topically_relevant=_to_bool(answers.get("topically_relevant")),
             evidence_sufficient=_to_bool(answers.get("evidence_sufficient")),
             misleading=_to_bool(answers.get("misleading")),

--- a/src/pragmata/core/annotation/record_builder.py
+++ b/src/pragmata/core/annotation/record_builder.py
@@ -99,6 +99,7 @@ def build_retrieval_records(pair: QueryResponsePair, record_uuid: str) -> list[r
             "chunk_id": chunk.chunk_id,
             "doc_id": chunk.doc_id,
             "chunk_rank": chunk.chunk_rank,
+            "n_retrieved_chunks": len(pair.chunks),
         }
         if pair.language is not None:
             metadata["language"] = pair.language

--- a/src/pragmata/core/schemas/annotation_export.py
+++ b/src/pragmata/core/schemas/annotation_export.py
@@ -55,6 +55,7 @@ class RetrievalAnnotation(AnnotationBase):
     chunk_id: str
     doc_id: str
     chunk_rank: int
+    n_retrieved_chunks: int
     topically_relevant: bool | None = None
     evidence_sufficient: bool | None = None
     misleading: bool | None = None

--- a/tests/unit/api/test_export_api.py
+++ b/tests/unit/api/test_export_api.py
@@ -97,6 +97,7 @@ BASE_METADATA = {
     "chunk_id": "chunk-1",
     "doc_id": "doc-1",
     "chunk_rank": 1,
+    "n_retrieved_chunks": 5,
 }
 
 _UID1 = UUID("00000000-0000-0000-0000-000000000001")

--- a/tests/unit/core/annotation/test_argilla_task_definitions.py
+++ b/tests/unit/core/annotation/test_argilla_task_definitions.py
@@ -198,7 +198,7 @@ class TestDiscardContract:
 class TestMetadataProperties:
     def test_retrieval_metadata(self):
         meta = [m.name for m in _RETRIEVAL.metadata]
-        assert meta == ["record_uuid", "language", "chunk_id", "doc_id", "chunk_rank"]
+        assert meta == ["record_uuid", "language", "chunk_id", "doc_id", "chunk_rank", "n_retrieved_chunks"]
 
     def test_grounding_metadata(self):
         meta = [m.name for m in _GROUNDING.metadata]

--- a/tests/unit/core/annotation/test_constraints.py
+++ b/tests/unit/core/annotation/test_constraints.py
@@ -36,6 +36,7 @@ def _retrieval(**kwargs) -> RetrievalAnnotation:
         "chunk_id": "cid",
         "doc_id": "did",
         "chunk_rank": 1,
+        "n_retrieved_chunks": 5,
         "topically_relevant": True,
         "evidence_sufficient": False,
         "misleading": False,

--- a/tests/unit/core/annotation/test_export_runner.py
+++ b/tests/unit/core/annotation/test_export_runner.py
@@ -46,6 +46,7 @@ def _retrieval(**kwargs) -> RetrievalAnnotation:
         "chunk_id": "cid",
         "doc_id": "did",
         "chunk_rank": 1,
+        "n_retrieved_chunks": 5,
         "topically_relevant": True,
         "evidence_sufficient": False,
         "misleading": False,
@@ -102,6 +103,7 @@ BASE_METADATA = {
     "chunk_id": "chunk-1",
     "doc_id": "doc-1",
     "chunk_rank": 1,
+    "n_retrieved_chunks": 5,
 }
 
 
@@ -194,6 +196,7 @@ class TestWriteExportCsv:
                 "chunk_id": "cid",
                 "doc_id": "did",
                 "chunk_rank": 1,
+                "n_retrieved_chunks": 5,
                 "topically_relevant": True,
                 "evidence_sufficient": False,
                 "misleading": False,

--- a/tests/unit/core/annotation/test_iaa_runner.py
+++ b/tests/unit/core/annotation/test_iaa_runner.py
@@ -30,6 +30,7 @@ _RETRIEVAL_DEFAULTS = {
     "chunk_id": "cid",
     "doc_id": "did",
     "chunk_rank": 1,
+    "n_retrieved_chunks": 5,
     "notes": "",
 }
 

--- a/tests/unit/core/annotation/test_import.py
+++ b/tests/unit/core/annotation/test_import.py
@@ -106,6 +106,15 @@ class TestBuildRetrievalRecords:
         assert rec.metadata["doc_id"] == chunk.doc_id
         assert rec.metadata["chunk_rank"] == chunk.chunk_rank
 
+    def test_n_retrieved_chunks_stamped_on_every_chunk_record(self) -> None:
+        """K = len(pair.chunks) stamped uniformly on every chunk-record of the panel."""
+        pair = _make_pair()
+        records = build_retrieval_records(pair, _UUID)
+        k = len(pair.chunks)
+        assert k >= 2
+        for rec in records:
+            assert rec.metadata["n_retrieved_chunks"] == k
+
     def test_chunk_rank_from_chunk_not_enumerate(self) -> None:
         """chunk_rank must come from chunk.chunk_rank, not the loop index."""
         pair = _make_pair()

--- a/tests/unit/core/schemas/test_annotation_export.py
+++ b/tests/unit/core/schemas/test_annotation_export.py
@@ -44,6 +44,7 @@ def valid_retrieval(base_fields):
         "chunk_id": "c1",
         "doc_id": "d1",
         "chunk_rank": 1,
+        "n_retrieved_chunks": 5,
         "topically_relevant": True,
         "evidence_sufficient": False,
         "misleading": False,


### PR DESCRIPTION
## Why
Part of the **retrieval annotation completeness** feature stack. Persists K (= number of retrieved chunks per query) as record metadata so downstream consumers can compute true top-K retrieval metrics (precision@K, recall@K, NDCG@K, MRR@K). Foundation only: ships nothing user-visible on its own — the export columns and the live `annotation status` command land in the later stack PRs.

K varies per query (~15% K<5, 61% K=5, 24% K>5; the retriever is threshold-based, not top-K), so the export side can't infer K from `chunk_rank` — it must come from a separate per-record field.

## What
- `core/annotation/record_builder.py` — stamp `"n_retrieved_chunks": len(pair.chunks)` on every chunk-record's metadata at import time.
- `core/annotation/argilla_task_definitions.py` — declare `IntegerMetadataProperty("n_retrieved_chunks", min=1, visible_for_annotators=False)` on the retrieval task.
- `core/schemas/annotation_export.py` — `RetrievalAnnotation.n_retrieved_chunks: int` field.
- `core/annotation/export_fetcher.py` — read it back via `metadata.get("n_retrieved_chunks", 0)` (defensive default for pre-this-PR records).

End-to-end mirror of the existing `chunk_rank` field.

## Stack (4 PRs)
1. **this PR** — `01-persist-k`
2. `02-export-completeness` — adds `panel_complete` + completeness count columns to retrieval.csv + a `completeness_summary` block in the meta sidecar; uses a dedicated retrieval fetch independent of `--include-discarded`.
3. `03-status-command` — new `annotation status` CLI showing live per-panel completeness across prod + cal datasets, with both metric-facing `panel_complete` (strict: all chunks submitted) and operational `distribution_satisfied` (per-purpose `min_submitted` met).
4. `04-tag-incomplete` — opt-in `--tag-incomplete` flag stamps a `needs_completion` advisory tag on incomplete unresolved chunk-records (visible to annotators in the Argilla UI for filtering).

**Note:** a one-off backfill script for records imported before this PR is kept out of the supported CLI/API surface — it's a retrospective ops migration, not packaged functionality.

## Test plan
- [x] \`tests/unit/core/annotation/test_import.py\` — new \`test_n_retrieved_chunks_stamped_on_every_chunk_record\` locks the persist contract.
- [x] \`tests/unit/core/annotation/test_argilla_task_definitions.py\` — metadata-name list updated.
- [x] Fixture refresh across \`test_annotation_export.py\`, \`test_export_runner.py\`, \`test_constraints.py\`, \`test_iaa_runner.py\`, \`test_export_api.py\`.
- [x] Full unit suite green (825 tests, ruff clean, mypy clean on touched files).