### PR TITLE
feat: add train evaluator API

### DIFF
--- a/src/pragmata/__init__.py
+++ b/src/pragmata/__init__.py
@@ -5,9 +5,9 @@ Only curated, stable symbols should be exposed here.
 
 import logging
 
-from . import annotation, querygen
+from . import annotation, eval, querygen
 from .api import get_version
 
-__all__ = ["annotation", "get_version", "querygen"]
+__all__ = ["annotation", "eval", "get_version", "querygen"]
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/src/pragmata/api/eval.py
+++ b/src/pragmata/api/eval.py
@@ -64,7 +64,7 @@ def train_evaluator(
     """
     settings = EvalTrainSettings.resolve(
         config=load_config_file(config_path) if isinstance(config_path, (str, Path)) else None,
-        env=None, # Environment-derived settings are not wired for train_evaluator yet.
+        env=None,  # Environment-derived settings are not wired for train_evaluator yet.
         overrides={
             "base_dir": base_dir,
             "labeled_data_path": labeled_data_path,
@@ -79,13 +79,12 @@ def train_evaluator(
             "train_kwargs": train_kwargs,
         },
     )
-    workspace = WorkspacePaths.from_base_dir(settings.base_dir)
     train_paths = resolve_eval_train_paths(
-        workspace=workspace,
+        workspace=WorkspacePaths.from_base_dir(settings.base_dir),
         task=settings.task,
         labeled_data_path=settings.labeled_data_path,
         export_id=settings.export_id,
-    )
+    ).ensure_dirs()
 
     eval_frame = import_eval_train_frame(
         path=train_paths.training_input_csv,
@@ -100,7 +99,7 @@ def train_evaluator(
     assert settings.target_name is not None
     return run_tlmtc_train(
         labeled_data=tlmtc_frame,
-        work_dir=workspace.tool_root("eval"),
+        work_dir=train_paths.tool_root,
         target_name=settings.target_name,
         checkpoint=settings.checkpoint,
         proxy_checkpoint=settings.proxy_checkpoint,

--- a/src/pragmata/api/eval.py
+++ b/src/pragmata/api/eval.py
@@ -1,0 +1,111 @@
+"""API orchestration for evaluation workflows."""
+
+from pathlib import Path
+from typing import Any
+
+from pragmata.core.eval.imports import import_eval_train_frame
+from pragmata.core.eval.tlmtc_adapters import run_tlmtc_train
+from pragmata.core.eval.transforms import build_tlmtc_frame
+from pragmata.core.paths.eval_paths import resolve_eval_train_paths
+from pragmata.core.paths.paths import WorkspacePaths
+from pragmata.core.schemas.annotation_task import Task
+from pragmata.core.settings.eval_settings import EvalTrainSettings
+from pragmata.core.settings.settings_base import UNSET, Unset, load_config_file
+
+
+def train_evaluator(
+    *,
+    labeled_data_path: str | Path | Unset = UNSET,
+    export_id: str | Unset = UNSET,
+    task: str | Task | Unset = UNSET,
+    base_dir: str | Path | Unset = UNSET,
+    config_path: str | Path | Unset = UNSET,
+    target_name: str | Unset = UNSET,
+    checkpoint: str | Unset = UNSET,
+    proxy_checkpoint: str | Unset = UNSET,
+    scale_learning_rate: bool | Unset = UNSET,
+    sequence_length: int | Unset = UNSET,
+    trust_remote_code: bool | Unset = UNSET,
+    train_kwargs: dict[str, Any] | Unset = UNSET,
+) -> Any:
+    """Train a supervised evaluator model from labeled Pragmata eval data.
+
+    Args:
+        labeled_data_path: Optional direct path to labeled training data. If
+            omitted, the latest or selected annotation export containing data
+            for the selected ``task`` is used.
+        export_id: Optional annotation export identifier. Ignored when
+            ``labeled_data_path`` is provided. When used, the selected export
+            is resolved to the task-specific training CSV for ``task``.
+        task: Annotation task to train an evaluator for. Supported values are
+            ``"retrieval"``, ``"grounding"``, and ``"generation"``.
+        base_dir: Workspace base directory. Defaults to the current working
+            directory.
+        config_path: Path to a YAML configuration file.
+        target_name: Display name passed to tlmtc for logs and reports.
+            Defaults to the selected task name as an evaluation target.
+        checkpoint: Target checkpoint used for final fine-tuning. Defaults to
+            ``"EuroBERT/EuroBERT-610m"``.
+        proxy_checkpoint: Proxy checkpoint used for hyperparameter tuning.
+            Defaults to ``"EuroBERT/EuroBERT-210m"``.
+        scale_learning_rate: Whether tlmtc should scale a proxy-tuned learning
+            rate for the target checkpoint. Defaults to ``True`` because the
+            default proxy and target checkpoints differ.
+        sequence_length: Maximum combined tokenized sequence length passed to
+            tlmtc for ``text`` and ``text_pair``. Defaults to ``1024``.
+        trust_remote_code: Whether Hugging Face loading may execute custom
+            checkpoint code. Defaults to ``True`` because it is required by the
+            default checkpoint and proxy checkpoint.
+        train_kwargs: Additional tlmtc-owned keyword arguments passed through to
+            ``tlmtc.train_tlmtc``.
+
+    Returns:
+        The result returned by ``tlmtc.train_tlmtc``.
+    """
+    settings = EvalTrainSettings.resolve(
+        config=load_config_file(config_path) if isinstance(config_path, (str, Path)) else None,
+        env=None, # Environment-derived settings are not wired for train_evaluator yet.
+        overrides={
+            "base_dir": base_dir,
+            "labeled_data_path": labeled_data_path,
+            "export_id": export_id,
+            "task": task,
+            "target_name": target_name,
+            "checkpoint": checkpoint,
+            "proxy_checkpoint": proxy_checkpoint,
+            "scale_learning_rate": scale_learning_rate,
+            "sequence_length": sequence_length,
+            "trust_remote_code": trust_remote_code,
+            "train_kwargs": train_kwargs,
+        },
+    )
+    workspace = WorkspacePaths.from_base_dir(settings.base_dir)
+    train_paths = resolve_eval_train_paths(
+        workspace=workspace,
+        task=settings.task,
+        labeled_data_path=settings.labeled_data_path,
+        export_id=settings.export_id,
+    )
+
+    eval_frame = import_eval_train_frame(
+        path=train_paths.training_input_csv,
+        task=settings.task,
+    )
+    tlmtc_frame = build_tlmtc_frame(
+        eval_frame,
+        task=settings.task,
+        mode="train",
+    )
+
+    assert settings.target_name is not None
+    return run_tlmtc_train(
+        labeled_data=tlmtc_frame,
+        work_dir=workspace.tool_root("eval"),
+        target_name=settings.target_name,
+        checkpoint=settings.checkpoint,
+        proxy_checkpoint=settings.proxy_checkpoint,
+        scale_learning_rate=settings.scale_learning_rate,
+        sequence_length=settings.sequence_length,
+        trust_remote_code=settings.trust_remote_code,
+        train_kwargs=settings.train_kwargs,
+    )

--- a/src/pragmata/api/eval.py
+++ b/src/pragmata/api/eval.py
@@ -43,7 +43,7 @@ def train_evaluator(
             directory.
         config_path: Path to a YAML configuration file.
         target_name: Display name passed to tlmtc for logs and reports.
-            Defaults to the selected task name as an evaluation target.
+            Defaults to a task-specific evaluation label, e.g. "Retrieval evaluation".
         checkpoint: Target checkpoint used for final fine-tuning. Defaults to
             ``"EuroBERT/EuroBERT-610m"``.
         proxy_checkpoint: Proxy checkpoint used for hyperparameter tuning.
@@ -60,7 +60,10 @@ def train_evaluator(
             ``tlmtc.train_tlmtc``.
 
     Returns:
-        The result returned by ``tlmtc.train_tlmtc``.
+        Result metadata containing resolved filesystem paths for a single tlmtc
+        training run, including the run ID, run directory, model directory,
+        prepared split artifacts, metadata sidecar, and evaluation artifacts
+        under ``<base_dir>/eval/train_outputs/<run_id>/``.
     """
     settings = EvalTrainSettings.resolve(
         config=load_config_file(config_path) if isinstance(config_path, (str, Path)) else None,

--- a/src/pragmata/eval/__init__.py
+++ b/src/pragmata/eval/__init__.py
@@ -1,0 +1,5 @@
+"""Public evaluation namespace."""
+
+from pragmata.api.eval import train_evaluator as train_evaluator
+
+__all__ = ["train_evaluator"]

--- a/tests/unit/api/test_eval.py
+++ b/tests/unit/api/test_eval.py
@@ -1,0 +1,199 @@
+"""Tests for the eval API orchestration."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from textwrap import dedent
+from typing import Any
+
+import pandas as pd
+import pytest
+
+import pragmata.api.eval as eval_api
+from pragmata.core.paths.paths import WorkspacePaths
+from pragmata.core.schemas.annotation_task import Task
+
+
+def test_train_evaluator_orchestrates_direct_labeled_input(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """train_evaluator imports, transforms, and trains from a direct labeled CSV."""
+    input_csv = tmp_path / "labeled.csv"
+    input_csv.write_text("placeholder\nvalue\n", encoding="utf-8")
+    eval_frame = pd.DataFrame({"source": ["eval"]})
+    tlmtc_frame = pd.DataFrame({"text": ["query"], "text_pair": ["chunk"], "label_relevant": [1]})
+    expected_result = object()
+    calls: dict[str, Any] = {}
+
+    def import_eval_train_frame(
+        *,
+        path: Path,
+        task: Task,
+    ) -> pd.DataFrame:
+        calls["import"] = {"path": path, "task": task}
+        return eval_frame
+
+    def build_tlmtc_frame(
+        frame: pd.DataFrame,
+        *,
+        task: Task,
+        mode: str,
+    ) -> pd.DataFrame:
+        calls["transform"] = {"frame": frame, "task": task, "mode": mode}
+        return tlmtc_frame
+
+    def run_tlmtc_train(
+        **kwargs: Any,
+    ) -> object:
+        calls["train"] = kwargs
+        return expected_result
+
+    monkeypatch.setattr(eval_api, "import_eval_train_frame", import_eval_train_frame)
+    monkeypatch.setattr(eval_api, "build_tlmtc_frame", build_tlmtc_frame)
+    monkeypatch.setattr(eval_api, "run_tlmtc_train", run_tlmtc_train)
+
+    result = eval_api.train_evaluator(
+        labeled_data_path=input_csv,
+        task="retrieval",
+        base_dir=tmp_path,
+        train_kwargs={"run_id": "train-run-1", "verbosity": "quiet"},
+    )
+
+    assert result is expected_result
+    assert calls["import"] == {"path": input_csv.resolve(), "task": Task.RETRIEVAL}
+    assert calls["transform"]["frame"] is eval_frame
+    assert calls["transform"]["task"] == Task.RETRIEVAL
+    assert calls["transform"]["mode"] == "train"
+    assert calls["train"]["labeled_data"] is tlmtc_frame
+    assert {key: value for key, value in calls["train"].items() if key != "labeled_data"} == {
+        "work_dir": tmp_path.resolve() / "eval",
+        "target_name": "Retrieval evaluation",
+        "checkpoint": "EuroBERT/EuroBERT-610m",
+        "proxy_checkpoint": "EuroBERT/EuroBERT-210m",
+        "scale_learning_rate": True,
+        "sequence_length": 1024,
+        "trust_remote_code": True,
+        "train_kwargs": {"run_id": "train-run-1", "verbosity": "quiet"},
+    }
+    assert (tmp_path / "eval").is_dir()
+
+
+def test_train_evaluator_combines_config_and_explicit_overrides(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit train_evaluator args override config values before training."""
+    input_csv = tmp_path / "labeled.csv"
+    input_csv.write_text("placeholder\nvalue\n", encoding="utf-8")
+    config_path = tmp_path / "eval.yml"
+    config_path.write_text(
+        dedent(
+            """\
+            task: grounding
+            checkpoint: config/checkpoint
+            proxy_checkpoint: config/proxy
+            target_name: Config target
+            scale_learning_rate: false
+            sequence_length: 512
+            trust_remote_code: false
+            train_kwargs:
+              batch_size: 8
+            """
+        ),
+        encoding="utf-8",
+    )
+    tlmtc_frame = pd.DataFrame({"text": ["answer"], "text_pair": ["context"], "label_support_present": [1]})
+    train_calls: list[dict[str, Any]] = []
+
+    monkeypatch.setattr(eval_api, "import_eval_train_frame", lambda *, path, task: pd.DataFrame({"path": [path]}))
+    monkeypatch.setattr(eval_api, "build_tlmtc_frame", lambda frame, *, task, mode: tlmtc_frame)
+
+    def run_tlmtc_train(
+        **kwargs: Any,
+    ) -> str:
+        train_calls.append(kwargs)
+        return "trained"
+
+    monkeypatch.setattr(eval_api, "run_tlmtc_train", run_tlmtc_train)
+
+    result = eval_api.train_evaluator(
+        labeled_data_path=input_csv,
+        base_dir=tmp_path,
+        config_path=config_path,
+        checkpoint="override/checkpoint",
+        sequence_length=2048,
+        train_kwargs={"batch_size": 16, "run_id": "override-run"},
+    )
+
+    assert result == "trained"
+    assert len(train_calls) == 1
+    assert train_calls[0]["labeled_data"] is tlmtc_frame
+    assert {key: value for key, value in train_calls[0].items() if key != "labeled_data"} == {
+        "work_dir": tmp_path.resolve() / "eval",
+        "target_name": "Config target",
+        "checkpoint": "override/checkpoint",
+        "proxy_checkpoint": "config/proxy",
+        "scale_learning_rate": False,
+        "sequence_length": 2048,
+        "trust_remote_code": False,
+        "train_kwargs": {"batch_size": 16, "run_id": "override-run"},
+    }
+
+
+def test_train_evaluator_resolves_annotation_export_for_selected_task(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """train_evaluator asks path resolution for the selected export and task."""
+    expected_result = object()
+    seen: dict[str, Any] = {}
+    tlmtc_frame = pd.DataFrame({"text": ["query"], "text_pair": ["answer"], "label_helpful": [1]})
+
+    @dataclass(frozen=True, slots=True)
+    class FakeTrainPaths:
+        tool_root: Path
+        training_input_csv: Path
+
+        def ensure_dirs(self) -> "FakeTrainPaths":
+            seen["ensure_dirs_called"] = True
+            return self
+
+    def resolve_eval_train_paths(
+        *,
+        workspace: WorkspacePaths,
+        task: Task,
+        labeled_data_path: Path | None = None,
+        export_id: str | None = None,
+    ) -> FakeTrainPaths:
+        seen["resolve_paths"] = {
+            "workspace_base_dir": workspace.base_dir,
+            "task": task,
+            "labeled_data_path": labeled_data_path,
+            "export_id": export_id,
+        }
+        return FakeTrainPaths(
+            tool_root=workspace.tool_root("eval"),
+            training_input_csv=tmp_path / "annotation" / "exports" / "export-1" / "generation.csv",
+        )
+
+    monkeypatch.setattr(eval_api, "resolve_eval_train_paths", resolve_eval_train_paths)
+    monkeypatch.setattr(eval_api, "import_eval_train_frame", lambda *, path, task: pd.DataFrame({"path": [path]}))
+    monkeypatch.setattr(eval_api, "build_tlmtc_frame", lambda frame, *, task, mode: tlmtc_frame)
+    monkeypatch.setattr(eval_api, "run_tlmtc_train", lambda **kwargs: expected_result)
+
+    result = eval_api.train_evaluator(
+        export_id="export-1",
+        task=Task.GENERATION,
+        base_dir=tmp_path,
+    )
+
+    assert result is expected_result
+    assert seen == {
+        "resolve_paths": {
+            "workspace_base_dir": tmp_path.resolve(),
+            "task": Task.GENERATION,
+            "labeled_data_path": None,
+            "export_id": "export-1",
+        },
+        "ensure_dirs_called": True,
+    }


### PR DESCRIPTION
### Summary

Adds the public Python API surface for training `pragmata` eval models. `train_evaluator` now resolves eval train settings, selects the labeled input source, imports and validates the task-specific training data, transforms it into a `tlmtc` training frame, and delegates training through the eval `tlmtc` adapter.

### Key changes

- Add `pragmata.api.eval.train_evaluator`.
- Support direct labeled CSV input through `labeled_data_path`.
- Support annotation export input through:
  - explicit `export_id`
  - latest matching annotation export for the selected `task`
- Resolve and create the eval tool root before handing control to `tlmtc`.
- Import and validate the selected task CSV.
- Transform `pragmata` eval columns into `tlmtc` train columns.
- Pass the transformed dataframe directly to `run_tlmtc_train`.
- Forward curated train settings:
  - `target_name`
  - `checkpoint`
  - `proxy_checkpoint`
  - `scale_learning_rate`
  - `sequence_length`
  - `trust_remote_code`
- Preserve `train_kwargs` for all other `tlmtc`-owned training options.
- Add the public `pragmata.eval` namespace.
- Expose `eval` from the top-level `pragmata` package.

### Notes

This PR adds only the Python API. CLI wiring is intentionally left for a follow-up PR.

The API returns the `tlmtc` train result directly, so callers receive the resolved training run paths and generated artifact locations owned by `tlmtc`.

### Tests

- Added unit tests for train evaluator API orchestration.
- Cover direct labeled CSV input.
- Cover config plus explicit override precedence.
- Cover selected annotation export path resolution.