### PR TITLE
feat(annotation): persist n_retrieved_chunks on retrieval records

### DIFF
--- a/src/pragmata/core/annotation/argilla_task_definitions.py
+++ b/src/pragmata/core/annotation/argilla_task_definitions.py
@@ -335,6 +335,7 @@ def build_task_settings(settings: AnnotationSettings, locale: Locale = "en") -> 
                 rg.TermsMetadataProperty("chunk_id", visible_for_annotators=False),
                 rg.TermsMetadataProperty("doc_id", visible_for_annotators=False),
                 rg.IntegerMetadataProperty("chunk_rank", min=1, visible_for_annotators=False),
+                rg.IntegerMetadataProperty("n_retrieved_chunks", min=1, visible_for_annotators=False),
             ],
             guidelines=t(Task.RETRIEVAL, "guidelines", ""),
         ),

--- a/src/pragmata/core/annotation/export_fetcher.py
+++ b/src/pragmata/core/annotation/export_fetcher.py
@@ -65,7 +65,11 @@ def _build_row(
             chunk_id=metadata.get("chunk_id", ""),
             doc_id=metadata.get("doc_id", ""),
             chunk_rank=metadata.get("chunk_rank", 0),
-            n_retrieved_chunks=metadata.get("n_retrieved_chunks", 0),
+            # -1 is a sentinel for "metadata absent" (pre-backfill/pre-this-PR records) —
+            # real K is always >=1 (enforced by the min=1 metadata constraint), and -1
+            # can't be confused with a real count. Downstream consumers must guard with
+            # `k > 0` before using it as a divisor.
+            n_retrieved_chunks=metadata.get("n_retrieved_chunks", -1),
             topically_relevant=_to_bool(answers.get("topically_relevant")),
             evidence_sufficient=_to_bool(answers.get("evidence_sufficient")),
             misleading=_to_bool(answers.get("misleading")),

--- a/src/pragmata/core/annotation/export_fetcher.py
+++ b/src/pragmata/core/annotation/export_fetcher.py
@@ -64,6 +64,7 @@ def _build_row(
             chunk_id=metadata.get("chunk_id", ""),
             doc_id=metadata.get("doc_id", ""),
             chunk_rank=metadata.get("chunk_rank", 0),
+            n_retrieved_chunks=metadata.get("n_retrieved_chunks", 0),
             topically_relevant=_to_bool(answers.get("topically_relevant")),
             evidence_sufficient=_to_bool(answers.get("evidence_sufficient")),
             misleading=_to_bool(answers.get("misleading")),

--- a/src/pragmata/core/annotation/record_builder.py
+++ b/src/pragmata/core/annotation/record_builder.py
@@ -120,6 +120,7 @@ def build_retrieval_record_for_chunk(
         "chunk_id": chunk.chunk_id,
         "doc_id": chunk.doc_id,
         "chunk_rank": chunk.chunk_rank,
+        "n_retrieved_chunks": len(pair.chunks),
     }
     if pair.language is not None:
         metadata["language"] = pair.language

--- a/src/pragmata/core/schemas/annotation_export.py
+++ b/src/pragmata/core/schemas/annotation_export.py
@@ -56,6 +56,7 @@ class RetrievalAnnotation(AnnotationBase):
     chunk_id: NonEmptyStr  # IAA pivots retrieval rows by (record_uuid, chunk_id); empty would silently collapse chunks
     doc_id: str
     chunk_rank: int
+    n_retrieved_chunks: int
     topically_relevant: bool | None = None
     evidence_sufficient: bool | None = None
     misleading: bool | None = None

--- a/tests/unit/api/test_export_api.py
+++ b/tests/unit/api/test_export_api.py
@@ -97,6 +97,7 @@ BASE_METADATA = {
     "chunk_id": "chunk-1",
     "doc_id": "doc-1",
     "chunk_rank": 1,
+    "n_retrieved_chunks": 5,
 }
 
 _UID1 = UUID("00000000-0000-0000-0000-000000000001")

--- a/tests/unit/core/annotation/test_argilla_task_definitions.py
+++ b/tests/unit/core/annotation/test_argilla_task_definitions.py
@@ -199,7 +199,7 @@ class TestDiscardContract:
 class TestMetadataProperties:
     def test_retrieval_metadata(self):
         meta = [m.name for m in _RETRIEVAL.metadata]
-        assert meta == ["record_uuid", "language", "chunk_id", "doc_id", "chunk_rank"]
+        assert meta == ["record_uuid", "language", "chunk_id", "doc_id", "chunk_rank", "n_retrieved_chunks"]
 
     def test_grounding_metadata(self):
         meta = [m.name for m in _GROUNDING.metadata]

--- a/tests/unit/core/annotation/test_export_constraint_checks.py
+++ b/tests/unit/core/annotation/test_export_constraint_checks.py
@@ -36,6 +36,7 @@ def _retrieval(**kwargs) -> RetrievalAnnotation:
         "chunk_id": "cid",
         "doc_id": "did",
         "chunk_rank": 1,
+        "n_retrieved_chunks": 5,
         "topically_relevant": True,
         "evidence_sufficient": False,
         "misleading": False,

--- a/tests/unit/core/annotation/test_export_runner.py
+++ b/tests/unit/core/annotation/test_export_runner.py
@@ -46,6 +46,7 @@ def _retrieval(**kwargs) -> RetrievalAnnotation:
         "chunk_id": "cid",
         "doc_id": "did",
         "chunk_rank": 1,
+        "n_retrieved_chunks": 5,
         "topically_relevant": True,
         "evidence_sufficient": False,
         "misleading": False,
@@ -102,6 +103,7 @@ BASE_METADATA = {
     "chunk_id": "chunk-1",
     "doc_id": "doc-1",
     "chunk_rank": 1,
+    "n_retrieved_chunks": 5,
 }
 
 
@@ -194,6 +196,7 @@ class TestWriteExportCsv:
                 "chunk_id": "cid",
                 "doc_id": "did",
                 "chunk_rank": 1,
+                "n_retrieved_chunks": 5,
                 "topically_relevant": True,
                 "evidence_sufficient": False,
                 "misleading": False,

--- a/tests/unit/core/annotation/test_iaa_runner.py
+++ b/tests/unit/core/annotation/test_iaa_runner.py
@@ -30,6 +30,7 @@ _RETRIEVAL_DEFAULTS = {
     "chunk_id": "cid",
     "doc_id": "did",
     "chunk_rank": 1,
+    "n_retrieved_chunks": 5,
     "notes": "",
 }
 

--- a/tests/unit/core/annotation/test_import.py
+++ b/tests/unit/core/annotation/test_import.py
@@ -122,6 +122,15 @@ class TestBuildRetrievalRecords:
         assert rec.metadata["doc_id"] == chunk.doc_id
         assert rec.metadata["chunk_rank"] == chunk.chunk_rank
 
+    def test_n_retrieved_chunks_stamped_on_every_chunk_record(self) -> None:
+        """K = len(pair.chunks) stamped uniformly on every chunk-record of the panel."""
+        pair = _make_pair()
+        records = _build_retrieval_records(pair, _UUID)
+        k = len(pair.chunks)
+        assert k >= 2
+        for rec in records:
+            assert rec.metadata["n_retrieved_chunks"] == k
+
     def test_chunk_rank_from_chunk_not_enumerate(self) -> None:
         """chunk_rank must come from chunk.chunk_rank, not the loop index."""
         pair = _make_pair()

--- a/tests/unit/core/schemas/test_annotation_export.py
+++ b/tests/unit/core/schemas/test_annotation_export.py
@@ -44,6 +44,7 @@ def valid_retrieval(base_fields):
         "chunk_id": "c1",
         "doc_id": "d1",
         "chunk_rank": 1,
+        "n_retrieved_chunks": 5,
         "topically_relevant": True,
         "evidence_sufficient": False,
         "misleading": False,


### PR DESCRIPTION
**Stack (6 PRs):** #246 → #247 → #268 → #248 → #269 → #249

**Chain goal:** Persist K (number of retrieved chunks per query) on retrieval records, surface it as panel-completeness columns + sidecar at export time, ship a live `annotation status` CLI on top, and add an opt-in `--tag-partial-panels` advisory write so annotators can filter partially-done panels in the Argilla UI.

**This PR (1/6):** Foundation. Stamps `n_retrieved_chunks` on retrieval record metadata at import and surfaces it on `RetrievalAnnotation`. Ships nothing user-visible on its own — the export columns (#247/#268) and live status CLI (#248/#269) consume it.

---

## Scope

### Record building
- `core/annotation/record_builder.py`: add `"n_retrieved_chunks": len(pair.chunks)` to every chunk-record's metadata dict.

### Task definition
- `core/annotation/argilla_task_definitions.py`: declare `IntegerMetadataProperty("n_retrieved_chunks", min=1, visible_for_annotators=False)` on retrieval task settings.

### Schema
- `core/schemas/annotation_export.py`: `RetrievalAnnotation.n_retrieved_chunks: int` field (mirrors the existing `chunk_rank: int`).

### Export readback
- `core/annotation/export_fetcher.py`: `_build_row` retrieval branch reads `metadata.get("n_retrieved_chunks", 0)` (defensive default for records imported before this PR).

### Tests
- New `test_n_retrieved_chunks_stamped_on_every_chunk_record` in `test_import.py` locks the persist contract.
- Metadata-name list in `test_argilla_task_definitions.py` updated.
- Fixture refresh across `test_annotation_export.py`, `test_export_runner.py`, `test_export_constraint_checks.py`, `test_iaa_runner.py`, `test_export_api.py`.

## Why

K varies per query (~15% K<5, 61% K=5, 24% K>5; the retriever is threshold-based, not top-K), so the export side can't infer K from `chunk_rank` or from record-counting alone — it needs a persisted SSOT to drive true top-K metrics in the consumer pipeline (precision@K, recall@K, NDCG@K, MRR@K).

End-to-end mirror of the existing `chunk_rank` field: stamped at import, declared on the task, modelled on `RetrievalAnnotation`, read back by the fetcher.

A one-off backfill script for records imported before this PR (in-flight batches) lives outside the supported CLI/API surface — retrospective ops migration, not packaged functionality.

## Base

`feat/querygen-resumable-stack` — kitchen-sink integration branch carrying the full dep surface this stack assumes (`Locale`, `atomic_write_text`, `LogicalConstraint`, `WIDGET_FIELD_PLACEHOLDERS`, the `export_constraint_checks` rename). Rebases cleanly to `main` once those upstream stacks land.

## Test plan
- [x] `uv run python -m pytest tests/unit` (863 passing)

---