### PR TITLE
feat: add curated tlmtc train settings

### DIFF
--- a/src/pragmata/core/settings/eval_settings.py
+++ b/src/pragmata/core/settings/eval_settings.py
@@ -63,7 +63,7 @@ class EvalTrainSettings(ResolveSettings):
     train_kwargs: dict[str, Any] = Field(default_factory=dict)
 
     @model_validator(mode="after")
-    def default_target_name(
+    def _default_target_name(
         self,
     ) -> Self:
         """Fill the task-specific target name when the caller omits one."""

--- a/src/pragmata/core/settings/eval_settings.py
+++ b/src/pragmata/core/settings/eval_settings.py
@@ -1,13 +1,19 @@
 """Evaluation workflow settings."""
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Self
 from uuid import uuid4
 
-from pydantic import Field
+from pydantic import Field, PositiveInt, model_validator
 
 from pragmata.core.schemas.annotation_task import Task
 from pragmata.core.settings.settings_base import ResolveSettings
+
+DEFAULT_EVAL_TRAIN_TARGET_NAMES: dict[Task, str] = {
+    Task.RETRIEVAL: "Retrieval evaluation",
+    Task.GROUNDING: "Grounding evaluation",
+    Task.GENERATION: "Generation evaluation",
+}
 
 
 class EvalTrainSettings(ResolveSettings):
@@ -27,6 +33,19 @@ class EvalTrainSettings(ResolveSettings):
         task: Annotation task to train an evaluator for. The task determines the
             Pragmata-owned task mapping, serialization, labels, and internally
             derived split-group column.
+        target_name: Display name passed to tlmtc for training logs and reports.
+            Defaults to a task-specific Pragmata label.
+        checkpoint: Encoder-only Hugging Face checkpoint identifier or local path
+            used for final fine-tuning.
+        proxy_checkpoint: Encoder-only Hugging Face checkpoint identifier used for
+            hyperparameter tuning.
+        scale_learning_rate: Whether tlmtc should scale a proxy-tuned learning
+            rate for the target checkpoint.
+        sequence_length: Maximum tokenized sequence length passed to tlmtc.
+            Defaults to 1024 for paired RAG text with long-context EuroBERT
+            checkpoints.
+        trust_remote_code: Whether Hugging Face loading may execute custom remote
+            code for the selected checkpoints.
         train_kwargs: Additional `train_tlmtc`-specific keyword arguments passed
             through to the tlmtc API. Use this for tlmtc-owned options.
     """
@@ -35,7 +54,22 @@ class EvalTrainSettings(ResolveSettings):
     labeled_data_path: Path | None = None
     export_id: str | None = None
     task: Task
+    target_name: str | None = Field(default=None, min_length=1)
+    checkpoint: str = Field(default="EuroBERT/EuroBERT-610m", min_length=1)
+    proxy_checkpoint: str = Field(default="EuroBERT/EuroBERT-210m", min_length=1)
+    scale_learning_rate: bool = True
+    sequence_length: PositiveInt = 1024
+    trust_remote_code: bool = True
     train_kwargs: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def default_target_name(
+        self,
+    ) -> Self:
+        """Fill the task-specific target name when the caller omits one."""
+        if self.target_name is None:
+            self.target_name = DEFAULT_EVAL_TRAIN_TARGET_NAMES[self.task]
+        return self
 
 
 class EvalPredictSettings(ResolveSettings):

--- a/tests/unit/core/settings/test_eval_settings.py
+++ b/tests/unit/core/settings/test_eval_settings.py
@@ -87,6 +87,12 @@ def test_eval_train_settings_construction_with_defaults() -> None:
     assert settings.labeled_data_path is None
     assert settings.export_id is None
     assert settings.task == Task.RETRIEVAL
+    assert settings.target_name == "Retrieval evaluation"
+    assert settings.checkpoint == "EuroBERT/EuroBERT-610m"
+    assert settings.proxy_checkpoint == "EuroBERT/EuroBERT-210m"
+    assert settings.scale_learning_rate is True
+    assert settings.sequence_length == 1024
+    assert settings.trust_remote_code is True
     assert settings.train_kwargs == {}
 
 
@@ -101,6 +107,7 @@ def test_eval_train_settings_accepts_labeled_data_path() -> None:
 
     assert settings.labeled_data_path == Path("data/labeled.csv")
     assert settings.task == Task.GROUNDING
+    assert settings.target_name == "Grounding evaluation"
 
 
 def test_eval_train_settings_accepts_export_id_and_train_kwargs() -> None:
@@ -109,6 +116,12 @@ def test_eval_train_settings_accepts_export_id_and_train_kwargs() -> None:
         {
             "export_id": "export-001",
             "task": "generation",
+            "target_name": "Custom target",
+            "checkpoint": "custom/checkpoint",
+            "proxy_checkpoint": "custom/proxy",
+            "scale_learning_rate": False,
+            "sequence_length": 384,
+            "trust_remote_code": False,
             "train_kwargs": {
                 "run_id": "custom-train-run",
                 "batch_size": 8,
@@ -118,6 +131,12 @@ def test_eval_train_settings_accepts_export_id_and_train_kwargs() -> None:
 
     assert settings.export_id == "export-001"
     assert settings.task == Task.GENERATION
+    assert settings.target_name == "Custom target"
+    assert settings.checkpoint == "custom/checkpoint"
+    assert settings.proxy_checkpoint == "custom/proxy"
+    assert settings.scale_learning_rate is False
+    assert settings.sequence_length == 384
+    assert settings.trust_remote_code is False
     assert settings.train_kwargs == {
         "run_id": "custom-train-run",
         "batch_size": 8,


### PR DESCRIPTION
### Summary

Adds `pragmata`-level defaults for the small set of `tlmtc` training settings that should differ from plain `tlmtc` defaults for eval evaluator training.

These settings are exposed directly because they define the intended `pragmata` evaluator setup: multilingual long paired-text classification with EuroBERT checkpoints. The broader `tlmtc` training surface remains available through `train_kwargs`, so `pragmata` does not mirror every `tlmtc` argument.

### Key changes

- Add task-dependent default `target_name` values:
  - retrieval: `Retrieval evaluation`
  - grounding: `Grounding evaluation`
  - generation: `Generation evaluation`
- Set `pragmata` evaluator checkpoint defaults:
  - `checkpoint`: `EuroBERT/EuroBERT-610m`
  - `proxy_checkpoint`: `EuroBERT/EuroBERT-210m`
- Enable `scale_learning_rate` by default because the proxy and target checkpoints differ.
- Set `sequence_length` to `1024` for long paired RAG inputs.
- Enable `trust_remote_code` by default for EuroBERT compatibility.
- Keep all remaining `tlmtc` train options in `train_kwargs` rather than exposing them as first-class `pragmata` settings.

The reserved-kwargs merge and collision handling for these curated settings will be implemented in a follow-up adapter PR.

### Tests

- Update eval settings tests for the new train defaults.
- Cover task-derived `target_name` behavior.
- Cover explicit overrides for the newly exposed train settings.