### PR TITLE
feat(annotation): panel completeness calculator

### DIFF
--- a/src/pragmata/core/annotation/completeness.py
+++ b/src/pragmata/core/annotation/completeness.py
@@ -1,0 +1,219 @@
+"""Per-panel retrieval completeness: how many chunks per query have a submitted response.
+
+A "panel" is the set of retrieval chunk-records sharing one ``record_uuid``
+(one query, K chunks).
+
+The exported ``panel_complete`` flag uses the STRICT (submitted-only)
+definition: a panel is complete iff every one of its K chunks has at least
+one SUBMITTED response. This matches what downstream eval scorers actually
+need: pragmata's ``DiscardReason`` enum is refusal-only
+(``INVALID_OR_UNREALISTIC`` / ``UNCLEAR`` / ``OUTSIDE_REVIEWER_EXPERTISE``),
+so a discarded chunk is an abstention — not a judgement — and treating it
+as covered would feed unjudged chunks into NDCG@K / precision@K denominators
+as if they carried a 0-relevance label.
+
+Three count columns let consumers derive any policy they need:
+
+- ``n_annotated_chunks`` = distinct chunks with >=1 terminal response (submitted OR discarded)
+- ``n_submitted_chunks`` = distinct chunks with >=1 submitted response
+- ``n_discarded_chunks`` = distinct chunks with >=1 discarded response
+
+Sets aren't disjoint — a chunk where annotator A submitted and annotator B
+discarded is in all three. So ``n_submitted + n_discarded >= n_annotated``
+(equality when no mixed chunks). A consumer wanting the PERMISSIVE
+("terminal counts as covered") policy derives it in one line::
+
+    panel_complete_permissive = (n_annotated_chunks == n_retrieved_chunks)
+
+Computation is INDEPENDENT of the export's ``include_discarded`` flag (which
+gates only row emission to the CSV). When invoked from ``run_export`` the
+underlying walk is shared with the export's row-emission fetch so we don't
+scroll the retrieval datasets twice; standalone callers use the
+``compute_completeness(client, settings)`` convenience that does its own walk.
+"""
+
+import logging
+from dataclasses import dataclass
+
+import argilla as rg
+
+from pragmata.core.annotation.export_fetcher import RetrievalRecordSnapshot, walk_retrieval_records
+from pragmata.core.schemas.annotation_export import CompletenessSummary, KBucketStat
+from pragmata.core.settings.annotation_settings import AnnotationSettings
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PanelCompleteness:
+    """Completeness facts for one retrieval panel (one ``record_uuid``).
+
+    ``n_*_chunks`` count DISTINCT chunk_ids. The three sets overlap when a
+    chunk has both submitted and discarded responses from different
+    annotators; see module docstring for the derivation formulas.
+    """
+
+    record_uuid: str
+    k: int  # n_retrieved_chunks metadata (max if records disagree; 0 if absent)
+    n_annotated_chunks: int  # chunks with >=1 terminal response (union of submitted + discarded)
+    n_submitted_chunks: int  # chunks with >=1 submitted response (used by panel_complete)
+    n_discarded_chunks: int  # chunks with >=1 discarded response
+    panel_complete: bool  # STRICT: k > 0 and n_submitted_chunks == k
+    n_records_seen: int  # distinct chunk-records seen (for integrity check)
+
+
+@dataclass(frozen=True)
+class CompletenessReport:
+    """Per-uuid completeness map + the aggregate summary for the export sidecar."""
+
+    by_uuid: dict[str, PanelCompleteness]
+    summary: CompletenessSummary
+
+
+def k_bucket(k: int) -> str:
+    """Bucket key for the by_k_bucket cross-tab. Mirrors handover (~15/61/24% split)."""
+    if k < 5:
+        return "k_lt_5"
+    if k == 5:
+        return "k_eq_5"
+    return "k_gt_5"
+
+
+_BUCKET_KEYS = ("k_lt_5", "k_eq_5", "k_gt_5")
+
+
+def compute_completeness_from_records(snapshots: list[RetrievalRecordSnapshot]) -> CompletenessReport:
+    """Pure aggregator over pre-walked retrieval snapshots.
+
+    Shared by ``compute_completeness`` (standalone) and ``run_export`` (which
+    walks once and feeds both the row-emission and the completeness passes).
+    """
+    groups: dict[str, dict] = {}
+    n_orphans_skipped = 0
+
+    for snap in snapshots:
+        record_uuid = snap.record_uuid
+        if not record_uuid:
+            n_orphans_skipped += 1
+            continue
+        group = groups.setdefault(
+            record_uuid,
+            {
+                "chunk_ids_seen": set(),
+                "chunk_ids_terminal": set(),
+                "chunk_ids_submitted": set(),
+                "chunk_ids_discarded": set(),
+                "k_max": 0,
+                "k_min": 0,
+                "n_records_with_k": 0,  # mixed-backfill detector
+            },
+        )
+        group["chunk_ids_seen"].add(snap.chunk_id)
+        if snap.n_retrieved_chunks_metadata > 0:
+            k_meta = snap.n_retrieved_chunks_metadata
+            group["k_max"] = max(group["k_max"], k_meta)
+            group["k_min"] = k_meta if group["k_min"] == 0 else min(group["k_min"], k_meta)
+            group["n_records_with_k"] += 1
+        if snap.has_submitted:
+            group["chunk_ids_submitted"].add(snap.chunk_id)
+        if snap.has_discarded:
+            group["chunk_ids_discarded"].add(snap.chunk_id)
+        if snap.has_submitted or snap.has_discarded:
+            group["chunk_ids_terminal"].add(snap.chunk_id)
+
+    by_uuid: dict[str, PanelCompleteness] = {}
+    n_integrity_warnings = 0
+    n_panels_unknown_k = 0
+    buckets: dict[str, dict[str, int]] = {key: {"n_panels": 0, "n_complete": 0} for key in _BUCKET_KEYS}
+    by_k: dict[int, dict[str, int]] = {}
+    n_complete = 0
+    for uuid, group in groups.items():
+        k_max = group["k_max"]
+        k_min = group["k_min"]
+        if k_min and k_max != k_min:
+            logger.warning(
+                "record_uuid=%s: inconsistent n_retrieved_chunks across records (min=%d max=%d) - using max",
+                uuid,
+                k_min,
+                k_max,
+            )
+        k = k_max
+        n_annotated = len(group["chunk_ids_terminal"])
+        n_submitted = len(group["chunk_ids_submitted"])
+        n_discarded = len(group["chunk_ids_discarded"])
+        n_seen = len(group["chunk_ids_seen"])
+        n_with_k = group["n_records_with_k"]
+        # STRICT default: every chunk has a submitted response. Discards are
+        # abstentions, not judgements - see module docstring.
+        panel_complete = k > 0 and n_submitted == k
+        if k > 0 and n_seen != k:
+            logger.warning(
+                "record_uuid=%s: integrity warning - saw %d distinct chunk-records but n_retrieved_chunks=%d",
+                uuid,
+                n_seen,
+                k,
+            )
+            n_integrity_warnings += 1
+        elif n_with_k and n_with_k < n_seen:
+            logger.warning(
+                "record_uuid=%s: integrity warning - %d/%d records carry n_retrieved_chunks metadata "
+                "(panel partially backfilled)",
+                uuid,
+                n_with_k,
+                n_seen,
+            )
+            n_integrity_warnings += 1
+        if k == 0:
+            n_panels_unknown_k += 1
+        by_uuid[uuid] = PanelCompleteness(
+            record_uuid=uuid,
+            k=k,
+            n_annotated_chunks=n_annotated,
+            n_submitted_chunks=n_submitted,
+            n_discarded_chunks=n_discarded,
+            panel_complete=panel_complete,
+            n_records_seen=n_seen,
+        )
+        bucket = buckets[k_bucket(k)]
+        bucket["n_panels"] += 1
+        k_stat = by_k.setdefault(k, {"n_panels": 0, "n_complete": 0})
+        k_stat["n_panels"] += 1
+        if panel_complete:
+            bucket["n_complete"] += 1
+            k_stat["n_complete"] += 1
+            n_complete += 1
+
+    if n_orphans_skipped:
+        logger.warning(
+            "retrieval completeness: %d record(s) skipped (empty record_uuid metadata)",
+            n_orphans_skipped,
+        )
+    if by_uuid and n_panels_unknown_k == len(by_uuid):
+        logger.warning(
+            "retrieval completeness: ALL %d panel(s) have unknown K (n_retrieved_chunks metadata absent) - "
+            "run scripts/backfill_n_retrieved_chunks.py to populate it.",
+            len(by_uuid),
+        )
+
+    n_panels = len(by_uuid)
+    fraction = (n_complete / n_panels) if n_panels else 0.0
+    summary = CompletenessSummary(
+        n_panels=n_panels,
+        n_complete=n_complete,
+        fraction_complete=fraction,
+        by_k_bucket={key: KBucketStat(**value) for key, value in buckets.items()},
+        by_k={k: KBucketStat(**value) for k, value in sorted(by_k.items())},
+        n_integrity_warnings=n_integrity_warnings,
+        n_orphans_skipped=n_orphans_skipped,
+    )
+    return CompletenessReport(by_uuid=by_uuid, summary=summary)
+
+
+def compute_completeness(client: rg.Argilla, settings: AnnotationSettings) -> CompletenessReport:
+    """Walk retrieval datasets once and compute panel completeness.
+
+    Standalone-caller convenience; ``run_export`` calls ``walk_retrieval_records``
+    once itself and feeds the result to both this aggregator and the export's
+    row builder.
+    """
+    return compute_completeness_from_records(walk_retrieval_records(client, settings))

