### PR TITLE
fix: ensure train creates eval tool root

### DIFF
--- a/src/pragmata/core/paths/eval_paths.py
+++ b/src/pragmata/core/paths/eval_paths.py
@@ -16,13 +16,23 @@ class EvalTrainPaths:
     """Resolved labeled input path and source provenance for eval train.
 
     Attributes:
+        tool_root: Root directory for eval artifacts. Passed to tlmtc as
+            ``work_dir`` for training.
         training_input_csv: Concrete labeled CSV path consumed by eval train.
         annotation_export_id: Resolved annotation export ID when the input comes
             from the annotation tool. ``None`` for direct user-provided CSV input.
     """
 
+    tool_root: Path
     training_input_csv: Path
     annotation_export_id: str | None = None
+
+    def ensure_dirs(
+        self,
+    ) -> Self:
+        """Create the eval tool directory scaffold."""
+        self.tool_root.mkdir(parents=True, exist_ok=True)
+        return self
 
 
 def find_latest_annotation_export_id(
@@ -109,6 +119,7 @@ def resolve_eval_train_paths(
             raise FileNotFoundError(f"Labeled eval training input CSV does not exist: {training_input_csv}")
 
         return EvalTrainPaths(
+            tool_root=workspace.tool_root("eval"),
             training_input_csv=training_input_csv,
             annotation_export_id=None,
         )
@@ -143,6 +154,7 @@ def resolve_eval_train_paths(
         )
 
     return EvalTrainPaths(
+        tool_root=workspace.tool_root("eval"),
         training_input_csv=training_input_csv,
         annotation_export_id=resolved_export_id,
     )

--- a/tests/unit/core/paths/test_eval_paths.py
+++ b/tests/unit/core/paths/test_eval_paths.py
@@ -81,9 +81,31 @@ def test_resolve_eval_train_paths_uses_direct_labeled_data_path(
     )
 
     assert paths == EvalTrainPaths(
+        tool_root=workspace.base_dir / "eval",
         training_input_csv=input_csv.resolve(),
         annotation_export_id=None,
     )
+
+
+def test_eval_train_paths_ensure_dirs_creates_eval_tool_root(
+    workspace: WorkspacePaths,
+) -> None:
+    """EvalTrainPaths.ensure_dirs creates the eval tool root and returns self."""
+    input_csv = workspace.base_dir / "standalone" / "labeled.csv"
+    input_csv.parent.mkdir()
+    input_csv.write_text("example_id\nexample-1\n", encoding="utf-8")
+    paths = resolve_eval_train_paths(
+        workspace=workspace,
+        task=Task.RETRIEVAL,
+        labeled_data_path=input_csv,
+    )
+
+    assert not paths.tool_root.exists()
+
+    returned = paths.ensure_dirs()
+
+    assert returned is paths
+    assert paths.tool_root.is_dir()
 
 
 def test_resolve_eval_train_paths_rejects_missing_direct_labeled_data_path(
@@ -119,6 +141,7 @@ def test_resolve_eval_train_paths_uses_explicit_annotation_export_id(
 
     expected_csv = workspace.base_dir / "annotation" / "exports" / "export-a" / "retrieval.csv"
     assert paths == EvalTrainPaths(
+        tool_root=workspace.base_dir / "eval",
         training_input_csv=expected_csv,
         annotation_export_id="export-a",
     )
@@ -290,6 +313,7 @@ def test_resolve_eval_train_paths_uses_latest_annotation_export_when_selector_is
 
     expected_csv = workspace.base_dir / "annotation" / "exports" / "newer" / "retrieval.csv"
     assert paths == EvalTrainPaths(
+        tool_root=workspace.base_dir / "eval",
         training_input_csv=expected_csv,
         annotation_export_id="newer",
     )


### PR DESCRIPTION
### Summary

Adds the eval tool root to train path resolution so `eval train` can create `<base_dir>/eval` before handing that directory to `tlmtc` as its `work_dir`.

`pragmata` still does not create `tlmtc`-owned train output directories. It only ensures the eval tool root exists; `tlmtc` remains responsible for creating its own artifact structure below that root.

### Key changes

- Add `tool_root` to `EvalTrainPaths`.
- Add `EvalTrainPaths.ensure_dirs()` for creating the eval tool directory scaffold.
- Resolve `tool_root` as `<base_dir>/eval` for:
  - direct labeled training input
  - annotation-export-backed training input
- Keep train input CSV resolution unchanged.

### Tests

- Update eval train path expectations to include `tool_root`.
- Add coverage that `EvalTrainPaths.ensure_dirs()` creates the eval tool root and returns `self`.