### PR TITLE
feat: add tlmtc train adapter

### DIFF
--- a/src/pragmata/core/eval/tlmtc_adapters.py
+++ b/src/pragmata/core/eval/tlmtc_adapters.py
@@ -1,0 +1,83 @@
+"""tlmtc call boundary for eval workflows."""
+
+from pathlib import Path
+from typing import Any
+
+_RESERVED_TRAIN_KWARGS = frozenset(
+    {
+        "raw_csv",
+        "work_dir",
+        "target_name",
+        "checkpoint",
+        "proxy_checkpoint",
+        "scale_learning_rate",
+        "sequence_length",
+        "trust_remote_code",
+    }
+)
+
+
+def train_evaluator(
+    *,
+    raw_csv: Path,
+    work_dir: Path,
+    target_name: str,
+    checkpoint: str,
+    proxy_checkpoint: str,
+    scale_learning_rate: bool,
+    sequence_length: int,
+    trust_remote_code: bool,
+    train_kwargs: dict[str, Any],
+) -> Any:
+    """Train a pragmata evaluator model through tlmtc.
+
+    Args:
+        raw_csv: tlmtc-compatible labeled training CSV.
+        work_dir: Base eval work directory passed through to tlmtc.
+        target_name: Display name used in tlmtc logs and reports.
+        checkpoint: Target checkpoint used for final fine-tuning.
+        proxy_checkpoint: Proxy checkpoint used for hyperparameter tuning.
+        scale_learning_rate: Whether to scale the proxy-tuned learning rate for
+            the target checkpoint.
+        sequence_length: Maximum tokenized sequence length.
+        trust_remote_code: Whether Hugging Face loading may execute custom
+            checkpoint code.
+        train_kwargs: Additional tlmtc-owned keyword arguments. Keys managed by
+            pragmata's dedicated arguments are rejected.
+
+    Returns:
+        The result returned by ``tlmtc.train_tlmtc``.
+
+    Raises:
+        ImportError: If tlmtc is not installed.
+        ValueError: If ``train_kwargs`` attempts to override a dedicated
+            Pragmata-owned train argument.
+    """
+    overlapping_keys = _RESERVED_TRAIN_KWARGS.intersection(train_kwargs)
+    if overlapping_keys:
+        overlapping = ", ".join(sorted(overlapping_keys))
+        raise ValueError(
+            f"train_kwargs must not override core tlmtc train settings: {overlapping}. "
+            "Pass these via dedicated arguments instead."
+        )
+
+    try:
+        from tlmtc import train_tlmtc
+    except ImportError as exc:
+        raise ImportError(
+            "tlmtc is required for evaluator training. Install pragmata with the 'eval' extra."
+        ) from exc
+
+    train_args: dict[str, Any] = {
+        "raw_csv": raw_csv,
+        "work_dir": work_dir,
+        "target_name": target_name,
+        "checkpoint": checkpoint,
+        "proxy_checkpoint": proxy_checkpoint,
+        "scale_learning_rate": scale_learning_rate,
+        "sequence_length": sequence_length,
+        "trust_remote_code": trust_remote_code,
+    }
+    train_args.update(train_kwargs)
+
+    return train_tlmtc(**train_args)