--- a/src/pragmata/core/annotation/completeness.py
+++ b/src/pragmata/core/annotation/completeness.py
@@ -33,7 +33,7 @@ scroll the retrieval datasets twice; standalone callers use the
 """
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import argilla as rg
 
@@ -82,13 +82,28 @@ def k_bucket(k: int) -> str:
 _BUCKET_KEYS = ("k_lt_5", "k_eq_5", "k_gt_5")
 
 
-def compute_completeness_from_records(snapshots: list[RetrievalRecordSnapshot]) -> CompletenessReport:
-    """Pure aggregator over pre-walked retrieval snapshots.
+@dataclass
+class _PanelAccumulator:
+    """Mutable per-panel tally built during the aggregation pass over snapshots."""
 
-    Shared by ``compute_completeness`` (standalone) and ``run_export`` (which
-    walks once and feeds both the row-emission and the completeness passes).
+    chunk_ids_seen: set[str] = field(default_factory=set)
+    chunk_ids_terminal: set[str] = field(default_factory=set)
+    chunk_ids_submitted: set[str] = field(default_factory=set)
+    chunk_ids_discarded: set[str] = field(default_factory=set)
+    k_max: int = 0
+    k_min: int = 0
+    n_records_with_k: int = 0  # mixed-backfill detector
+
+
+def _aggregate_snapshots(
+    snapshots: list[RetrievalRecordSnapshot],
+) -> tuple[dict[str, _PanelAccumulator], int]:
+    """Group snapshots by ``record_uuid`` into per-panel tallies.
+
+    Returns the group map plus a count of snapshots skipped for missing
+    ``record_uuid`` metadata (orphans).
     """
