### PR TITLE
feat(annotation): panel-status core engine

### DIFF
--- a/src/pragmata/core/annotation/panel_status.py
+++ b/src/pragmata/core/annotation/panel_status.py
@@ -1,0 +1,417 @@
+"""Live read-only panel status across all retrieval datasets.
+
+For each retrieval panel (one query = ``(workspace, record_uuid)``, K chunks)
+reports two distinct notions of "complete":
+
+- ``panel_complete`` (metric-facing, STRICT) = all K chunks have at least
+  one SUBMITTED response. Discards are abstentions, not judgements, so they
+  don't count toward "ready for eval scoring" - see completeness.py.
+- ``overlap_satisfied`` (operational) = every chunk's submitted-response count
+  is >= the dataset's annotator overlap target (Argilla ``min_submitted``;
+  typically 1 for production, 3 for calibration - the term used throughout
+  the daily report's IAA tables). This is the readiness signal for
+  Krippendorff's alpha, distinct from merely having a first opinion: a panel
+  can be complete but overlap-unsatisfied (e.g. 1-of-3 calibration votes in).
+
+The walk is CONFIG-FREE: it enumerates the live datasets and selects retrieval
+ones by name prefix (``retrieval`` / ``retrieval_*``), so it covers every
+workspace/domain in one pass rather than a single configured workspace. Panels
+are keyed by ``(workspace, record_uuid)``: retrieval is split across one
+workspace per domain, so the same ``record_uuid`` can recur across domains (it
+also links a query across the grounding/generation workspaces). Keying by the
+bare uuid would fuse those distinct panels once the walk is multi-domain.
+
+``min_submitted`` is read from each dataset's live Argilla settings
+(``dataset.settings.distribution.min_submitted``), not local config - for a
+live status report, what the server enforces is the source of truth.
+
+Headline totals come from ``dataset.progress()`` aggregated across the walked
+datasets.
+
+K is computed by COUNTING distinct chunk-records per panel (every chunk became
+a record at import; records are never deleted). This is distinct from the
+export-time completeness which sources K from the ``n_retrieved_chunks``
+metadata; the live K is the ground truth pre-backfill and the metadata is
+cross-checked for integrity.
+
+Pure read; safe to invoke against live datasets without side effects. The
+optional ``--tag-partial-panels`` advisory write that stamps records for
+annotator UI filtering ships in a follow-up PR (separates the read path from
+any Argilla mutation surface).
+"""
+
+import logging
+from collections.abc import Hashable, Iterator
+from dataclasses import dataclass, replace
+
+import argilla as rg
+
+logger = logging.getLogger(__name__)
+
+# Terminal response statuses = a judgement was recorded (vs pending/draft).
+# Mirrors the inline ``{"submitted", "discarded"}`` in export_fetcher; kept
+# local so the status read path carries no import-time coupling to export.
+_TERMINAL_STATUSES = frozenset({"submitted", "discarded"})
+
+RETRIEVAL_TASK = "retrieval"
+_TASK_ORDER = {"retrieval": 0, "grounding": 1, "generation": 2}
+
+
+def _task_of(dataset_name: str) -> str:
+    """Task label for a dataset = its name prefix before the first underscore."""
+    return dataset_name.split("_", 1)[0]
+
+
+def _select_datasets(client: rg.Argilla, workspace: str | None, task: str | None) -> Iterator[rg.Dataset]:
+    """Config-free dataset selection: iterate the live server, filter by name.
+
+    ``task`` matches a dataset-name prefix (e.g. ``retrieval`` matches
+    ``retrieval_production`` / ``retrieval_calibration``); ``workspace`` is an
+    exact workspace-name filter. ``None`` means no filter on that axis. No
+    ``AnnotationSettings`` needed, so status covers every workspace at once.
+    """
+    for ds in client.datasets:
+        if workspace is not None and ds.workspace.name != workspace:
+            continue
+        if task is not None and ds.name != task and not ds.name.startswith(f"{task}_"):
+            continue
+        yield ds
+
+
+def _dataset_min_submitted(dataset: rg.Dataset) -> int:
+    """Read the dataset's Argilla ``min_submitted`` overlap threshold, live.
+
+    Sourced from ``dataset.settings.distribution`` (the SDK never leaves this
+    None - it defaults to ``min_submitted=1``), so status needs no local
+    topology config to compute distribution-satisfaction.
+    """
+    return int(getattr(dataset.settings.distribution, "min_submitted", 1))
+
+
+@dataclass(frozen=True)
+class PanelStatus:
+    """Live status facts for one retrieval panel (one ``(workspace, record_uuid)``)."""
+
+    workspace: str
+    record_uuid: str
+    k_records: int  # distinct chunk-records seen (live K)
+    k_metadata: int  # n_retrieved_chunks metadata (0 if missing)
+    n_terminal: int  # distinct chunks with >=1 terminal response (submitted OR discarded)
+    n_submitted: int  # distinct chunks with >=1 submitted response (used by panel_complete)
+    panel_complete: bool  # STRICT: k_records > 0 and n_submitted == k_records
+    overlap_satisfied: bool  # every chunk meets its dataset's annotator overlap (min_submitted)
+    integrity_ok: bool  # k_records == k_metadata (when metadata present)
+
+
+@dataclass(frozen=True)
+class HeadlineTotals:
+    """Aggregate counts from ``dataset.progress()`` across walked datasets."""
+
+    total: int
+    completed: int
+    pending: int
+
+
+@dataclass(frozen=True)
+class ProgressRow:
+    """Record-level progress for one grouping (a task, a workspace, or a dataset)."""
+
+    label: str  # display label: task name, workspace name, or "workspace/dataset"
+    task: str  # the task this row belongs to (equals label for by-task rows)
+    total: int
+    completed: int  # records that reached their Argilla min_submitted
+    pending: int
+
+
+@dataclass(frozen=True)
+class ProgressReport:
+    """All-task record progress from ``dataset.progress()``, grouped three ways."""
+
+    grand: HeadlineTotals
+    by_task: list[ProgressRow]
+    by_workspace: list[ProgressRow]
+    by_dataset: list[ProgressRow]
+
+
+@dataclass(frozen=True)
+class StatusReport:
+    """Live per-panel status + headline aggregates.
+
+    ``progress`` (all-task record counts) is attached by ``report_status``; the
+    panel fields below are retrieval-only.
+    """
+
+    panels: dict[tuple[str, str], PanelStatus]
+    headline: HeadlineTotals
+    n_panels: int
+    n_complete: int
+    n_overlap_satisfied: int
+    n_integrity_warnings: int
+    n_orphans_skipped: int
+    progress: "ProgressReport | None" = None
+
+    def with_progress(self, progress: ProgressReport) -> "StatusReport":
+        """Return a copy with the all-task ``progress`` summary attached."""
+        return replace(self, progress=progress)
+
+
+@dataclass
+class _ChunkRecord:
+    """Internal: live record snapshot for status + tag passes."""
+
+    record: rg.Record  # argilla record handle (needed for tag write)
+    dataset: rg.Dataset  # owning dataset (needed for tag write)
+    workspace: str  # owning workspace name (panel grouping key)
+    record_uuid: str
+    chunk_id: str
+    min_submitted: int  # this dataset's Argilla overlap threshold (live-sourced)
+    n_retrieved_chunks_metadata: int
+    has_terminal: bool  # >=1 response in {submitted, discarded}
+    has_submitted: bool  # >=1 response with status == submitted (subset of has_terminal)
+    n_submitted_responses: int
+
+
+@dataclass(frozen=True)
+class _CollectedRecords:
+    """Internal: output of one config-free walk across the selected datasets."""
+
+    records: list[_ChunkRecord]
+    n_orphans: int
+    headline: HeadlineTotals
+
+
+def _collect_records(
+    client: rg.Argilla, *, workspace: str | None = None, task: str | None = RETRIEVAL_TASK
+) -> _CollectedRecords:
+    """Single config-free walk across the selected retrieval datasets."""
+    records: list[_ChunkRecord] = []
+    n_orphans = 0
+    totals = {"total": 0, "completed": 0, "pending": 0}
+    for dataset in _select_datasets(client, workspace, task):
+        ws_name = dataset.workspace.name
+        min_submitted = _dataset_min_submitted(dataset)
+        progress = dataset.progress()
+        for key in totals:
+            totals[key] += int(progress.get(key, 0) or 0)
+        for record in dataset.records(with_responses=True):
+            record_uuid: str = record.metadata.get("record_uuid", "")
+            if not record_uuid:
+                n_orphans += 1
+                continue
+            chunk_id: str = record.metadata.get("chunk_id", "")
+            k_meta = int(record.metadata.get("n_retrieved_chunks") or 0)
+            # Single pass over responses: terminal-presence + submitted-count + has-submitted.
+            has_terminal = False
+            has_submitted = False
+            n_submitted = 0
+            for r in record.responses or []:
+                if r.status == "submitted":
+                    n_submitted += 1
+                    has_submitted = True
+                    has_terminal = True
+                elif r.status in _TERMINAL_STATUSES:
+                    has_terminal = True
+            records.append(
+                _ChunkRecord(
+                    record=record,
+                    dataset=dataset,
+                    workspace=ws_name,
+                    record_uuid=record_uuid,
+                    chunk_id=chunk_id,
+                    min_submitted=min_submitted,
+                    n_retrieved_chunks_metadata=k_meta,
+                    has_terminal=has_terminal,
+                    has_submitted=has_submitted,
+                    n_submitted_responses=n_submitted,
+                )
+            )
+    return _CollectedRecords(records=records, n_orphans=n_orphans, headline=HeadlineTotals(**totals))
+
+
+@dataclass(frozen=True)
+class _PanelFacts:
+    """Derived facts for one panel: shared by status and tag passes.
+
+    Computed once per panel so the two consumers cannot drift on the
+    panel_complete predicate or the K-source semantics.
+    """
+
+    record_uuid: str
+    group: list[_ChunkRecord]
+    chunk_ids_terminal: set[str]
+    chunk_ids_submitted: set[str]
+    chunk_ids_seen: set[str]
+    k_records: int  # distinct chunk_ids in this panel (live K)
+    k_metadata: int  # n_retrieved_chunks metadata (max if records disagree; 0 if absent)
+    panel_complete: bool  # STRICT: k_records > 0 AND every chunk has a SUBMITTED response
+
+
+def _group_by_panel(records: list[_ChunkRecord]) -> dict[tuple[str, str], list[_ChunkRecord]]:
+    """Group by ``(workspace, record_uuid)`` - the panel identity across datasets.
+
+    Keyed by workspace too, not the bare uuid: retrieval spans one workspace
+    per domain, so the same ``record_uuid`` recurs across domains (and, more
+    broadly, across a query's grounding/generation workspaces). A bare-uuid key
+    would fuse those distinct panels once the walk is multi-domain.
+    """
+    groups: dict[tuple[str, str], list[_ChunkRecord]] = {}
+    for rec in records:
+        groups.setdefault((rec.workspace, rec.record_uuid), []).append(rec)
+    return groups
+
+
+def _panel_facts(uuid: str, group: list[_ChunkRecord]) -> _PanelFacts:
+    """Aggregate one panel's facts. Logs inconsistent-K-across-records as a warning."""
+    chunk_ids_seen = {r.chunk_id for r in group}
+    chunk_ids_terminal = {r.chunk_id for r in group if r.has_terminal}
+    chunk_ids_submitted = {r.chunk_id for r in group if r.has_submitted}
+    k_values = {r.n_retrieved_chunks_metadata for r in group if r.n_retrieved_chunks_metadata > 0}
+    if len(k_values) > 1:
+        logger.warning(
+            "record_uuid=%s: inconsistent n_retrieved_chunks across records: %s - using max",
+            uuid,
+            sorted(k_values),
+        )
+    k_metadata = max(k_values, default=0)
+    k_records = len(chunk_ids_seen)
+    return _PanelFacts(
+        record_uuid=uuid,
+        group=group,
+        chunk_ids_terminal=chunk_ids_terminal,
+        chunk_ids_submitted=chunk_ids_submitted,
+        chunk_ids_seen=chunk_ids_seen,
+        k_records=k_records,
+        k_metadata=k_metadata,
+        # STRICT default - see module docstring.
+        panel_complete=k_records > 0 and len(chunk_ids_submitted) == k_records,
+    )
+
+
+def _build_report(collected: _CollectedRecords) -> StatusReport:
+    """Build StatusReport from already-collected records. Pure aggregation."""
+    panels: dict[tuple[str, str], PanelStatus] = {}
+    n_complete = 0
+    n_overlap_satisfied = 0
+    n_integrity_warnings = 0
+    n_panels_unknown_k = 0
+    for (ws_name, uuid), group in _group_by_panel(collected.records).items():
+        facts = _panel_facts(uuid, group)
+        # Overlap: sum submitted responses PER chunk_id (so duplicate
+        # chunk-records for one chunk_id don't each get checked separately
+        # against the threshold). Each chunk-record carries its own dataset's
+        # min_submitted; if a chunk spans prod+cal (rare), require the higher.
+        submitted_by_chunk: dict[str, int] = {}
+        threshold_by_chunk: dict[str, int] = {}
+        for rec in group:
+            submitted_by_chunk[rec.chunk_id] = submitted_by_chunk.get(rec.chunk_id, 0) + rec.n_submitted_responses
+            threshold_by_chunk[rec.chunk_id] = max(threshold_by_chunk.get(rec.chunk_id, 0), rec.min_submitted)
+        overlap_satisfied = all(n >= threshold_by_chunk[cid] for cid, n in submitted_by_chunk.items())
+        integrity_ok = facts.k_metadata == 0 or facts.k_metadata == facts.k_records
+        if not integrity_ok:
+            logger.warning(
+                "record_uuid=%s: integrity warning - %d records but n_retrieved_chunks metadata=%d",
+                uuid,
+                facts.k_records,
+                facts.k_metadata,
+            )
+            n_integrity_warnings += 1
+        if facts.k_metadata == 0:
+            n_panels_unknown_k += 1
+        if facts.panel_complete:
+            n_complete += 1
+        if overlap_satisfied:
+            n_overlap_satisfied += 1
+        panels[(ws_name, uuid)] = PanelStatus(
+            workspace=ws_name,
+            record_uuid=uuid,
+            k_records=facts.k_records,
+            k_metadata=facts.k_metadata,
+            n_terminal=len(facts.chunk_ids_terminal),
+            n_submitted=len(facts.chunk_ids_submitted),
+            panel_complete=facts.panel_complete,
+            overlap_satisfied=overlap_satisfied,
+            integrity_ok=integrity_ok,
+        )
+
+    if collected.n_orphans:
+        logger.warning(
+            "panel status: %d retrieval record(s) skipped (empty record_uuid metadata)",
+            collected.n_orphans,
+        )
+    if panels and n_panels_unknown_k == len(panels):
+        # Most likely cause: the n_retrieved_chunks backfill has not been run
+        # against this dataset yet, so panel_complete reads as False across
+        # the board for the WRONG reason. Surface this so operators don't
+        # interpret 0% as "annotators haven't started".
+        logger.warning(
+            "panel status: ALL %d panel(s) have unknown K (n_retrieved_chunks metadata absent) - "
+            "run scripts/backfill_n_retrieved_chunks.py to populate it.",
+            len(panels),
+        )
+
+    return StatusReport(
+        panels=panels,
+        headline=collected.headline,
+        n_panels=len(panels),
+        n_complete=n_complete,
+        n_overlap_satisfied=n_overlap_satisfied,
+        n_integrity_warnings=n_integrity_warnings,
+        n_orphans_skipped=collected.n_orphans,
+    )
+
+
+def compute_panel_status(
+    client: rg.Argilla, *, workspace: str | None = None, task: str | None = RETRIEVAL_TASK
+) -> StatusReport:
+    """Compute live per-panel status across the selected retrieval datasets.
+
+    Config-free: walks every matching dataset (all workspaces by default).
+    Pure read; safe to invoke against live datasets without side effects.
+    """
+    return _build_report(_collect_records(client, workspace=workspace, task=task))
+
+
+def compute_task_progress(client: rg.Argilla, *, workspace: str | None = None) -> ProgressReport:
+    """All-task record progress from ``dataset.progress()``.
+
+    Grouped by task, workspace, and dataset. Config-free and cheap: one
+    ``progress()`` call per dataset (no record iteration), covering every
+    task/workspace in one pass. Rows are ordered retrieval -> grounding ->
+    generation, then by workspace/dataset name.
+    """
+    grand = {"total": 0, "completed": 0, "pending": 0}
+    by_task: dict[str, dict[str, int]] = {}
+    by_ws: dict[tuple[str, str], dict[str, int]] = {}
+    by_ds: dict[tuple[str, str, str], dict[str, int]] = {}
+
+    def _acc(bucket: dict[str, int], p: dict) -> None:
+        for key in bucket:
+            bucket[key] += int(p.get(key, 0) or 0)
+
+    def _bucket(store: dict, key: Hashable) -> dict[str, int]:
+        return store.setdefault(key, {"total": 0, "completed": 0, "pending": 0})
+
+    for ds in _select_datasets(client, workspace, task=None):
+        task = _task_of(ds.name)
+        ws_name = ds.workspace.name
+        p = dict(ds.progress())
+        _acc(grand, p)
+        _acc(_bucket(by_task, task), p)
+        _acc(_bucket(by_ws, (ws_name, task)), p)
+        _acc(_bucket(by_ds, (ws_name, ds.name, task)), p)
+
+    def _row(label: str, task: str, b: dict[str, int]) -> ProgressRow:
+        return ProgressRow(label=label, task=task, total=b["total"], completed=b["completed"], pending=b["pending"])
+
+    task_rows = [_row(t, t, b) for t, b in sorted(by_task.items(), key=lambda kv: _TASK_ORDER.get(kv[0], 99))]
+    ws_rows = [
+        _row(ws, task, b)
+        for (ws, task), b in sorted(by_ws.items(), key=lambda kv: (_TASK_ORDER.get(kv[0][1], 99), kv[0][0]))
+    ]
+    ds_rows = [
+        _row(f"{ws}/{name}", task, b)
+        for (ws, name, task), b in sorted(
+            by_ds.items(), key=lambda kv: (_TASK_ORDER.get(kv[0][2], 99), kv[0][0], kv[0][1])
+        )
+    ]
+    return ProgressReport(grand=HeadlineTotals(**grand), by_task=task_rows, by_workspace=ws_rows, by_dataset=ds_rows)

