### PR TITLE
feat: add eval training split groups and row consolidation

### DIFF
--- a/src/pragmata/core/eval/transforms.py
+++ b/src/pragmata/core/eval/transforms.py
@@ -1,11 +1,14 @@
 """Transforms from pragmata eval frames to tlmtc-compatible frames."""
 
+import logging
 from typing import Literal
 
 import pandas as pd
 
 from pragmata.core.schemas.annotation_task import Task
 from pragmata.core.schemas.eval_input import LABEL_COLUMNS_BY_TASK, TEXT_COLUMNS_BY_TASK
+
+logger = logging.getLogger(__name__)
 
 _DUPLICATE_KEY_COLUMNS_BY_TASK: dict[Task, tuple[str, ...]] = {
     Task.RETRIEVAL: ("record_uuid", "chunk_id"),
@@ -145,5 +148,16 @@ def _consolidate_training_rows(
 
     for target_position, label_override in label_overrides_by_target.items():
         consolidated.loc[target_position, label_override.index] = label_override
+
+    logger.info(
+        "Consolidated duplicate eval training rows for %s: input_rows=%d output_rows=%d "
+        "collapsed_rows=%d duplicate_units=%d key_columns=%s",
+        task.value,
+        len(frame),
+        len(consolidated),
+        len(frame) - len(consolidated),
+        duplicate_groups.ngroups,
+        key_columns,
+    )
 
     return consolidated.reset_index(drop=True)

--- a/src/pragmata/core/eval/transforms.py
+++ b/src/pragmata/core/eval/transforms.py
@@ -7,6 +7,12 @@ import pandas as pd
 from pragmata.core.schemas.annotation_task import Task
 from pragmata.core.schemas.eval_input import LABEL_COLUMNS_BY_TASK, TEXT_COLUMNS_BY_TASK
 
+_DUPLICATE_KEY_COLUMNS_BY_TASK: dict[Task, tuple[str, ...]] = {
+    Task.RETRIEVAL: ("record_uuid", "chunk_id"),
+    Task.GROUNDING: ("record_uuid",),
+    Task.GENERATION: ("record_uuid",),
+}
+
 
 def build_tlmtc_frame(
     frame: pd.DataFrame,
@@ -39,6 +45,8 @@ def build_tlmtc_frame(
     if mode not in {"train", "predict"}:
         raise ValueError(f"Unsupported eval transform mode: {mode!r}.")
 
+    consolidated_frame = _consolidate_training_rows(frame, task=task) if mode == "train" else frame
+
     text_column, text_pair_column = TEXT_COLUMNS_BY_TASK[task]
     rename_map = {
         text_column: "text",
@@ -52,8 +60,49 @@ def build_tlmtc_frame(
         if task == Task.RETRIEVAL:
             rename_map["record_uuid"] = "split_group"
 
-    reserved_columns = sorted(set(rename_map.values()).intersection(frame.columns))
+    reserved_columns = sorted(set(rename_map.values()).intersection(consolidated_frame.columns))
     if reserved_columns:
         raise ValueError(f"Input contains reserved tlmtc columns that Pragmata derives internally: {reserved_columns}.")
 
-    return frame.reset_index(drop=True).rename(columns=rename_map)
+    return consolidated_frame.reset_index(drop=True).rename(columns=rename_map)
+
+
+def _consolidate_training_rows(
+    frame: pd.DataFrame,
+    *,
+    task: Task,
+) -> pd.DataFrame:
+    """Deduplicate repeated annotation units with deterministic consensus fallback."""
+    key_columns = _DUPLICATE_KEY_COLUMNS_BY_TASK[task]
+    label_columns = LABEL_COLUMNS_BY_TASK[task]
+
+    if any(column not in frame.columns for column in key_columns):
+        return frame
+
+    if not frame.duplicated(subset=key_columns, keep=False).any():
+        return frame
+
+    working = frame.reset_index(drop=True)
+    working_labels = working.loc[:, label_columns].astype("int64")
+
+    kept_positions: list[int] = []
+
+    for _, group in working.groupby(key_columns, sort=False, dropna=False):
+        selected_position = group.index[0]
+
+        if len(group) > 1:
+            labels = working_labels.loc[group.index]
+            positive_counts = labels.sum(axis=0)
+            majority_threshold = len(group) / 2
+
+            has_tie = positive_counts.eq(majority_threshold).any()
+            if not has_tie:
+                majority_vector = positive_counts.gt(majority_threshold).astype("int64")
+                matching_rows = labels.eq(majority_vector, axis=1).all(axis=1)
+
+                if matching_rows.any():
+                    selected_position = matching_rows.idxmax()
+
+        kept_positions.append(selected_position)
+
+    return frame.iloc[kept_positions].copy()

--- a/src/pragmata/core/eval/transforms.py
+++ b/src/pragmata/core/eval/transforms.py
@@ -87,7 +87,7 @@ def _consolidate_training_rows(
 
     kept_positions: list[int] = []
 
-    for _, group in working.groupby(key_columns, sort=False, dropna=False):
+    for _, group in working.groupby(list(key_columns), sort=False, dropna=False):
         selected_position = group.index[0]
 
         if len(group) > 1:

--- a/src/pragmata/core/eval/transforms.py
+++ b/src/pragmata/core/eval/transforms.py
@@ -72,37 +72,78 @@ def _consolidate_training_rows(
     *,
     task: Task,
 ) -> pd.DataFrame:
-    """Deduplicate repeated annotation units with deterministic consensus fallback."""
+    """Deduplicate repeated annotation units with per-label majority consensus.
+
+    For duplicate rows, labels with a strict majority are consolidated independently.
+    Tied labels fall back to the selected source row. When an observed row matches
+    all strict-majority labels, that row is selected to preserve non-label metadata
+    deterministically.
+    """
     key_columns = _DUPLICATE_KEY_COLUMNS_BY_TASK[task]
     label_columns = LABEL_COLUMNS_BY_TASK[task]
 
     if any(column not in frame.columns for column in key_columns):
         return frame
 
-    if not frame.duplicated(subset=key_columns, keep=False).any():
+    duplicate_mask = frame.duplicated(subset=key_columns, keep=False)
+    if not duplicate_mask.any():
         return frame
 
     working = frame.reset_index(drop=True)
+    duplicate_mask = working.duplicated(subset=key_columns, keep=False)
+    subsequent_duplicate_mask = working.duplicated(subset=key_columns, keep="first")
     working_labels = working.loc[:, label_columns].astype("int64")
 
-    kept_positions: list[int] = []
+    consolidated = working.loc[~subsequent_duplicate_mask].copy()
 
-    for _, group in working.groupby(list(key_columns), sort=False, dropna=False):
-        selected_position = group.index[0]
+    replacement_sources_by_target: dict[int, int] = {}
+    label_overrides_by_target: dict[int, pd.Series] = {}
 
-        if len(group) > 1:
-            labels = working_labels.loc[group.index]
-            positive_counts = labels.sum(axis=0)
-            majority_threshold = len(group) / 2
+    duplicate_groups = working.loc[duplicate_mask].groupby(
+        list(key_columns),
+        sort=False,
+        dropna=False,
+    )
 
-            has_tie = positive_counts.eq(majority_threshold).any()
-            if not has_tie:
-                majority_vector = positive_counts.gt(majority_threshold).astype("int64")
-                matching_rows = labels.eq(majority_vector, axis=1).all(axis=1)
+    for _, group in duplicate_groups:
+        target_position = group.index[0]
+        selected_position = target_position
 
-                if matching_rows.any():
-                    selected_position = matching_rows.idxmax()
+        labels = working_labels.loc[group.index]
+        positive_counts = labels.sum(axis=0)
+        majority_threshold = len(group) / 2
 
-        kept_positions.append(selected_position)
+        strict_majority_labels = positive_counts.ne(majority_threshold)
+        majority_vector = positive_counts.gt(majority_threshold).astype("int64")
 
-    return frame.iloc[kept_positions].copy()
+        if strict_majority_labels.any():
+            matching_rows = (
+                labels.loc[:, strict_majority_labels]
+                .eq(
+                    majority_vector.loc[strict_majority_labels],
+                    axis=1,
+                )
+                .all(axis=1)
+            )
+
+            if matching_rows.any():
+                selected_position = matching_rows.idxmax()
+
+            label_overrides_by_target[target_position] = majority_vector.loc[strict_majority_labels]
+
+        if selected_position != target_position:
+            replacement_sources_by_target[target_position] = selected_position
+
+    if replacement_sources_by_target:
+        target_positions = list(replacement_sources_by_target)
+        source_positions = list(replacement_sources_by_target.values())
+
+        consolidated.loc[target_positions, :] = working.loc[
+            source_positions,
+            consolidated.columns,
+        ].to_numpy()
+
+    for target_position, label_override in label_overrides_by_target.items():
+        consolidated.loc[target_position, label_override.index] = label_override
+
+    return consolidated.reset_index(drop=True)

--- a/src/pragmata/core/eval/transforms.py
+++ b/src/pragmata/core/eval/transforms.py
@@ -22,12 +22,15 @@ def build_tlmtc_frame(
         task: Eval task that determines the source text, text-pair, and label
             columns.
         mode: Target tlmtc workflow. Train mode also renames task label columns
-            to ``label_*`` columns. Predict mode only renames text columns.
+            to ``label_*`` columns. Retrieval train mode additionally maps
+            ``record_uuid`` to ``split_group`` so rows from the same retrieval
+            example stay in the same train/validation/test split. Predict mode
+            only renames text columns.
 
     Returns:
         Dataframe with all input columns preserved, a reset integer index, and
         task-specific columns renamed to tlmtc's ``text``, ``text_pair``, and
-        train-only ``label_*`` names.
+        train-only ``label_*``, and retrieval-train-only ``split_group`` names.
 
     Raises:
         ValueError: If ``mode`` is unsupported or the input already contains a
@@ -44,8 +47,10 @@ def build_tlmtc_frame(
 
     if mode == "train":
         source_label_columns = LABEL_COLUMNS_BY_TASK[task]
-        label_columns = tuple(f"label_{column}" for column in source_label_columns)
-        rename_map.update(dict(zip(source_label_columns, label_columns, strict=True)))
+        rename_map.update({column: f"label_{column}" for column in source_label_columns})
+
+        if task == Task.RETRIEVAL:
+            rename_map["record_uuid"] = "split_group"
 
     reserved_columns = sorted(set(rename_map.values()).intersection(frame.columns))
     if reserved_columns:

--- a/tests/unit/core/eval/test_transforms.py
+++ b/tests/unit/core/eval/test_transforms.py
@@ -1,63 +1,106 @@
 """Tests for eval dataframe transforms."""
 
+from collections.abc import Callable
+
 import pandas as pd
 import pytest
 
 from pragmata.core.eval.transforms import build_tlmtc_frame
 from pragmata.core.schemas.annotation_task import Task
 
+FrameFactory = Callable[..., pd.DataFrame]
+
+
+@pytest.fixture
+def retrieval_train_frame() -> FrameFactory:
+    """Return a factory for retrieval training dataframes."""
+
+    def _factory(**overrides: object) -> pd.DataFrame:
+        data: dict[str, object] = {
+            "query": ["first query", "second query"],
+            "chunk": ["first chunk", "second chunk"],
+            "chunk_id": ["chunk-1", "chunk-2"],
+            "record_uuid": ["record-1", "record-2"],
+            "topically_relevant": [1, 0],
+            "evidence_sufficient": [1, 0],
+            "misleading": [0, 1],
+        }
+        data.update(overrides)
+        return pd.DataFrame(data)
+
+    return _factory
+
+
+@pytest.fixture
+def generation_train_frame() -> FrameFactory:
+    """Return a factory for generation training dataframes."""
+
+    def _factory(**overrides: object) -> pd.DataFrame:
+        data: dict[str, object] = {
+            "query": ["first query", "second query"],
+            "answer": ["first answer", "second answer"],
+            "record_uuid": ["record-1", "record-2"],
+            "proper_action": [1, 0],
+            "response_on_topic": [1, 0],
+            "helpful": [1, 0],
+            "incomplete": [0, 1],
+            "unsafe_content": [0, 1],
+        }
+        data.update(overrides)
+        return pd.DataFrame(data)
+
+    return _factory
+
+
+def test_build_tlmtc_train_frame_maps_retrieval_labels_and_split_group(
+    retrieval_train_frame: FrameFactory,
+) -> None:
+    frame = retrieval_train_frame(doc_id=["doc-1", "doc-2"])
+
+    transformed = build_tlmtc_frame(frame, task=Task.RETRIEVAL, mode="train")
+
+    expected = pd.DataFrame(
+        {
+            "text": ["first query", "second query"],
+            "text_pair": ["first chunk", "second chunk"],
+            "chunk_id": ["chunk-1", "chunk-2"],
+            "split_group": ["record-1", "record-2"],
+            "label_topically_relevant": [1, 0],
+            "label_evidence_sufficient": [1, 0],
+            "label_misleading": [0, 1],
+            "doc_id": ["doc-1", "doc-2"],
+        }
+    )
+    pd.testing.assert_frame_equal(transformed, expected)
+
 
 @pytest.mark.parametrize(
     ("task", "frame", "expected"),
     [
-        pytest.param(
-            Task.RETRIEVAL,
-            pd.DataFrame(
-                {
-                    "query": ["first query", "second query"],
-                    "chunk": ["first chunk", "second chunk"],
-                    "topically_relevant": [1, 0],
-                    "evidence_sufficient": [1, 0],
-                    "misleading": [0, 1],
-                    "record_uuid": ["record-1", "record-2"],
-                }
-            ),
-            pd.DataFrame(
-                {
-                    "text": ["first query", "second query"],
-                    "text_pair": ["first chunk", "second chunk"],
-                    "label_topically_relevant": [1, 0],
-                    "label_evidence_sufficient": [1, 0],
-                    "label_misleading": [0, 1],
-                    "record_uuid": ["record-1", "record-2"],
-                }
-            ),
-            id="retrieval",
-        ),
         pytest.param(
             Task.GROUNDING,
             pd.DataFrame(
                 {
                     "answer": ["first answer", "second answer"],
                     "context_set": ["first context", "second context"],
+                    "record_uuid": ["record-1", "record-2"],
                     "support_present": [1, 0],
                     "unsupported_claim_present": [0, 1],
                     "contradicted_claim_present": [0, 1],
                     "source_cited": [1, 0],
                     "fabricated_source": [0, 1],
-                    "record_uuid": ["record-1", "record-2"],
                 }
             ),
             pd.DataFrame(
                 {
                     "text": ["first answer", "second answer"],
                     "text_pair": ["first context", "second context"],
+                    "record_uuid": ["record-1", "record-2"],
                     "label_support_present": [1, 0],
                     "label_unsupported_claim_present": [0, 1],
                     "label_contradicted_claim_present": [0, 1],
                     "label_source_cited": [1, 0],
                     "label_fabricated_source": [0, 1],
-                    "record_uuid": ["record-1", "record-2"],
                 }
             ),
             id="grounding",
@@ -68,31 +111,31 @@ from pragmata.core.schemas.annotation_task import Task
                 {
                     "query": ["first query", "second query"],
                     "answer": ["first answer", "second answer"],
+                    "record_uuid": ["record-1", "record-2"],
                     "proper_action": [1, 0],
                     "response_on_topic": [1, 0],
                     "helpful": [1, 0],
                     "incomplete": [0, 1],
                     "unsafe_content": [0, 1],
-                    "record_uuid": ["record-1", "record-2"],
                 }
             ),
             pd.DataFrame(
                 {
                     "text": ["first query", "second query"],
                     "text_pair": ["first answer", "second answer"],
+                    "record_uuid": ["record-1", "record-2"],
                     "label_proper_action": [1, 0],
                     "label_response_on_topic": [1, 0],
                     "label_helpful": [1, 0],
                     "label_incomplete": [0, 1],
                     "label_unsafe_content": [0, 1],
-                    "record_uuid": ["record-1", "record-2"],
                 }
             ),
             id="generation",
         ),
     ],
 )
-def test_build_tlmtc_train_frame_renames_task_columns(
+def test_build_tlmtc_train_frame_maps_non_retrieval_task_columns(
     task: Task,
     frame: pd.DataFrame,
     expected: pd.DataFrame,
@@ -107,56 +150,20 @@ def test_build_tlmtc_train_frame_renames_task_columns(
     [
         pytest.param(
             Task.RETRIEVAL,
-            pd.DataFrame(
-                {
-                    "query": ["first query"],
-                    "chunk": ["first chunk"],
-                    "record_uuid": ["record-1"],
-                }
-            ),
-            pd.DataFrame(
-                {
-                    "text": ["first query"],
-                    "text_pair": ["first chunk"],
-                    "record_uuid": ["record-1"],
-                }
-            ),
+            pd.DataFrame({"query": ["first query"], "chunk": ["first chunk"], "record_uuid": ["record-1"]}),
+            pd.DataFrame({"text": ["first query"], "text_pair": ["first chunk"], "record_uuid": ["record-1"]}),
             id="retrieval",
         ),
         pytest.param(
             Task.GROUNDING,
-            pd.DataFrame(
-                {
-                    "answer": ["first answer"],
-                    "context_set": ["first context"],
-                    "record_uuid": ["record-1"],
-                }
-            ),
-            pd.DataFrame(
-                {
-                    "text": ["first answer"],
-                    "text_pair": ["first context"],
-                    "record_uuid": ["record-1"],
-                }
-            ),
+            pd.DataFrame({"answer": ["first answer"], "context_set": ["first context"], "record_uuid": ["record-1"]}),
+            pd.DataFrame({"text": ["first answer"], "text_pair": ["first context"], "record_uuid": ["record-1"]}),
             id="grounding",
         ),
         pytest.param(
             Task.GENERATION,
-            pd.DataFrame(
-                {
-                    "query": ["first query"],
-                    "answer": ["first answer"],
-                    "record_uuid": ["record-1"],
-                }
-            ),
-            pd.DataFrame(
-                {
-                    "text": ["first query"],
-                    "text_pair": ["first answer"],
-                    "record_uuid": ["record-1"],
-                }
-            ),
+            pd.DataFrame({"query": ["first query"], "answer": ["first answer"], "record_uuid": ["record-1"]}),
+            pd.DataFrame({"text": ["first query"], "text_pair": ["first answer"], "record_uuid": ["record-1"]}),
             id="generation",
         ),
     ],
@@ -195,8 +202,130 @@ def test_build_tlmtc_frame_resets_index_and_preserves_extra_column_order() -> No
     pd.testing.assert_frame_equal(transformed, expected)
 
 
+def test_build_tlmtc_frame_preserves_retrieval_train_without_record_uuid() -> None:
+    frame = pd.DataFrame(
+        {
+            "query": ["first query"],
+            "chunk": ["first chunk"],
+            "topically_relevant": [1],
+            "evidence_sufficient": [1],
+            "misleading": [0],
+        }
+    )
+
+    transformed = build_tlmtc_frame(frame, task=Task.RETRIEVAL, mode="train")
+
+    expected = pd.DataFrame(
+        {
+            "text": ["first query"],
+            "text_pair": ["first chunk"],
+            "label_topically_relevant": [1],
+            "label_evidence_sufficient": [1],
+            "label_misleading": [0],
+        }
+    )
+    pd.testing.assert_frame_equal(transformed, expected)
+
+
+def test_build_tlmtc_frame_consolidates_training_duplicates_by_earliest_consensus_match(
+    generation_train_frame: FrameFactory,
+) -> None:
+    frame = generation_train_frame(
+        query=["query", "query", "query"],
+        answer=["answer", "answer", "answer"],
+        record_uuid=["record-1", "record-1", "record-1"],
+        proper_action=[0, 1, 1],
+        response_on_topic=[1, 1, 1],
+        helpful=[0, 1, 1],
+        incomplete=[1, 0, 0],
+        unsafe_content=[0, 0, 0],
+        annotator_id=["annotator-a", "annotator-b", "annotator-c"],
+    )
+
+    transformed = build_tlmtc_frame(frame, task=Task.GENERATION, mode="train")
+
+    expected = pd.DataFrame(
+        {
+            "text": ["query"],
+            "text_pair": ["answer"],
+            "record_uuid": ["record-1"],
+            "label_proper_action": [1],
+            "label_response_on_topic": [1],
+            "label_helpful": [1],
+            "label_incomplete": [0],
+            "label_unsafe_content": [0],
+            "annotator_id": ["annotator-b"],
+        }
+    )
+    pd.testing.assert_frame_equal(transformed, expected)
+
+
+def test_build_tlmtc_frame_consolidates_training_duplicates_by_earliest_fallback_on_tie(
+    generation_train_frame: FrameFactory,
+) -> None:
+    frame = generation_train_frame(
+        query=["query", "query"],
+        answer=["answer", "answer"],
+        record_uuid=["record-1", "record-1"],
+        proper_action=[1, 0],
+        response_on_topic=[1, 1],
+        helpful=[1, 0],
+        incomplete=[0, 1],
+        unsafe_content=[0, 0],
+        annotator_id=["annotator-a", "annotator-b"],
+    )
+
+    transformed = build_tlmtc_frame(frame, task=Task.GENERATION, mode="train")
+
+    expected = pd.DataFrame(
+        {
+            "text": ["query"],
+            "text_pair": ["answer"],
+            "record_uuid": ["record-1"],
+            "label_proper_action": [1],
+            "label_response_on_topic": [1],
+            "label_helpful": [1],
+            "label_incomplete": [0],
+            "label_unsafe_content": [0],
+            "annotator_id": ["annotator-a"],
+        }
+    )
+    pd.testing.assert_frame_equal(transformed, expected)
+
+
+def test_build_tlmtc_frame_consolidates_retrieval_duplicates_by_record_and_chunk(
+    retrieval_train_frame: FrameFactory,
+) -> None:
+    frame = retrieval_train_frame(
+        query=["query", "query", "query"],
+        chunk=["first chunk", "first chunk", "second chunk"],
+        record_uuid=["record-1", "record-1", "record-1"],
+        chunk_id=["chunk-1", "chunk-1", "chunk-2"],
+        topically_relevant=[1, 1, 0],
+        evidence_sufficient=[1, 1, 0],
+        misleading=[0, 0, 1],
+        annotator_id=["annotator-a", "annotator-b", "annotator-c"],
+    )
+
+    transformed = build_tlmtc_frame(frame, task=Task.RETRIEVAL, mode="train")
+
+    expected = pd.DataFrame(
+        {
+            "text": ["query", "query"],
+            "text_pair": ["first chunk", "second chunk"],
+            "chunk_id": ["chunk-1", "chunk-2"],
+            "split_group": ["record-1", "record-1"],
+            "label_topically_relevant": [1, 0],
+            "label_evidence_sufficient": [1, 0],
+            "label_misleading": [0, 1],
+            "annotator_id": ["annotator-a", "annotator-c"],
+        }
+    )
+    pd.testing.assert_frame_equal(transformed, expected)
+
+
 @pytest.mark.parametrize("reserved_column", ["text", "text_pair"])
-def test_build_tlmtc_frame_rejects_reserved_target_columns(reserved_column: str) -> None:
+def test_build_tlmtc_frame_rejects_reserved_text_columns(reserved_column: str) -> None:
     frame = pd.DataFrame(
         {
             "query": ["first query"],
@@ -207,6 +336,15 @@ def test_build_tlmtc_frame_rejects_reserved_target_columns(reserved_column: str)
 
     with pytest.raises(ValueError, match="reserved tlmtc columns"):
         build_tlmtc_frame(frame, task=Task.RETRIEVAL, mode="predict")
+
+
+def test_build_tlmtc_frame_rejects_reserved_retrieval_split_group_column(
+    retrieval_train_frame: FrameFactory,
+) -> None:
+    frame = retrieval_train_frame(split_group=["already present", "already present"])
+
+    with pytest.raises(ValueError, match="reserved tlmtc columns"):
+        build_tlmtc_frame(frame, task=Task.RETRIEVAL, mode="train")
 
 
 def test_build_tlmtc_frame_rejects_unknown_mode() -> None:

--- a/tests/unit/core/eval/test_transforms.py
+++ b/tests/unit/core/eval/test_transforms.py
@@ -1,5 +1,6 @@
 """Tests for eval dataframe transforms."""
 
+import logging
 from collections.abc import Callable
 
 import pandas as pd
@@ -324,6 +325,30 @@ def test_build_tlmtc_frame_consolidates_training_duplicates_by_per_label_majorit
         }
     )
     pd.testing.assert_frame_equal(transformed, expected)
+
+
+def test_build_tlmtc_frame_logs_training_duplicate_consolidation(
+    generation_train_frame: FrameFactory,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    frame = generation_train_frame(
+        query=["query", "query", "query", "query"],
+        answer=["answer", "answer", "answer", "answer"],
+        record_uuid=["record-1", "record-1", "record-1", "record-1"],
+        proper_action=[0, 1, 1, 1],
+        response_on_topic=[1, 1, 1, 1],
+        helpful=[0, 1, 0, 1],
+        incomplete=[0, 0, 1, 1],
+        unsafe_content=[1, 0, 0, 0],
+    )
+
+    with caplog.at_level(logging.INFO, logger="pragmata.core.eval.transforms"):
+        build_tlmtc_frame(frame, task=Task.GENERATION, mode="train")
+
+    assert caplog.messages == [
+        "Consolidated duplicate eval training rows for generation: input_rows=4 output_rows=1 "
+        "collapsed_rows=3 duplicate_units=1 key_columns=('record_uuid',)"
+    ]
 
 
 def test_build_tlmtc_frame_consolidates_retrieval_duplicates_by_record_and_chunk(

--- a/tests/unit/core/eval/test_transforms.py
+++ b/tests/unit/core/eval/test_transforms.py
@@ -293,6 +293,39 @@ def test_build_tlmtc_frame_consolidates_training_duplicates_by_earliest_fallback
     pd.testing.assert_frame_equal(transformed, expected)
 
 
+def test_build_tlmtc_frame_consolidates_training_duplicates_by_per_label_majority(
+    generation_train_frame: FrameFactory,
+) -> None:
+    frame = generation_train_frame(
+        query=["query", "query", "query", "query"],
+        answer=["answer", "answer", "answer", "answer"],
+        record_uuid=["record-1", "record-1", "record-1", "record-1"],
+        proper_action=[0, 1, 1, 1],
+        response_on_topic=[1, 1, 1, 1],
+        helpful=[0, 1, 0, 1],
+        incomplete=[0, 0, 1, 1],
+        unsafe_content=[1, 0, 0, 0],
+        annotator_id=["annotator-a", "annotator-b", "annotator-c", "annotator-d"],
+    )
+
+    transformed = build_tlmtc_frame(frame, task=Task.GENERATION, mode="train")
+
+    expected = pd.DataFrame(
+        {
+            "text": ["query"],
+            "text_pair": ["answer"],
+            "record_uuid": ["record-1"],
+            "label_proper_action": [1],
+            "label_response_on_topic": [1],
+            "label_helpful": [1],
+            "label_incomplete": [0],
+            "label_unsafe_content": [0],
+            "annotator_id": ["annotator-b"],
+        }
+    )
+    pd.testing.assert_frame_equal(transformed, expected)
+
+
 def test_build_tlmtc_frame_consolidates_retrieval_duplicates_by_record_and_chunk(
     retrieval_train_frame: FrameFactory,
 ) -> None:


### PR DESCRIPTION
### Summary

Extends the eval transform layer with training-specific preparation before handing data to `tlmtc`.

Retrieval training rows now get a `split_group` column derived from `record_uuid`, so rows from the same retrieval example stay together across train/validation/test splits. Training data also consolidates duplicate annotation rows deterministically before column renaming.

### Key changes

- Map retrieval train `record_uuid` to `tlmtc`'s `split_group` column.
- Leave grounding and generation ungrouped by default.
- Add duplicate training-row consolidation before `tlmtc` column mapping.
- Group duplicate annotation units by task:
  - retrieval: `record_uuid`, `chunk_id`
  - grounding/generation: `record_uuid`
- For duplicate groups:
  - keep single-row groups unchanged
  - select the earliest row matching the strict per-label majority vector
  - fall back to the earliest row when there is a tie or no exact consensus match
- Preserve behavior for standalone training CSVs that do not include annotation export identifiers.

### Tests

- Update transform tests for retrieval `split_group` mapping.
- Add unit tests covering:
  - retrieval train split-group output
  - retrieval training without `record_uuid`
  - duplicate consolidation by strict consensus match
  - duplicate consolidation fallback on ties
  - retrieval duplicate grouping by `record_uuid` and `chunk_id`
  - reserved `split_group` collision rejection