-    groups: dict[str, dict] = {}
+    groups: dict[str, _PanelAccumulator] = {}
     n_orphans_skipped = 0
 
     for snap in snapshots:
@@ -96,31 +111,25 @@ def compute_completeness_from_records(snapshots: list[RetrievalRecordSnapshot]) 
         if not record_uuid:
             n_orphans_skipped += 1
             continue
-        group = groups.setdefault(
-            record_uuid,
-            {
-                "chunk_ids_seen": set(),
-                "chunk_ids_terminal": set(),
-                "chunk_ids_submitted": set(),
-                "chunk_ids_discarded": set(),
-                "k_max": 0,
-                "k_min": 0,
-                "n_records_with_k": 0,  # mixed-backfill detector
-            },
-        )
-        group["chunk_ids_seen"].add(snap.chunk_id)
+        group = groups.setdefault(record_uuid, _PanelAccumulator())
+        group.chunk_ids_seen.add(snap.chunk_id)
         if snap.n_retrieved_chunks_metadata > 0:
             k_meta = snap.n_retrieved_chunks_metadata
-            group["k_max"] = max(group["k_max"], k_meta)
-            group["k_min"] = k_meta if group["k_min"] == 0 else min(group["k_min"], k_meta)
-            group["n_records_with_k"] += 1
+            group.k_max = max(group.k_max, k_meta)
+            group.k_min = k_meta if group.k_min == 0 else min(group.k_min, k_meta)
+            group.n_records_with_k += 1
         if snap.has_submitted:
-            group["chunk_ids_submitted"].add(snap.chunk_id)
+            group.chunk_ids_submitted.add(snap.chunk_id)
         if snap.has_discarded:
-            group["chunk_ids_discarded"].add(snap.chunk_id)
+            group.chunk_ids_discarded.add(snap.chunk_id)
         if snap.has_submitted or snap.has_discarded:
-            group["chunk_ids_terminal"].add(snap.chunk_id)
+            group.chunk_ids_terminal.add(snap.chunk_id)
 
+    return groups, n_orphans_skipped
+
+
+def _summarize_groups(groups: dict[str, _PanelAccumulator], n_orphans_skipped: int) -> CompletenessReport:
+    """Transform per-panel tallies into ``PanelCompleteness`` rows + the aggregate summary."""
     by_uuid: dict[str, PanelCompleteness] = {}
     n_integrity_warnings = 0
     n_panels_unknown_k = 0
@@ -128,8 +137,8 @@ def compute_completeness_from_records(snapshots: list[RetrievalRecordSnapshot]) 
     by_k: dict[int, dict[str, int]] = {}
     n_complete = 0
     for uuid, group in groups.items():
-        k_max = group["k_max"]
-        k_min = group["k_min"]
+        k_max = group.k_max
+        k_min = group.k_min
         if k_min and k_max != k_min:
             logger.warning(
                 "record_uuid=%s: inconsistent n_retrieved_chunks across records (min=%d max=%d) - using max",
@@ -138,11 +147,11 @@ def compute_completeness_from_records(snapshots: list[RetrievalRecordSnapshot]) 
                 k_max,
             )
         k = k_max
