### PR TITLE
feat: add predict dataframe import

### DIFF
--- a/src/pragmata/core/eval/imports.py
+++ b/src/pragmata/core/eval/imports.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pandas as pd
 
 from pragmata.core.schemas.annotation_task import Task
-from pragmata.core.schemas.eval_input import validate_eval_train_frame
+from pragmata.core.schemas.eval_input import validate_eval_predict_frame, validate_eval_train_frame
 
 
 def import_eval_train_frame(
@@ -24,3 +24,21 @@ def import_eval_train_frame(
     """
     frame = pd.read_csv(path, encoding="utf-8")
     return validate_eval_train_frame(frame, task=task)
+
+
+def import_eval_predict_frame(
+    *,
+    path: Path,
+    task: Task,
+) -> pd.DataFrame:
+    """Read and validate an unlabeled eval prediction dataframe.
+
+    Args:
+        path: CSV path to read.
+        task: Annotation task that determines the dataframe contract.
+
+    Returns:
+        Validated dataframe with original columns preserved.
+    """
+    frame = pd.read_csv(path, encoding="utf-8")
+    return validate_eval_predict_frame(frame, task=task)

--- a/tests/unit/core/eval/test_imports.py
+++ b/tests/unit/core/eval/test_imports.py
@@ -5,79 +5,156 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from pragmata.core.eval.imports import import_eval_train_frame
+from pragmata.core.eval.imports import import_eval_predict_frame, import_eval_train_frame
 from pragmata.core.schemas.annotation_task import Task
 from pragmata.core.schemas.eval_input import EvalInputSchemaError
 
 
-def test_import_eval_train_frame_reads_and_validates_csv(tmp_path: Path) -> None:
-    path = tmp_path / "retrieval.csv"
-    path.write_text(
-        "\n".join(
-            [
-                "query,chunk,topically_relevant,evidence_sufficient,misleading,record_uuid",
-                "first query,first chunk,1,1,0,record-1",
-                "second query,second chunk,0,0,1,record-2",
-            ]
-        ),
-        encoding="utf-8",
-    )
+class TestImportEvalTrainFrame:
+    """Tests for labeled eval training dataframe imports."""
 
-    frame = import_eval_train_frame(path=path, task=Task.RETRIEVAL)
+    def test_import_eval_train_frame_reads_and_validates_csv(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        path = tmp_path / "retrieval.csv"
+        path.write_text(
+            "\n".join(
+                [
+                    "query,chunk,topically_relevant,evidence_sufficient,misleading,record_uuid",
+                    "first query,first chunk,1,1,0,record-1",
+                    "second query,second chunk,0,0,1,record-2",
+                ]
+            ),
+            encoding="utf-8",
+        )
 
-    expected = pd.DataFrame(
-        {
-            "query": ["first query", "second query"],
-            "chunk": ["first chunk", "second chunk"],
-            "topically_relevant": [1, 0],
-            "evidence_sufficient": [1, 0],
-            "misleading": [0, 1],
-            "record_uuid": ["record-1", "record-2"],
-        }
-    )
-    pd.testing.assert_frame_equal(frame, expected)
+        frame = import_eval_train_frame(path=path, task=Task.RETRIEVAL)
+
+        expected = pd.DataFrame(
+            {
+                "query": ["first query", "second query"],
+                "chunk": ["first chunk", "second chunk"],
+                "topically_relevant": [1, 0],
+                "evidence_sufficient": [1, 0],
+                "misleading": [0, 1],
+                "record_uuid": ["record-1", "record-2"],
+            }
+        )
+        pd.testing.assert_frame_equal(frame, expected)
+
+    def test_import_eval_train_frame_accepts_export_style_lowercase_boolean_labels(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        path = tmp_path / "retrieval.csv"
+        path.write_text(
+            "\n".join(
+                [
+                    "query,chunk,topically_relevant,evidence_sufficient,misleading",
+                    "first query,first chunk,true,true,false",
+                    "second query,second chunk,false,false,true",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        frame = import_eval_train_frame(path=path, task=Task.RETRIEVAL)
+
+        expected_labels = pd.DataFrame(
+            {
+                "topically_relevant": [1, 0],
+                "evidence_sufficient": [1, 0],
+                "misleading": [0, 1],
+            },
+            dtype="int64",
+        )
+        pd.testing.assert_frame_equal(
+            frame[["topically_relevant", "evidence_sufficient", "misleading"]],
+            expected_labels,
+        )
+
+    def test_import_eval_train_frame_rejects_invalid_csv(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        path = tmp_path / "retrieval.csv"
+        path.write_text(
+            "\n".join(
+                [
+                    "query,topically_relevant,evidence_sufficient,misleading",
+                    "first query,1,1,0",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(EvalInputSchemaError, match="eval training data contract"):
+            import_eval_train_frame(path=path, task=Task.RETRIEVAL)
 
 
-def test_import_eval_train_frame_accepts_export_style_lowercase_boolean_labels(tmp_path: Path) -> None:
-    path = tmp_path / "retrieval.csv"
-    path.write_text(
-        "\n".join(
-            [
-                "query,chunk,topically_relevant,evidence_sufficient,misleading",
-                "first query,first chunk,true,true,false",
-                "second query,second chunk,false,false,true",
-            ]
-        ),
-        encoding="utf-8",
-    )
+class TestImportEvalPredictFrame:
+    """Tests for unlabeled eval prediction dataframe imports."""
 
-    frame = import_eval_train_frame(path=path, task=Task.RETRIEVAL)
+    def test_import_eval_predict_frame_reads_and_validates_csv(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        path = tmp_path / "retrieval_predict.csv"
+        path.write_text(
+            "\n".join(
+                [
+                    "query,chunk,record_uuid",
+                    "first query,first chunk,record-1",
+                    "second query,second chunk,record-2",
+                ]
+            ),
+            encoding="utf-8",
+        )
 
-    expected_labels = pd.DataFrame(
-        {
-            "topically_relevant": [1, 0],
-            "evidence_sufficient": [1, 0],
-            "misleading": [0, 1],
-        },
-        dtype="int64",
-    )
-    pd.testing.assert_frame_equal(
-        frame[["topically_relevant", "evidence_sufficient", "misleading"]],
-        expected_labels,
-    )
+        frame = import_eval_predict_frame(path=path, task=Task.RETRIEVAL)
 
+        expected = pd.DataFrame(
+            {
+                "query": ["first query", "second query"],
+                "chunk": ["first chunk", "second chunk"],
+                "record_uuid": ["record-1", "record-2"],
+            }
+        )
+        pd.testing.assert_frame_equal(frame, expected)
 
-def test_import_eval_train_frame_rejects_invalid_csv(tmp_path: Path) -> None:
-    path = tmp_path / "retrieval.csv"
-    path.write_text(
-        "\n".join(
-            [
-                "query,topically_relevant,evidence_sufficient,misleading",
-                "first query,1,1,0",
-            ]
-        ),
-        encoding="utf-8",
-    )
+    def test_import_eval_predict_frame_rejects_labeled_csv(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        path = tmp_path / "retrieval_predict.csv"
+        path.write_text(
+            "\n".join(
+                [
+                    "query,chunk,topically_relevant",
+                    "first query,first chunk,1",
+                ]
+            ),
+            encoding="utf-8",
+        )
 
-    with pytest.raises(EvalInputSchemaError, match="eval training data contract"):
-        import_eval_train_frame(path=path, task=Task.RETRIEVAL)
+        with pytest.raises(EvalInputSchemaError, match="Prediction input must be unlabeled"):
+            import_eval_predict_frame(path=path, task=Task.RETRIEVAL)
+
+    def test_import_eval_predict_frame_rejects_invalid_csv(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        path = tmp_path / "retrieval_predict.csv"
+        path.write_text(
+            "\n".join(
+                [
+                    "query,record_uuid",
+                    "first query,record-1",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(EvalInputSchemaError, match="eval prediction data contract"):
+            import_eval_predict_frame(path=path, task=Task.RETRIEVAL)


### PR DESCRIPTION
### Summary

Adds eval prediction dataframe import support.

`import_eval_predict_frame(...)` reads an explicit unlabeled prediction CSV and validates it against the task-specific eval prediction contract. This mirrors the existing train import while keeping prediction input explicit and free of annotation export lookup logic.

### Key changes

- Add `import_eval_predict_frame(...)` to `core/eval/imports.py`.
- Read prediction CSVs via pandas using UTF-8 encoding.
- Validate imported frames with the existing task-specific eval prediction schema.

### Tests

- Add unit tests covering:
  - successful unlabeled prediction CSV import and validation
  - preservation of additional provenance columns
  - rejection of labeled prediction inputs
  - rejection of prediction CSVs that violate the eval prediction data contract
- Group train and predict import tests by workflow-specific test classes.