--- a/tests/unit/core/annotation/test_panel_status.py
+++ b/tests/unit/core/annotation/test_panel_status.py
@@ -1,0 +1,253 @@
+"""Unit tests for live panel status (read-only, config-free)."""
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from pragmata.core.annotation.panel_status import compute_panel_status, compute_task_progress
+
+WS = "dom_retrieval"
+
+
+def _record(
+    *,
+    record_id: str = "rec-x",
+    record_uuid: str = "u1",
+    chunk_id: str = "c1",
+    n_retrieved_chunks: int | None = None,
+    response_statuses: list[str] | None = None,
+) -> MagicMock:
+    metadata: dict[str, object] = {"record_uuid": record_uuid, "chunk_id": chunk_id}
+    if n_retrieved_chunks is not None:
+        metadata["n_retrieved_chunks"] = n_retrieved_chunks
+    rec = MagicMock()
+    rec.id = record_id
+    rec.metadata = metadata
+    responses = []
+    for s in response_statuses or []:
+        r = MagicMock()
+        r.status = s
+        responses.append(r)
+    rec.responses = responses
+    return rec
+
+
+def _dataset(
+    name: str,
+    records: list[MagicMock],
+    *,
+    workspace: str = WS,
+    min_submitted: int = 1,
+    progress: dict | None = None,
+) -> MagicMock:
+    """A config-free dataset handle: name + workspace + records + live min_submitted."""
+    ds = MagicMock()
+    ds.name = name
+    ds.workspace.name = workspace
+    ds.records.side_effect = lambda *a, **kw: iter(records)
+    ds.progress.return_value = progress or {"total": 0, "completed": 0, "pending": 0}
+    ds.settings.distribution.min_submitted = min_submitted
+    return ds
+
+
+def _client(datasets: list[MagicMock]) -> MagicMock:
+    """Config-free client: ``client.datasets`` is the iterable of dataset handles."""
+    client = MagicMock()
+    client.datasets = list(datasets)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# compute_panel_status
+# ---------------------------------------------------------------------------
+
+
+class TestComputePanelStatus:
+    def test_headline_aggregated_from_progress(self) -> None:
+        records = [_record(chunk_id=f"c{i}", response_statuses=["submitted"]) for i in range(3)]
+        report = compute_panel_status(
+            _client([_dataset("retrieval_production", records, progress={"total": 10, "completed": 4, "pending": 6})])
+        )
+        assert report.headline.total == 10
+        assert report.headline.completed == 4
+        assert report.headline.pending == 6
+
+    def test_panel_complete_when_every_chunk_has_terminal(self) -> None:
+        records = [_record(chunk_id=f"c{i}", response_statuses=["submitted"]) for i in range(5)]
+        report = compute_panel_status(_client([_dataset("retrieval_production", records)]))
+        panel = report.panels[(WS, "u1")]
+        assert panel.panel_complete is True
+        assert panel.k_records == 5
+        assert panel.n_terminal == 5
+
+    def test_label_vs_overlap_diverges_in_calibration(self) -> None:
+        """One submitted response per cal chunk → panel_complete but NOT overlap_satisfied (cal needs 3)."""
+        cal_records = [
+            _record(record_uuid="u-cal", chunk_id=f"c{i}", response_statuses=["submitted"]) for i in range(3)
+        ]
+        report = compute_panel_status(
+            _client(
+                [
+                    _dataset("retrieval_production", []),
+                    _dataset("retrieval_calibration", cal_records, min_submitted=3),
+                ]
+            )
+        )
+        panel = report.panels[(WS, "u-cal")]
+        assert panel.panel_complete is True
+        assert panel.overlap_satisfied is False
+
+    def test_overlap_satisfied_when_three_submitted_in_calibration(self) -> None:
+        cal_records = [
+            _record(record_uuid="u-cal", chunk_id=f"c{i}", response_statuses=["submitted", "submitted", "submitted"])
+            for i in range(3)
+        ]
+        report = compute_panel_status(_client([_dataset("retrieval_calibration", cal_records, min_submitted=3)]))
+        panel = report.panels[(WS, "u-cal")]
+        assert panel.panel_complete is True
+        assert panel.overlap_satisfied is True
+
+    def test_min_submitted_read_from_live_dataset_settings(self) -> None:
+        """overlap_satisfied uses each dataset's live min_submitted, not config."""
+        # 2 submitted on the only chunk; dataset says it needs 3 → not satisfied.
+        records = [_record(record_uuid="u1", chunk_id="c1", response_statuses=["submitted", "submitted"])]
+        report = compute_panel_status(_client([_dataset("retrieval_calibration", records, min_submitted=3)]))
+        assert report.panels[(WS, "u1")].overlap_satisfied is False
+
+    def test_integrity_warning_when_records_mismatch_metadata_k(self, caplog: pytest.LogCaptureFixture) -> None:
+        records = [
+            _record(chunk_id="c1", n_retrieved_chunks=5, response_statuses=["submitted"]),
+            _record(chunk_id="c2", n_retrieved_chunks=5, response_statuses=["submitted"]),
+        ]
+        with caplog.at_level(logging.WARNING, logger="pragmata.core.annotation.panel_status"):
+            report = compute_panel_status(_client([_dataset("retrieval_production", records)]))
+        panel = report.panels[(WS, "u1")]
+        assert panel.integrity_ok is False
+        assert report.n_integrity_warnings == 1
+        assert any("integrity warning" in r.message for r in caplog.records)
+
+    def test_integrity_ok_when_metadata_absent(self) -> None:
+        """No metadata K → integrity_ok=True (skips the check). Pre-backfill state."""
+        records = [_record(chunk_id="c1", n_retrieved_chunks=None, response_statuses=["submitted"])]
+        report = compute_panel_status(_client([_dataset("retrieval_production", records)]))
+        assert report.panels[(WS, "u1")].integrity_ok is True
+
+    def test_orphan_record_excluded(self) -> None:
+        records = [
+            _record(record_uuid="", chunk_id="orphan"),
+            _record(record_uuid="u1", chunk_id="c1", response_statuses=["submitted"]),
+        ]
+        report = compute_panel_status(_client([_dataset("retrieval_production", records)]))
+        assert (WS, "") not in report.panels
+        assert report.n_orphans_skipped == 1
+
+    def test_walks_prod_and_cal(self) -> None:
+        prod = [_record(record_uuid="u-prod", chunk_id="c1", response_statuses=["submitted"])]
+        cal = [_record(record_uuid="u-cal", chunk_id="c1", response_statuses=["submitted"])]
+        report = compute_panel_status(
+            _client([_dataset("retrieval_production", prod), _dataset("retrieval_calibration", cal, min_submitted=3)])
+        )
+        assert set(report.panels) == {(WS, "u-prod"), (WS, "u-cal")}
+
+    def test_same_uuid_in_two_workspaces_not_fused(self) -> None:
+        """Multi-domain walk: identical record_uuid in two workspaces stays two panels."""
+        d1 = _dataset(
+            "retrieval_production",
+            [_record(record_uuid="u1", chunk_id="c1", response_statuses=["submitted"])],
+            workspace="dom1_retrieval",
+        )
+        d2 = _dataset(
+            "retrieval_production",
+            [_record(record_uuid="u1", chunk_id="c1", response_statuses=[])],
+            workspace="dom2_retrieval",
+        )
+        report = compute_panel_status(_client([d1, d2]))
+        assert set(report.panels) == {("dom1_retrieval", "u1"), ("dom2_retrieval", "u1")}
+        assert report.panels[("dom1_retrieval", "u1")].panel_complete is True
+        assert report.panels[("dom2_retrieval", "u1")].panel_complete is False
+
+    def test_non_retrieval_datasets_are_skipped(self) -> None:
+        """Default task='retrieval' selects by name prefix; other tasks are ignored."""
+        report = compute_panel_status(
+            _client(
+                [
+                    _dataset("generation_production", [_record(record_uuid="g1", chunk_id="c1")]),
+                    _dataset(
+                        "retrieval_production",
+                        [_record(record_uuid="u1", chunk_id="c1", response_statuses=["submitted"])],
+                    ),
+                ]
+            )
+        )
+        assert set(report.panels) == {(WS, "u1")}
+
+
+class TestComputePanelStatusEdgeCases:
+    def test_overlap_aggregates_submissions_across_duplicate_chunk_records(self) -> None:
+        """If a single chunk_id has two records (rare anomaly), submissions sum across them."""
+        rec_a = _record(record_uuid="u-cal", chunk_id="c1", response_statuses=["submitted", "submitted"])
+        rec_b = _record(record_uuid="u-cal", chunk_id="c1", response_statuses=["submitted", "submitted"])
+        report = compute_panel_status(_client([_dataset("retrieval_calibration", [rec_a, rec_b], min_submitted=3)]))
+        panel = report.panels[(WS, "u-cal")]
+        assert panel.overlap_satisfied is True
+
+    def test_warns_when_all_panels_have_unknown_k(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Pre-backfill: all records missing n_retrieved_chunks → distinct warning."""
+        records = [
+            _record(record_uuid="u1", chunk_id="c1", n_retrieved_chunks=None, response_statuses=["submitted"]),
+            _record(record_uuid="u2", chunk_id="c1", n_retrieved_chunks=None, response_statuses=["submitted"]),
+        ]
+        with caplog.at_level(logging.WARNING, logger="pragmata.core.annotation.panel_status"):
+            compute_panel_status(_client([_dataset("retrieval_production", records)]))
+        assert any("unknown K" in r.message for r in caplog.records)
+
+
+class TestComputeTaskProgress:
+    def test_groups_by_task_workspace_dataset(self) -> None:
+        client = _client(
+            [
+                _dataset(
+                    "retrieval_production",
+                    [],
+                    workspace="A_retrieval",
+                    progress={"total": 100, "completed": 10, "pending": 90},
+                ),
+                _dataset(
+                    "grounding_production",
+                    [],
+                    workspace="A_grounding",
+                    progress={"total": 20, "completed": 5, "pending": 15},
+                ),
+                _dataset(
+                    "generation_production",
+                    [],
+                    workspace="A_generation",
+                    progress={"total": 30, "completed": 9, "pending": 21},
+                ),
+            ]
+        )
+        pr = compute_task_progress(client)
+        # grand total across all tasks
+        assert (pr.grand.total, pr.grand.completed, pr.grand.pending) == (150, 24, 126)
+        # by-task ordered retrieval -> grounding -> generation
+        assert [r.task for r in pr.by_task] == ["retrieval", "grounding", "generation"]
+        assert pr.by_task[0].total == 100
+        # by-workspace and by-dataset carry the same numbers, labelled differently
+        assert {r.label for r in pr.by_workspace} == {"A_retrieval", "A_grounding", "A_generation"}
+        assert any(r.label == "A_retrieval/retrieval_production" for r in pr.by_dataset)
+
+    def test_all_tasks_present_even_with_zero_progress(self) -> None:
+        client = _client(
+            [
+                _dataset(
+                    "grounding_production",
+                    [],
+                    workspace="B_grounding",
+                    progress={"total": 5, "completed": 0, "pending": 5},
+                )
+            ]
+        )
+        pr = compute_task_progress(client)
+        assert [r.task for r in pr.by_task] == ["grounding"]
+        assert pr.grand.completed == 0


### PR DESCRIPTION
**Stack (6 PRs):** #246 → #247 → #268 → #248 → #269 → #249

**This PR (4/6):** Core engine for live per-panel completeness + all-task progress, computed directly against Argilla (no export round-trip). Exposed via CLI/API in #269. Stacked on #268.

- **All tasks**: walks every dataset and computes record progress (total / completed) across `retrieval` / `grounding` / `generation`.
- **Retrieval panels**: the retrieval row also carries panel-completeness (`panel_complete` = all K chunks have ≥1 submitted, `overlap_satisfied` = each chunk meets its `min_submitted`, integrity vs `n_retrieved_chunks`).
- **Config-free + multi-domain**: selects datasets by name-prefix (no `AnnotationSettings`), covering every workspace in one pass. Panels keyed by `(workspace, record_uuid)`. `min_submitted` read live from each dataset's Argilla settings.

The CLI/API surface (`pragmata annotation status`) ships in #269. The `--tag-partial-panels` write ships in #249.