### PR TITLE
feat: add train dataframe import

### DIFF
--- a/src/pragmata/core/eval/imports.py
+++ b/src/pragmata/core/eval/imports.py
@@ -1,0 +1,26 @@
+"""Dataframe imports for eval workflows."""
+
+from pathlib import Path
+
+import pandas as pd
+
+from pragmata.core.schemas.annotation_task import Task
+from pragmata.core.schemas.eval_input import validate_eval_train_frame
+
+
+def import_eval_train_frame(
+    *,
+    path: Path,
+    task: Task,
+) -> pd.DataFrame:
+    """Read and validate a labeled eval training dataframe.
+
+    Args:
+        path: Resolved CSV path to read.
+        task: Annotation task that determines the dataframe contract.
+
+    Returns:
+        Validated dataframe with original columns preserved.
+    """
+    frame = pd.read_csv(path, encoding="utf-8")
+    return validate_eval_train_frame(frame, task=task)

--- a/tests/unit/core/eval/test_imports.py
+++ b/tests/unit/core/eval/test_imports.py
@@ -1,0 +1,83 @@
+"""Tests for eval dataframe import workflows."""
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from pragmata.core.eval.imports import import_eval_train_frame
+from pragmata.core.schemas.annotation_task import Task
+from pragmata.core.schemas.eval_input import EvalInputSchemaError
+
+
+def test_import_eval_train_frame_reads_and_validates_csv(tmp_path: Path) -> None:
+    path = tmp_path / "retrieval.csv"
+    path.write_text(
+        "\n".join(
+            [
+                "query,chunk,topically_relevant,evidence_sufficient,misleading,record_uuid",
+                "first query,first chunk,1,1,0,record-1",
+                "second query,second chunk,0,0,1,record-2",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    frame = import_eval_train_frame(path=path, task=Task.RETRIEVAL)
+
+    expected = pd.DataFrame(
+        {
+            "query": ["first query", "second query"],
+            "chunk": ["first chunk", "second chunk"],
+            "topically_relevant": [1, 0],
+            "evidence_sufficient": [1, 0],
+            "misleading": [0, 1],
+            "record_uuid": ["record-1", "record-2"],
+        }
+    )
+    pd.testing.assert_frame_equal(frame, expected)
+
+
+def test_import_eval_train_frame_accepts_export_style_lowercase_boolean_labels(tmp_path: Path) -> None:
+    path = tmp_path / "retrieval.csv"
+    path.write_text(
+        "\n".join(
+            [
+                "query,chunk,topically_relevant,evidence_sufficient,misleading",
+                "first query,first chunk,true,true,false",
+                "second query,second chunk,false,false,true",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    frame = import_eval_train_frame(path=path, task=Task.RETRIEVAL)
+
+    expected_labels = pd.DataFrame(
+        {
+            "topically_relevant": [1, 0],
+            "evidence_sufficient": [1, 0],
+            "misleading": [0, 1],
+        },
+        dtype="int64",
+    )
+    pd.testing.assert_frame_equal(
+        frame[["topically_relevant", "evidence_sufficient", "misleading"]],
+        expected_labels,
+    )
+
+
+def test_import_eval_train_frame_rejects_invalid_csv(tmp_path: Path) -> None:
+    path = tmp_path / "retrieval.csv"
+    path.write_text(
+        "\n".join(
+            [
+                "query,topically_relevant,evidence_sufficient,misleading",
+                "first query,1,1,0",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(EvalInputSchemaError, match="eval training data contract"):
+        import_eval_train_frame(path=path, task=Task.RETRIEVAL)


### PR DESCRIPTION
### Summary

Adds the eval import module for reading and validating labeled training data.

`import_eval_train_frame(...)` consumes a resolved CSV path and applies the task-specific eval training dataframe contract. Path selection and annotation export provenance remain owned by `eval_paths.py`; this module only handles dataframe import and validation.

### Key changes

- Add `core/eval/imports.py` with `import_eval_train_frame(...)`.
- Read eval training CSVs via pandas using UTF-8 encoding.
- Validate imported frames with the existing task-specific eval train schema.
- Preserve extra provenance columns in the returned dataframe.

### Tests

- Add unit tests covering:
  - successful CSV import and validation
  - preservation of additional columns
  - lowercase boolean label values from export-style CSVs
  - rejection of CSVs that violate the eval training data contract