-        n_annotated = len(group["chunk_ids_terminal"])
-        n_submitted = len(group["chunk_ids_submitted"])
-        n_discarded = len(group["chunk_ids_discarded"])
-        n_seen = len(group["chunk_ids_seen"])
-        n_with_k = group["n_records_with_k"]
+        n_annotated = len(group.chunk_ids_terminal)
+        n_submitted = len(group.chunk_ids_submitted)
+        n_discarded = len(group.chunk_ids_discarded)
+        n_seen = len(group.chunk_ids_seen)
+        n_with_k = group.n_records_with_k
         # STRICT default: every chunk has a submitted response. Discards are
         # abstentions, not judgements - see module docstring.
         panel_complete = k > 0 and n_submitted == k
@@ -207,6 +216,16 @@ def compute_completeness_from_records(snapshots: list[RetrievalRecordSnapshot]) 
         n_orphans_skipped=n_orphans_skipped,
     )
     return CompletenessReport(by_uuid=by_uuid, summary=summary)
+
+
+def compute_completeness_from_records(snapshots: list[RetrievalRecordSnapshot]) -> CompletenessReport:
+    """Pure aggregator over pre-walked retrieval snapshots.
+
+    Shared by ``compute_completeness`` (standalone) and ``run_export`` (which
+    walks once and feeds both the row-emission and the completeness passes).
+    """
+    groups, n_orphans_skipped = _aggregate_snapshots(snapshots)
+    return _summarize_groups(groups, n_orphans_skipped)
 
 
 def compute_completeness(client: rg.Argilla, settings: AnnotationSettings) -> CompletenessReport:

--- a/src/pragmata/core/annotation/export_fetcher.py
+++ b/src/pragmata/core/annotation/export_fetcher.py
@@ -5,6 +5,7 @@ model construction. The api/ layer resolves settings and delegates here.
 """
 
 import logging
+from dataclasses import dataclass
 from datetime import datetime
 from uuid import UUID
 
@@ -97,6 +98,88 @@ def _build_row(
     )
 
 
+@dataclass(frozen=True)
+class RetrievalRecordSnapshot:
+    """One retrieval chunk-record + its per-purpose tagging + response summary.
+
+    The single output of ``walk_retrieval_records`` so the export pipeline's
+    row-emission pass and the completeness aggregator can both consume the
+    same in-memory record set without independently scrolling the Argilla
+    retrieval datasets.
+
+    ``response_user_pairs`` is the per-user grouping (one entry per
+    annotator with their (status, answers)), needed for typed-row
+    construction; ``has_submitted`` / ``has_discarded`` are the aggregate
+    flags completeness needs. ``n_retrieved_chunks_metadata`` is 0 when the
+    record has no such metadata (pre-backfill state).
+    """
+
+    record: rg.Record
+    record_uuid: str
+    chunk_id: str
+    calibration: bool
+    n_retrieved_chunks_metadata: int
+    response_user_pairs: list[tuple[UUID, str, dict[str, str]]]
+    has_submitted: bool
+    has_discarded: bool
+
+
+def resolve_task_purposes(settings: AnnotationSettings, task: Task) -> tuple[str | None, list[bool]]:
+    """Topology lookup: workspace owning the task, and which purposes to fetch.
+
+    Returns ``(workspace_name, purposes)`` where purposes is ``[False]`` for
+    production-only or ``[False, True]`` when the task has a calibration
+    dataset declared. Used by both ``fetch_task`` and the completeness /
+    status passes so they walk identical dataset sets.
+    """
+    workspace_name: str | None = None
+    for ws_base, ws_settings in settings.workspaces.items():
+        if task in ws_settings.tasks:
+            workspace_name = ws_base
+            break
+    purposes: list[bool] = [False]
+    if workspace_name is not None:
+        if settings.resolved_task(workspace_name, task).calibration_min_submitted is not None:
+            purposes.append(True)
+    return workspace_name, purposes
+
+
+def walk_retrieval_records(client: rg.Argilla, settings: AnnotationSettings) -> list[RetrievalRecordSnapshot]:
+    """One walk across prod + cal retrieval datasets, no response.status filter.
+
+    Used by both ``compute_completeness`` (needs every record including
+    no-response ones for the integrity check) and ``run_export``'s
+    retrieval row-emission path (filters in Python at row-construction
+    time). When both consumers run in the same export, this lets
+    ``run_export`` collect once and pass the result to both - one Argilla
+    scroll per dataset instead of two.
+    """
+    workspace_name, purposes = resolve_task_purposes(settings, Task.RETRIEVAL)
+    snapshots: list[RetrievalRecordSnapshot] = []
+    for calibration in purposes:
+        ds_name = dataset_name(Task.RETRIEVAL, calibration=calibration, dataset_id=settings.dataset_id)
+        dataset = client.datasets(ds_name, workspace=workspace_name)
+        if dataset is None:
+            continue
+        for record in dataset.records(with_responses=True):
+            grouped = _group_responses_by_user(record)
+            user_pairs = [(uid, status, answers) for uid, (status, answers) in grouped.items()]
+            statuses = {s for _, s, _ in user_pairs}
+            snapshots.append(
+                RetrievalRecordSnapshot(
+                    record=record,
+                    record_uuid=record.metadata.get("record_uuid", ""),
+                    chunk_id=record.metadata.get("chunk_id", ""),
+                    calibration=calibration,
+                    n_retrieved_chunks_metadata=int(record.metadata.get("n_retrieved_chunks") or 0),
+                    response_user_pairs=user_pairs,
+                    has_submitted="submitted" in statuses,
+                    has_discarded="discarded" in statuses,
+                )
+            )
+    return snapshots
+
+
 def fetch_task(
     client: rg.Argilla,
     settings: AnnotationSettings,
@@ -114,16 +197,7 @@ def fetch_task(
     By default returns only submitted responses; pass ``include_discarded=True``
     to also include responses the annotator discarded.
     """