--- a/src/pragmata/core/eval/tlmtc_adapters.py
+++ b/src/pragmata/core/eval/tlmtc_adapters.py
@@ -64,9 +64,7 @@ def train_evaluator(
     try:
         from tlmtc import train_tlmtc
     except ImportError as exc:
-        raise ImportError(
-            "tlmtc is required for evaluator training. Install pragmata with the 'eval' extra."
-        ) from exc
+        raise ImportError("tlmtc is required for evaluator training. Install pragmata with the 'eval' extra.") from exc
 
     train_args: dict[str, Any] = {
         "raw_csv": raw_csv,

--- a/src/pragmata/core/eval/tlmtc_adapters.py
+++ b/src/pragmata/core/eval/tlmtc_adapters.py
@@ -43,7 +43,7 @@ def train_evaluator(
         trust_remote_code: Whether Hugging Face loading may execute custom
             checkpoint code.
         train_kwargs: Additional tlmtc-owned keyword arguments. Keys managed by
-            pragmata's dedicated arguments are rejected.
+            pragmata are rejected.
 
     Returns:
         The result returned by ``tlmtc.train_tlmtc``.
@@ -57,7 +57,7 @@ def train_evaluator(
     if overlapping_keys:
         overlapping = ", ".join(sorted(overlapping_keys))
         raise ValueError(
-            f"train_kwargs must not override core tlmtc train settings: {overlapping}. "
+            f"train_kwargs must not override pragmata-managed train settings: {overlapping}. "
             "Pass these via dedicated arguments instead."
         )
 

--- a/src/pragmata/core/eval/tlmtc_adapters.py
+++ b/src/pragmata/core/eval/tlmtc_adapters.py
@@ -3,9 +3,12 @@
 from pathlib import Path
 from typing import Any
 
+import pandas as pd
+
+# Keep this in sync with train_evaluator's dedicated arguments.
 _RESERVED_TRAIN_KWARGS = frozenset(
     {
-        "raw_csv",
+        "labeled_data",
         "work_dir",
         "target_name",
         "checkpoint",
@@ -19,7 +22,7 @@ _RESERVED_TRAIN_KWARGS = frozenset(
 
 def train_evaluator(
     *,
-    raw_csv: Path,
+    labeled_data: str | Path | pd.DataFrame,
     work_dir: Path,
     target_name: str,
     checkpoint: str,
@@ -32,7 +35,9 @@ def train_evaluator(
     """Train a pragmata evaluator model through tlmtc.
 
     Args:
-        raw_csv: tlmtc-compatible labeled training CSV.
+        labeled_data: Path to labeled multi-label training data, or an in-memory
+            DataFrame. The data must contain a ``text`` column, at least two
+            binary ``label_*`` columns, and optionally a ``text_pair`` column.
         work_dir: Base eval work directory passed through to tlmtc.
         target_name: Display name used in tlmtc logs and reports.
         checkpoint: Target checkpoint used for final fine-tuning.
@@ -67,7 +72,7 @@ def train_evaluator(
         raise ImportError("tlmtc is required for evaluator training. Install pragmata with the 'eval' extra.") from exc
 
     train_args: dict[str, Any] = {
-        "raw_csv": raw_csv,
+        "labeled_data": labeled_data,
         "work_dir": work_dir,
         "target_name": target_name,
         "checkpoint": checkpoint,

--- a/tests/unit/core/eval/test_tlmtc_adapters.py
+++ b/tests/unit/core/eval/test_tlmtc_adapters.py
@@ -11,12 +11,7 @@ import pytest
 
 from pragmata.core.eval.tlmtc_adapters import train_evaluator
 
-
-_DEDICATED_TRAIN_EVALUATOR_ARGS = [
-    name
-    for name in signature(train_evaluator).parameters
-    if name != "train_kwargs"
-]
+_DEDICATED_TRAIN_EVALUATOR_ARGS = [name for name in signature(train_evaluator).parameters if name != "train_kwargs"]
 
 
 def _train_evaluator_kwargs(
@@ -83,11 +78,7 @@ def test_train_evaluator_rejects_reserved_train_kwargs(
 ) -> None:
     """train_kwargs must not override settings managed by dedicated arguments."""
     with pytest.raises(ValueError, match=reserved_key):
-        train_evaluator(
-            **_train_evaluator_kwargs(
-                train_kwargs={reserved_key: "override"}
-            )
-        )
+        train_evaluator(**_train_evaluator_kwargs(train_kwargs={reserved_key: "override"}))
 
 
 def test_train_evaluator_imports_tlmtc_lazily_and_reports_missing_extra(

--- a/tests/unit/core/eval/test_tlmtc_adapters.py
+++ b/tests/unit/core/eval/test_tlmtc_adapters.py
@@ -19,7 +19,7 @@ def _train_evaluator_kwargs(
     train_kwargs: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     return {
-        "raw_csv": Path("train.csv"),
+        "labeled_data": Path("train.csv"),
         "work_dir": Path("eval"),
         "target_name": "Retrieval evaluation",
         "checkpoint": "EuroBERT/EuroBERT-610m",
@@ -58,7 +58,7 @@ def test_train_evaluator_merges_curated_args_and_train_kwargs(
 
     assert result is expected_result
     assert captured_kwargs == {
-        "raw_csv": Path("train.csv"),
+        "labeled_data": Path("train.csv"),
         "work_dir": Path("eval"),
         "target_name": "Retrieval evaluation",
         "checkpoint": "EuroBERT/EuroBERT-610m",
@@ -69,6 +69,36 @@ def test_train_evaluator_merges_curated_args_and_train_kwargs(
         "run_id": "custom-run",
         "batch_size": 8,
         "verbosity": "quiet",
+    }
+
+
+def test_train_evaluator_forwards_dedicated_args_when_train_kwargs_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """train_evaluator forwards exactly the dedicated args without passthrough kwargs."""
+    captured_kwargs: dict[str, Any] = {}
+    fake_tlmtc = ModuleType("tlmtc")
+    expected_result = object()
+
+    def train_tlmtc(**kwargs: Any) -> object:
+        captured_kwargs.update(kwargs)
+        return expected_result
+
+    setattr(fake_tlmtc, "train_tlmtc", train_tlmtc)
+    monkeypatch.setitem(sys.modules, "tlmtc", fake_tlmtc)
+
+    result = train_evaluator(**_train_evaluator_kwargs(train_kwargs={}))
+
+    assert result is expected_result
+    assert captured_kwargs == {
+        "labeled_data": Path("train.csv"),
+        "work_dir": Path("eval"),
+        "target_name": "Retrieval evaluation",
+        "checkpoint": "EuroBERT/EuroBERT-610m",
+        "proxy_checkpoint": "EuroBERT/EuroBERT-210m",
+        "scale_learning_rate": True,
+        "sequence_length": 1024,
+        "trust_remote_code": True,
     }
 
 

--- a/tests/unit/core/eval/test_tlmtc_adapters.py
+++ b/tests/unit/core/eval/test_tlmtc_adapters.py
@@ -1,0 +1,101 @@
+"""Unit tests for tlmtc eval adapters."""
+
+import sys
+from collections.abc import MutableMapping
+from inspect import signature
+from pathlib import Path
+from types import ModuleType
+from typing import Any, cast
+
+import pytest
+
+from pragmata.core.eval.tlmtc_adapters import train_evaluator
+
+
+_DEDICATED_TRAIN_EVALUATOR_ARGS = [
+    name
+    for name in signature(train_evaluator).parameters
+    if name != "train_kwargs"
+]
+
+
+def _train_evaluator_kwargs(
+    *,
+    train_kwargs: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "raw_csv": Path("train.csv"),
+        "work_dir": Path("eval"),
+        "target_name": "Retrieval evaluation",
+        "checkpoint": "EuroBERT/EuroBERT-610m",
+        "proxy_checkpoint": "EuroBERT/EuroBERT-210m",
+        "scale_learning_rate": True,
+        "sequence_length": 1024,
+        "trust_remote_code": True,
+        "train_kwargs": train_kwargs or {},
+    }
+
+
+def test_train_evaluator_merges_curated_args_and_train_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """train_evaluator forwards curated settings plus tlmtc-owned passthrough kwargs."""
+    captured_kwargs: dict[str, Any] = {}
+    fake_tlmtc = ModuleType("tlmtc")
+    expected_result = object()
+
+    def train_tlmtc(**kwargs: Any) -> object:
+        captured_kwargs.update(kwargs)
+        return expected_result
+
+    setattr(fake_tlmtc, "train_tlmtc", train_tlmtc)
+    monkeypatch.setitem(sys.modules, "tlmtc", fake_tlmtc)
+
+    result = train_evaluator(
+        **_train_evaluator_kwargs(
+            train_kwargs={
+                "run_id": "custom-run",
+                "batch_size": 8,
+                "verbosity": "quiet",
+            }
+        )
+    )
+
+    assert result is expected_result
+    assert captured_kwargs == {
+        "raw_csv": Path("train.csv"),
+        "work_dir": Path("eval"),
+        "target_name": "Retrieval evaluation",
+        "checkpoint": "EuroBERT/EuroBERT-610m",
+        "proxy_checkpoint": "EuroBERT/EuroBERT-210m",
+        "scale_learning_rate": True,
+        "sequence_length": 1024,
+        "trust_remote_code": True,
+        "run_id": "custom-run",
+        "batch_size": 8,
+        "verbosity": "quiet",
+    }
+
+
+@pytest.mark.parametrize("reserved_key", _DEDICATED_TRAIN_EVALUATOR_ARGS)
+def test_train_evaluator_rejects_reserved_train_kwargs(
+    reserved_key: str,
+) -> None:
+    """train_kwargs must not override settings managed by dedicated arguments."""
+    with pytest.raises(ValueError, match=reserved_key):
+        train_evaluator(
+            **_train_evaluator_kwargs(
+                train_kwargs={reserved_key: "override"}
+            )
+        )
+
+
+def test_train_evaluator_imports_tlmtc_lazily_and_reports_missing_extra(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing tlmtc raises an install hint only when training is invoked."""
+    modules = cast(MutableMapping[str, Any], sys.modules)
+    monkeypatch.setitem(modules, "tlmtc", None)
+
+    with pytest.raises(ImportError, match="Install pragmata with the 'eval' extra"):
+        train_evaluator(**_train_evaluator_kwargs())


### PR DESCRIPTION
### Summary

Adds the eval training boundary for calling `tlmtc.train_tlmtc`.

The adapter exposes a `pragmata`-facing `train_evaluator(...)` function, merges dedicated `pragmata` train settings with `train_kwargs`, validates reserved keyword collisions, and imports `tlmtc` lazily so the optional eval dependency is only required when training is invoked.

### Key changes

- Add `src/pragmata/core/eval/tlmtc_adapters.py`.
- Add `train_evaluator(...)` as the internal Pragmata call boundary for evaluator training.
- Forward dedicated train arguments to `tlmtc.train_tlmtc`:
  - `raw_csv`
  - `work_dir`
  - `target_name`
  - `checkpoint`
  - `proxy_checkpoint`
  - `scale_learning_rate`
  - `sequence_length`
  - `trust_remote_code`
- Preserve `train_kwargs` as the pass-through surface for other `tlmtc` train options.
- Reject `train_kwargs` keys that would override dedicated Pragmata-managed arguments.
- Import `tlmtc` lazily and surface an install hint when the eval extra is missing.

### Tests

- Add adapter tests covering:
  - merging dedicated train args with `train_kwargs`
  - forwarding the merged call to `tlmtc.train_tlmtc`
  - returning the raw `tlmtc.train_tlmtc` result
  - rejecting every dedicated adapter argument when repeated in `train_kwargs`
  - lazy import behavior when `tlmtc` is missing