### PR TITLE
feat: add eval transforms for tlmtc dataframes

### DIFF
--- a/src/pragmata/core/eval/__init__.py
+++ b/src/pragmata/core/eval/__init__.py
@@ -1,0 +1,1 @@
+"""Internal eval implementation."""

--- a/src/pragmata/core/eval/transforms.py
+++ b/src/pragmata/core/eval/transforms.py
@@ -1,0 +1,54 @@
+"""Transforms from pragmata eval frames to tlmtc-compatible frames."""
+
+from typing import Literal
+
+import pandas as pd
+
+from pragmata.core.schemas.annotation_task import Task
+from pragmata.core.schemas.eval_input import LABEL_COLUMNS_BY_TASK, TEXT_COLUMNS_BY_TASK
+
+
+def build_tlmtc_frame(
+    frame: pd.DataFrame,
+    *,
+    task: Task,
+    mode: Literal["train", "predict"],
+) -> pd.DataFrame:
+    """Rename validated Pragmata eval columns to tlmtc's expected names.
+
+    Args:
+        frame: Validated eval dataframe returned by ``import_eval_train_frame``
+            or ``import_eval_predict_frame``.
+        task: Eval task that determines the source text, text-pair, and label
+            columns.
+        mode: Target tlmtc workflow. Train mode also renames task label columns
+            to ``label_*`` columns. Predict mode only renames text columns.
+
+    Returns:
+        Dataframe with all input columns preserved, a reset integer index, and
+        task-specific columns renamed to tlmtc's ``text``, ``text_pair``, and
+        train-only ``label_*`` names.
+
+    Raises:
+        ValueError: If ``mode`` is unsupported or the input already contains a
+            tlmtc-reserved output column that Pragmata derives internally.
+    """
+    if mode not in {"train", "predict"}:
+        raise ValueError(f"Unsupported eval transform mode: {mode!r}.")
+
+    text_column, text_pair_column = TEXT_COLUMNS_BY_TASK[task]
+    rename_map = {
+        text_column: "text",
+        text_pair_column: "text_pair",
+    }
+
+    if mode == "train":
+        source_label_columns = LABEL_COLUMNS_BY_TASK[task]
+        label_columns = tuple(f"label_{column}" for column in source_label_columns)
+        rename_map.update(dict(zip(source_label_columns, label_columns, strict=True)))
+
+    reserved_columns = sorted(set(rename_map.values()).intersection(frame.columns))
+    if reserved_columns:
+        raise ValueError(f"Input contains reserved tlmtc columns that Pragmata derives internally: {reserved_columns}.")
+
+    return frame.reset_index(drop=True).rename(columns=rename_map)