-    workspace_name: str | None = None
-    for ws_base, ws_settings in settings.workspaces.items():
-        if task in ws_settings.tasks:
-            workspace_name = ws_base
-            break
-
-    purposes: list[bool] = [False]
-    if workspace_name is not None:
-        if settings.resolved_task(workspace_name, task).calibration_min_submitted is not None:
-            purposes.append(True)
+    workspace_name, purposes = resolve_task_purposes(settings, task)
 
     statuses = ["submitted", "discarded"] if include_discarded else ["submitted"]
     query = rg.Query(filter=rg.Filter([("response.status", "in", statuses)]))

--- a/src/pragmata/core/schemas/annotation_export.py
+++ b/src/pragmata/core/schemas/annotation_export.py
@@ -112,6 +112,40 @@ class GenerationExportRow(GenerationAnnotation):
     constraint_details: str = ""
 
 
+class KBucketStat(BaseModel):
+    """Per K-bucket panel counts for retrieval completeness MNAR analysis.
+
+    Incompleteness correlates with K (the panel size), so reporting coverage
+    bucketed by K lets the eval side detect bias from dropping partial panels.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    n_panels: NonNegativeInt
+    n_complete: NonNegativeInt
+
+
+class CompletenessSummary(BaseModel):
+    """Retrieval panel-completeness aggregates for one export run.
+
+    ``n_panels`` counts distinct non-orphan ``record_uuid``s; ``n_complete``
+    counts those whose all K chunks have a terminal (submitted-or-discarded)
+    response. ``by_k_bucket`` cross-tabs the same counts by K bucket
+    (``k_lt_5`` / ``k_eq_5`` / ``k_gt_5``) for at-a-glance reporting;
+    ``by_k`` is the full per-K histogram for MNAR / per-K marginal analysis.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    n_panels: NonNegativeInt
+    n_complete: NonNegativeInt
+    fraction_complete: float = Field(ge=0.0, le=1.0)
+    by_k_bucket: dict[str, KBucketStat]
+    by_k: dict[int, KBucketStat]
+    n_integrity_warnings: NonNegativeInt
+    n_orphans_skipped: NonNegativeInt
+
+
 class AnnotationExportMeta(BaseModel):
     """Schema for annotation export run provenance (sidecar to the task CSVs)."""
 

