### PR TITLE
ci: avoid reapplying type labels after PR updates

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -6,7 +6,6 @@ on:
       - opened
       - reopened
       - synchronize
-      - edited
 
 permissions:
   contents: read
@@ -23,12 +22,10 @@ jobs:
 
     steps:
       - name: Apply type labels
+        if: github.event.action == 'opened' || github.event.action == 'reopened'
         uses: actions/labeler@v6
-        with:
-          sync-labels: false
 
       - name: Apply size label
-        if: github.event.action != 'edited'
         uses: codelytv/pr-size-labeler@v1
         with:
           xs_label: 'size: XS'


### PR DESCRIPTION
### Summary 

Updates the PR labeler workflow so type labels are only applied when a pull request is opened or reopened. Size labels still update on branch pushes, but branch-name-derived type labels are no longer reapplied on every `synchronize` event. This allows maintainers to manually correct labels, for example changing `feature` to `fix`, without the workflow reverting that change on the next push.

### Changes 

- Remove the unused `edited` trigger from the PR labeler workflow.
- Run `actions/labeler` only on `opened` and `reopened` events.
- Keep the PR size labeler active on `synchronize` so size labels remain current.

### Notes

This keeps type labels as an initial branch-name-based suggestion while preserving manual maintainer overrides afterward.