--- a/tests/unit/core/eval/test_transforms.py
+++ b/tests/unit/core/eval/test_transforms.py
@@ -1,0 +1,221 @@
+"""Tests for eval dataframe transforms."""
+
+import pandas as pd
+import pytest
+
+from pragmata.core.eval.transforms import build_tlmtc_frame
+from pragmata.core.schemas.annotation_task import Task
+
+
+@pytest.mark.parametrize(
+    ("task", "frame", "expected"),
+    [
+        pytest.param(
+            Task.RETRIEVAL,
+            pd.DataFrame(
+                {
+                    "query": ["first query", "second query"],
+                    "chunk": ["first chunk", "second chunk"],
+                    "topically_relevant": [1, 0],
+                    "evidence_sufficient": [1, 0],
+                    "misleading": [0, 1],
+                    "record_uuid": ["record-1", "record-2"],
+                }
+            ),
+            pd.DataFrame(
+                {
+                    "text": ["first query", "second query"],
+                    "text_pair": ["first chunk", "second chunk"],
+                    "label_topically_relevant": [1, 0],
+                    "label_evidence_sufficient": [1, 0],
+                    "label_misleading": [0, 1],
+                    "record_uuid": ["record-1", "record-2"],
+                }
+            ),
+            id="retrieval",
+        ),
+        pytest.param(
+            Task.GROUNDING,
+            pd.DataFrame(
+                {
+                    "answer": ["first answer", "second answer"],
+                    "context_set": ["first context", "second context"],
+                    "support_present": [1, 0],
+                    "unsupported_claim_present": [0, 1],
+                    "contradicted_claim_present": [0, 1],
+                    "source_cited": [1, 0],
+                    "fabricated_source": [0, 1],
+                    "record_uuid": ["record-1", "record-2"],
+                }
+            ),
+            pd.DataFrame(
+                {
+                    "text": ["first answer", "second answer"],
+                    "text_pair": ["first context", "second context"],
+                    "label_support_present": [1, 0],
+                    "label_unsupported_claim_present": [0, 1],
+                    "label_contradicted_claim_present": [0, 1],
+                    "label_source_cited": [1, 0],
+                    "label_fabricated_source": [0, 1],
+                    "record_uuid": ["record-1", "record-2"],
+                }
+            ),
+            id="grounding",
+        ),
+        pytest.param(
+            Task.GENERATION,
+            pd.DataFrame(
+                {
+                    "query": ["first query", "second query"],
+                    "answer": ["first answer", "second answer"],
+                    "proper_action": [1, 0],
+                    "response_on_topic": [1, 0],
+                    "helpful": [1, 0],
+                    "incomplete": [0, 1],
+                    "unsafe_content": [0, 1],
+                    "record_uuid": ["record-1", "record-2"],
+                }
+            ),
+            pd.DataFrame(
+                {
+                    "text": ["first query", "second query"],
+                    "text_pair": ["first answer", "second answer"],
+                    "label_proper_action": [1, 0],
+                    "label_response_on_topic": [1, 0],
+                    "label_helpful": [1, 0],
+                    "label_incomplete": [0, 1],
+                    "label_unsafe_content": [0, 1],
+                    "record_uuid": ["record-1", "record-2"],
+                }
+            ),
+            id="generation",
+        ),
+    ],
+)
+def test_build_tlmtc_train_frame_renames_task_columns(
+    task: Task,
+    frame: pd.DataFrame,
+    expected: pd.DataFrame,
+) -> None:
+    transformed = build_tlmtc_frame(frame, task=task, mode="train")
+
+    pd.testing.assert_frame_equal(transformed, expected)
+
+
+@pytest.mark.parametrize(
+    ("task", "frame", "expected"),
+    [
+        pytest.param(
+            Task.RETRIEVAL,
+            pd.DataFrame(
+                {
+                    "query": ["first query"],
+                    "chunk": ["first chunk"],
+                    "record_uuid": ["record-1"],
+                }
+            ),
+            pd.DataFrame(
+                {
+                    "text": ["first query"],
+                    "text_pair": ["first chunk"],
+                    "record_uuid": ["record-1"],
+                }
+            ),
+            id="retrieval",
+        ),
+        pytest.param(
+            Task.GROUNDING,
+            pd.DataFrame(
+                {
+                    "answer": ["first answer"],
+                    "context_set": ["first context"],
+                    "record_uuid": ["record-1"],
+                }
+            ),
+            pd.DataFrame(
+                {
+                    "text": ["first answer"],
+                    "text_pair": ["first context"],
+                    "record_uuid": ["record-1"],
+                }
+            ),
+            id="grounding",
+        ),
+        pytest.param(
+            Task.GENERATION,
+            pd.DataFrame(
+                {
+                    "query": ["first query"],
+                    "answer": ["first answer"],
+                    "record_uuid": ["record-1"],
+                }
+            ),
+            pd.DataFrame(
+                {
+                    "text": ["first query"],
+                    "text_pair": ["first answer"],
+                    "record_uuid": ["record-1"],
+                }
+            ),
+            id="generation",
+        ),
+    ],
+)
+def test_build_tlmtc_predict_frame_renames_task_columns(
+    task: Task,
+    frame: pd.DataFrame,
+    expected: pd.DataFrame,
+) -> None:
+    transformed = build_tlmtc_frame(frame, task=task, mode="predict")
+
+    pd.testing.assert_frame_equal(transformed, expected)
+
+
+def test_build_tlmtc_frame_resets_index_and_preserves_extra_column_order() -> None:
+    frame = pd.DataFrame(
+        {
+            "record_uuid": ["record-1", "record-2"],
+            "chunk": ["first chunk", "second chunk"],
+            "query": ["first query", "second query"],
+            "doc_id": ["doc-1", "doc-2"],
+        },
+        index=[10, 20],
+    )
+
+    transformed = build_tlmtc_frame(frame, task=Task.RETRIEVAL, mode="predict")
+
+    expected = pd.DataFrame(
+        {
+            "record_uuid": ["record-1", "record-2"],
+            "text_pair": ["first chunk", "second chunk"],
+            "text": ["first query", "second query"],
+            "doc_id": ["doc-1", "doc-2"],
+        }
+    )
+    pd.testing.assert_frame_equal(transformed, expected)
+
+
+@pytest.mark.parametrize("reserved_column", ["text", "text_pair"])
+def test_build_tlmtc_frame_rejects_reserved_target_columns(reserved_column: str) -> None:
+    frame = pd.DataFrame(
+        {
+            "query": ["first query"],
+            "chunk": ["first chunk"],
+            reserved_column: ["already present"],
+        }
+    )
+
+    with pytest.raises(ValueError, match="reserved tlmtc columns"):
+        build_tlmtc_frame(frame, task=Task.RETRIEVAL, mode="predict")
+
+
+def test_build_tlmtc_frame_rejects_unknown_mode() -> None:
+    frame = pd.DataFrame(
+        {
+            "query": ["first query"],
+            "chunk": ["first chunk"],
+        }
+    )
+
+    with pytest.raises(ValueError, match="Unsupported eval transform mode"):
+        build_tlmtc_frame(frame, task=Task.RETRIEVAL, mode="score")  # type: ignore[arg-type]


### PR DESCRIPTION
### Summary

Adds the eval transform layer that maps validated `pragmata` eval dataframes to `tlmtc`-compatible dataframe columns.

The new transform keeps the dataframe shape otherwise intact and only renames task-specific columns into `tlmtc`'s expected contract:

- `text`
- `text_pair`
- train-only `label_*` columns

This keeps validation in `eval_input.py`, CSV loading in `eval/imports.py`, and `tlmtc`-specific column naming in `eval/transforms.py`.

### Key changes

- Add the `pragmata.core.eval` package initializer.
- Add `build_tlmtc_frame(...)` for train and predict workflows.
- Map task-specific text columns
- In train mode, rename task label columns to `tlmtc` `label_*` columns.
- In predict mode, only apply text/text-pair mapping; unlabeled input validation remains responsible for rejecting label columns.
- Reject inputs that already contain reserved `tlmtc` target columns derived by `pragmata`.

### Tests

- Add unit tests covering:
  - train column mapping for retrieval, grounding, and generation
  - predict column mapping for retrieval, grounding, and generation
  - preservation of extra columns and existing column order
  - rejection of reserved `tlmtc` columns
  - rejection of unsupported transform modes