--- a/tests/unit/core/annotation/test_completeness.py
+++ b/tests/unit/core/annotation/test_completeness.py
@@ -1,0 +1,295 @@
+"""Unit tests for retrieval panel completeness."""
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from pragmata.core.annotation.completeness import (
+    PanelCompleteness,
+    compute_completeness,
+    k_bucket,
+)
+
+
+def _make_record(
+    *,
+    record_uuid: str = "uuid-a",
+    chunk_id: str = "c1",
+    n_retrieved_chunks: int | None = 5,
+    response_statuses: list[str] | None = None,
+) -> MagicMock:
+    """A mock Argilla record. ``response_statuses=None`` means a record with no responses."""
+    metadata: dict[str, object] = {"record_uuid": record_uuid, "chunk_id": chunk_id}
+    if n_retrieved_chunks is not None:
+        metadata["n_retrieved_chunks"] = n_retrieved_chunks
+    rec = MagicMock()
+    rec.metadata = metadata
+    responses = []
+    for status in response_statuses or []:
+        r = MagicMock()
+        r.status = status
+        responses.append(r)
+    rec.responses = responses
+    return rec
+
+
+def _settings(*, with_calibration: bool = False) -> MagicMock:
+    """AnnotationSettings stub for compute_completeness."""
+    settings = MagicMock()
+    settings.dataset_id = ""
+    ws_settings = MagicMock()
+    ws_settings.tasks = ["retrieval"]
+    settings.workspaces = {"ws1": ws_settings}
+    resolved = MagicMock()
+    resolved.calibration_min_submitted = 3 if with_calibration else None
+    settings.resolved_task.return_value = resolved
+    return settings
+
+
+def _client(records_by_dataset: dict[str, list[MagicMock]]) -> MagicMock:
+    """Mock client.datasets(name) returns a dataset whose .records(...) yields the given records.
+
+    Each call to dataset.records(...) returns a FRESH iterator (single dataset
+    can be fetched multiple times in one run).
+    """
+    client = MagicMock()
+
+    def _datasets(name: str, workspace: str | None = None):
+        records = records_by_dataset.get(name)
+        if records is None:
+            return None
+        ds = MagicMock()
+        ds.records.side_effect = lambda *a, **kw: iter(records)
+        return ds
+
+    client.datasets.side_effect = _datasets
+    return client
+
+
+# ---------------------------------------------------------------------------
+# k_bucket
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("k", "expected"),
+    [(0, "k_lt_5"), (1, "k_lt_5"), (4, "k_lt_5"), (5, "k_eq_5"), (6, "k_gt_5"), (20, "k_gt_5")],
+)
+def test_k_bucket(k: int, expected: str) -> None:
+    assert k_bucket(k) == expected
+
+
+# ---------------------------------------------------------------------------
+# compute_completeness — core semantics
+# ---------------------------------------------------------------------------
+
+
+class TestComputeCompleteness:
+    def test_panel_complete_when_all_chunks_have_submitted_response(self) -> None:
+        records = [_make_record(chunk_id=f"c{i}", response_statuses=["submitted"]) for i in range(5)]
+        report = compute_completeness(_client({"retrieval_production": records}), _settings())
+        panel = report.by_uuid["uuid-a"]
+        assert panel == PanelCompleteness(
+            record_uuid="uuid-a",
+            k=5,
+            n_annotated_chunks=5,
+            n_submitted_chunks=5,
+            n_discarded_chunks=0,
+            panel_complete=True,
+            n_records_seen=5,
+        )
+        assert report.summary.n_panels == 1
+        assert report.summary.n_complete == 1
+        assert report.summary.fraction_complete == 1.0
+
+    def test_discarded_does_not_count_toward_panel_complete(self) -> None:
+        """STRICT default: a discarded-only chunk is NOT metric-covered.
+
+        DiscardReason is refusal-only (INVALID_OR_UNREALISTIC / UNCLEAR /
+        OUTSIDE_REVIEWER_EXPERTISE) — abstentions, not judgements. The
+        permissive view is still recoverable via n_annotated_chunks.
+        """
+        records = [
+            _make_record(chunk_id="c1", response_statuses=["submitted"]),
+            _make_record(chunk_id="c2", response_statuses=["submitted"]),
+            _make_record(chunk_id="c3", response_statuses=["discarded"]),
+            _make_record(chunk_id="c4", response_statuses=["submitted"]),
+            _make_record(chunk_id="c5", response_statuses=["discarded"]),
+        ]
+        report = compute_completeness(_client({"retrieval_production": records}), _settings())
+        panel = report.by_uuid["uuid-a"]
+        # STRICT: only 3 of 5 chunks are submitted → panel_complete False.
+        assert panel.panel_complete is False
+        assert panel.n_submitted_chunks == 3
+        assert panel.n_discarded_chunks == 2
+        # Permissive view stays recoverable: every chunk has SOME terminal response.
+        assert panel.n_annotated_chunks == 5
+        assert panel.n_annotated_chunks == panel.k  # consumer's permissive predicate
+
+    def test_partial_panel_not_complete(self) -> None:
+        records = [
+            _make_record(chunk_id="c1", response_statuses=["submitted"]),
+            _make_record(chunk_id="c2", response_statuses=["submitted"]),
+            _make_record(chunk_id="c3", response_statuses=[]),  # no responses yet
+            _make_record(chunk_id="c4", response_statuses=[]),
+            _make_record(chunk_id="c5", response_statuses=[]),
+        ]
+        report = compute_completeness(_client({"retrieval_production": records}), _settings())
+        panel = report.by_uuid["uuid-a"]
+        assert panel.panel_complete is False
+        assert panel.n_annotated_chunks == 2
+        assert panel.k == 5
+
+    def test_draft_only_response_does_not_count(self) -> None:
+        """Only submitted/discarded count as terminal; draft does not."""
+        records = [_make_record(chunk_id=f"c{i}", response_statuses=["draft"]) for i in range(5)]
+        report = compute_completeness(_client({"retrieval_production": records}), _settings())
+        assert report.by_uuid["uuid-a"].n_annotated_chunks == 0
+        assert report.by_uuid["uuid-a"].panel_complete is False
+
+    def test_distinct_by_chunk_id(self) -> None:
+        """Duplicate records for the same chunk_id count as one chunk."""
+        records = [
+            _make_record(chunk_id="c1", response_statuses=["submitted"]),
+            _make_record(chunk_id="c1", response_statuses=["submitted"]),  # duplicate
+            _make_record(chunk_id="c2", response_statuses=["submitted"]),
+        ]
+        report = compute_completeness(_client({"retrieval_production": records}), _settings())
+        assert report.by_uuid["uuid-a"].n_annotated_chunks == 2
+        assert report.by_uuid["uuid-a"].n_records_seen == 2
+
+    def test_orphan_record_skipped_and_counted(self) -> None:
+        """Records with empty record_uuid are excluded and counted in n_orphans_skipped."""
+        records = [
+            _make_record(record_uuid="", chunk_id="orphan"),
+            _make_record(record_uuid="uuid-a", chunk_id="c1", response_statuses=["submitted"]),
+        ]
+        report = compute_completeness(_client({"retrieval_production": records}), _settings())
+        assert "" not in report.by_uuid
+        assert "uuid-a" in report.by_uuid
+        assert report.summary.n_orphans_skipped == 1
+
+    def test_integrity_warning_when_records_seen_not_equal_k(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Saw fewer (or more) chunk-records than K → integrity warning logged + counter."""
+        records = [
+            _make_record(chunk_id="c1", n_retrieved_chunks=5, response_statuses=["submitted"]),
+            _make_record(chunk_id="c2", n_retrieved_chunks=5, response_statuses=["submitted"]),
+        ]
+        with caplog.at_level(logging.WARNING, logger="pragmata.core.annotation.completeness"):
+            report = compute_completeness(_client({"retrieval_production": records}), _settings())
+        assert report.summary.n_integrity_warnings == 1
+        assert any("integrity warning" in r.message for r in caplog.records)
+
+    def test_warns_on_mixed_backfill_state_within_panel(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Partial-backfill: some records carry n_retrieved_chunks, others don't.
+
+        records_seen matches k_max coincidentally, so the records-vs-K check
+        doesn't fire; the dedicated partial-backfill check should.
+        """
+        records = [
+            _make_record(chunk_id="c1", n_retrieved_chunks=3, response_statuses=["submitted"]),
+            _make_record(chunk_id="c2", n_retrieved_chunks=None, response_statuses=["submitted"]),
+            _make_record(chunk_id="c3", n_retrieved_chunks=None, response_statuses=["submitted"]),
+        ]
+        with caplog.at_level(logging.WARNING, logger="pragmata.core.annotation.completeness"):
+            report = compute_completeness(_client({"retrieval_production": records}), _settings())
+        assert report.summary.n_integrity_warnings == 1
+        assert any("partially backfilled" in r.message for r in caplog.records)
+
+    def test_warns_when_all_panels_have_unknown_k(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Pre-backfill: every record lacks n_retrieved_chunks.
+
+        Mirrors the panel_status warning; an export against a pre-backfill
+        dataset must not look like '0% complete because nobody annotated'.
+        """
+        records = [
+            _make_record(record_uuid="u1", chunk_id="c1", n_retrieved_chunks=None, response_statuses=["submitted"]),
+            _make_record(record_uuid="u2", chunk_id="c1", n_retrieved_chunks=None, response_statuses=["submitted"]),
+        ]
+        with caplog.at_level(logging.WARNING, logger="pragmata.core.annotation.completeness"):
+            compute_completeness(_client({"retrieval_production": records}), _settings())
+        assert any("ALL" in r.message and "unknown K" in r.message for r in caplog.records)
+
+    def test_inconsistent_k_across_records_uses_max_and_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        records = [
+            _make_record(chunk_id="c1", n_retrieved_chunks=5, response_statuses=["submitted"]),
+            _make_record(chunk_id="c2", n_retrieved_chunks=7, response_statuses=["submitted"]),
+        ]
+        with caplog.at_level(logging.WARNING, logger="pragmata.core.annotation.completeness"):
+            report = compute_completeness(_client({"retrieval_production": records}), _settings())
+        assert report.by_uuid["uuid-a"].k == 7
+        assert any("inconsistent n_retrieved_chunks" in r.message for r in caplog.records)
+
+    def test_k_zero_panel_is_not_complete(self) -> None:
+        """Missing/zero n_retrieved_chunks metadata never produces a complete panel."""
+        records = [_make_record(chunk_id="c1", n_retrieved_chunks=None, response_statuses=["submitted"])]
+        report = compute_completeness(_client({"retrieval_production": records}), _settings())
+        panel = report.by_uuid["uuid-a"]
+        assert panel.k == 0
+        assert panel.panel_complete is False
+
+    def test_calibration_dataset_walked_when_enabled(self) -> None:
+        """When calibration is declared, both prod and cal datasets are fetched."""
+        prod_records = [
+            _make_record(record_uuid="u-prod", chunk_id="c1", response_statuses=["submitted"], n_retrieved_chunks=1)
+        ]
+        cal_records = [
+            _make_record(record_uuid="u-cal", chunk_id="c1", response_statuses=["submitted"], n_retrieved_chunks=1)
+        ]
+        client = _client({"retrieval_production": prod_records, "retrieval_calibration": cal_records})
+        report = compute_completeness(client, _settings(with_calibration=True))
+        assert set(report.by_uuid.keys()) == {"u-prod", "u-cal"}
+        assert report.summary.n_panels == 2
+        assert report.summary.n_complete == 2
+
+    def test_calibration_skipped_when_topology_disables(self) -> None:
+        """Without calibration_min_submitted, the cal dataset is not fetched."""
+        prod_records = [
+            _make_record(record_uuid="u-prod", chunk_id="c1", response_statuses=["submitted"], n_retrieved_chunks=1)
+        ]
+        cal_records = [_make_record(record_uuid="u-cal")]
+        client = _client({"retrieval_production": prod_records, "retrieval_calibration": cal_records})
+        report = compute_completeness(client, _settings(with_calibration=False))
+        assert "u-cal" not in report.by_uuid
+        assert "u-prod" in report.by_uuid
+
+    def test_missing_dataset_is_skipped_silently(self) -> None:
+        """A None dataset (e.g. cal not yet created) doesn't break the walk."""
+        client = _client({})  # no datasets
+        report = compute_completeness(client, _settings())
+        assert report.by_uuid == {}
+        assert report.summary.n_panels == 0
+        assert report.summary.fraction_complete == 0.0
+
+    def test_by_k_bucket_cross_tab(self) -> None:
+        """Panels are bucketed by K (<5, =5, >5) with per-bucket complete counts."""
+
+        def panel(uuid: str, k: int, n_terminal: int) -> list[MagicMock]:
+            return [
+                _make_record(
+                    record_uuid=uuid,
+                    chunk_id=f"{uuid}-c{i}",
+                    n_retrieved_chunks=k,
+                    response_statuses=["submitted"] if i < n_terminal else [],
+                )
+                for i in range(k)
+            ]
+
+        records = (
+            panel("small-complete", k=3, n_terminal=3)
+            + panel("small-partial", k=3, n_terminal=1)
+            + panel("five-complete", k=5, n_terminal=5)
+            + panel("big-partial", k=7, n_terminal=4)
+        )
+        report = compute_completeness(_client({"retrieval_production": records}), _settings())
+        buckets = report.summary.by_k_bucket
+        assert buckets["k_lt_5"].n_panels == 2
+        assert buckets["k_lt_5"].n_complete == 1
+        assert buckets["k_eq_5"].n_panels == 1
+        assert buckets["k_eq_5"].n_complete == 1
+        assert buckets["k_gt_5"].n_panels == 1
+        assert buckets["k_gt_5"].n_complete == 0
+        assert report.summary.n_panels == 4
+        assert report.summary.n_complete == 2
+        assert report.summary.fraction_complete == pytest.approx(0.5)


### PR DESCRIPTION
**Stack (6 PRs):** #246 (merged) → #247 → #268 → #248 → #269 → #249

**Chain goal:** Persist K (number of retrieved chunks per query) on retrieval records, surface it as panel-completeness columns + sidecar at export time, ship a live `annotation status` CLI on top, and add an opt-in `--tag-partial-panels` advisory write so annotators can filter partially-done panels in the Argilla UI.

**This PR (2/6):** The standalone, export-agnostic panel-completeness calculator, plus the shared retrieval-walk primitive it and #268 both consume. Split out of what was originally a single ~1000-line PR; wiring completeness into the retrieval export path ships separately in #268.

---

## Scope

### Completeness aggregator
- New `core/annotation/completeness.py`: groups retrieval snapshots by `record_uuid`, distinct-by-`chunk_id`, derives per-panel facts, emits `CompletenessReport` (`by_uuid` + `summary`). Aggregation is split into a typed `_PanelAccumulator` plus `_aggregate_snapshots` (grouping) / `_summarize_groups` (transform) passes.

### Shared retrieval walk
- `core/annotation/export_fetcher.py`: `RetrievalRecordSnapshot` + `walk_retrieval_records` — one Argilla scroll, no status filter (so records lacking terminal responses are still seen for the integrity check), feeding both this module's completeness pass and #268's row emission. Plus `resolve_task_purposes`, a topology lookup extracted from `fetch_task` (no behaviour change).

### Schema
- `core/schemas/annotation_export.py`: `CompletenessSummary` + `KBucketStat` models for the export sidecar (populated by #268).

### Tests
- New `test_completeness.py`: happy path, distinct-by-chunk_id, orphan exclusion, integrity warnings (records-vs-K + mixed-backfill within panel), all-unknown-K warning, K-bucket cross-tab + per-K histogram, STRICT `panel_complete` (discards do NOT count), `n_discarded_chunks` subset of `n_annotated_chunks`, calibration walked when topology declares it.

## Why STRICT `panel_complete`

The computed `panel_complete: bool` is STRICT: True iff every K chunk in the panel has at least one **submitted** response. Discarded responses are abstentions, not judgements (pragmata's `DiscardReason` enum is refusal-only: `INVALID_OR_UNREALISTIC` / `UNCLEAR` / `OUTSIDE_REVIEWER_EXPERTISE`), so treating them as covered would feed unjudged chunks into NDCG@K / precision@K denominators as 0-relevance labels. The bool is derivable from the count columns, so a consumer wanting the permissive policy computes `n_annotated_chunks == n_retrieved_chunks` in one line.

The retriever is threshold-based, so dropping partial panels biases metrics toward small K (MNAR); this module is the shared calculation both the export path (#268) and the live status path (#248) build on — one aggregator, two consumers.

## Test plan
- [x] `uv run python -m pytest tests/unit` (1040 passing)
