### PR TITLE
feat(annotation): wire completeness into export (columns + meta summary)

### DIFF
--- a/src/pragmata/core/annotation/export_fetcher.py
+++ b/src/pragmata/core/annotation/export_fetcher.py
@@ -180,6 +180,60 @@ def walk_retrieval_records(client: rg.Argilla, settings: AnnotationSettings) -> 
     return snapshots
 
 
+def fetch_retrieval_from_records(
+    snapshots: list[RetrievalRecordSnapshot],
+    user_lookup: dict[UUID, str],
+    *,
+    include_discarded: bool,
+) -> list[tuple[AnnotationModel, list[LogicalConstraint]]]:
+    """Project pre-walked retrieval snapshots into typed rows.
+
+    The status filter is applied in Python (per user-response) since the
+    walk skipped the query-level filter to feed the completeness pass too.
+    Mirrors ``fetch_task``'s retrieval branch but reuses ``_build_row`` so
+    typed-row construction has one source of truth.
+    """
+    accepted = {"submitted", "discarded"} if include_discarded else {"submitted"}
+    check_constraints = CONSTRAINT_CHECKERS[Task.RETRIEVAL]
+    rows: list[tuple[AnnotationModel, list[LogicalConstraint]]] = []
+    missing_uuid_count = 0
+    for snap in snapshots:
+        if not snap.record_uuid:
+            missing_uuid_count += 1
+            # Mirror fetch_task: keep going, the row still gets emitted with
+            # an empty record_uuid (the export uses this signal too).
+        record = snap.record
+        created_at: datetime = record._model.updated_at or record._model.inserted_at
+        inserted_at: datetime = record._model.inserted_at
+        language: str | None = record.metadata.get("language")
+        record_status: str = record.status
+        for user_id, response_status, answers in snap.response_user_pairs:
+            if response_status not in accepted:
+                continue
+            base = {
+                "record_uuid": snap.record_uuid,
+                "annotator_id": user_lookup.get(user_id, str(user_id)),
+                "language": language,
+                "calibration": snap.calibration,
+                "inserted_at": inserted_at,
+                "created_at": created_at,
+                "record_status": record_status,
+                "response_status": response_status,
+                "discard_reason": answers.get("discard_reason"),
+                "discard_notes": answers.get("discard_notes"),
+                "notes": answers.get("notes") or "",
+            }
+            row = _build_row(Task.RETRIEVAL, base=base, answers=answers, fields=record.fields, metadata=record.metadata)
+            violations = check_constraints(row) if response_status == "submitted" else []
+            rows.append((row, violations))
+    if missing_uuid_count:
+        logger.warning(
+            "task=retrieval: %d record(s) missing record_uuid metadata — included with empty string",
+            missing_uuid_count,
+        )
+    return rows
+
+
 def fetch_task(
     client: rg.Argilla,
     settings: AnnotationSettings,

--- a/src/pragmata/core/annotation/export_runner.py
+++ b/src/pragmata/core/annotation/export_runner.py
@@ -6,16 +6,28 @@ import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import argilla as rg
 
-from pragmata.core.annotation.export_fetcher import AnnotationModel, build_user_lookup, fetch_task
+from pragmata.core.annotation.completeness import (
+    CompletenessReport,
+    PanelCompleteness,
+    compute_completeness_from_records,
+)
+from pragmata.core.annotation.export_fetcher import (
+    AnnotationModel,
+    build_user_lookup,
+    fetch_retrieval_from_records,
+    fetch_task,
+    walk_retrieval_records,
+)
 from pragmata.core.annotation.logical_constraints import LogicalConstraint
 from pragmata.core.csv_io import _to_csv_value
 from pragmata.core.paths.annotation_paths import AnnotationExportPaths
 from pragmata.core.schemas.annotation_export import (
     AnnotationExportMeta,
+    CompletenessSummary,
     GenerationAnnotation,
     GenerationExportRow,
     GroundingAnnotation,
@@ -62,6 +74,8 @@ class ExportResult:
         constraint_summary: Violation count per ``constraint_id`` (the stable
             short identifier defined in :mod:`logical_constraints`).
         n_annotators: Count of distinct annotators per task.
+        completeness: Retrieval panel-completeness report (``None`` when
+            retrieval was not in the exported task set).
     """
 
     paths: AnnotationExportPaths
@@ -69,17 +83,21 @@ class ExportResult:
     row_counts: dict[Task, int]
     constraint_summary: dict[str, int]
     n_annotators: dict[Task, int]
+    completeness: CompletenessReport | None = None
 
 
 def write_export_csv(
     rows: list[tuple[RetrievalAnnotation | GroundingAnnotation | GenerationAnnotation, list[LogicalConstraint]]],
     path: Path,
     task: Task,
+    *,
+    completeness: dict[str, PanelCompleteness] | None = None,
 ) -> None:
     """Write annotation rows to a CSV using the task's export-row schema.
 
     The schema (``TASK_EXPORT_ROW[task]``) models the full on-disk format,
-    including ``constraint_violated`` and ``constraint_details``. Writes
+    including ``constraint_violated`` / ``constraint_details`` (all tasks)
+    and ``panel_complete`` / ``n_annotated_chunks`` (retrieval only). Writes
     atomically via a .tmp file; cleans up on failure. Always writes the
     header row even when rows is empty.
 
@@ -90,6 +108,10 @@ def write_export_csv(
             in the legacy verbose ``";"``-joined format for human readers.
         path: Final output path.
         task: Task type — determines the export-row schema.
+        completeness: Optional per-``record_uuid`` panel-completeness map.
+            Only used for retrieval; ignored otherwise. Rows whose
+            ``record_uuid`` is absent fall back to the schema defaults
+            (``False`` / ``0``).
     """
     row_cls = TASK_EXPORT_ROW[task]
     headers = list(row_cls.model_fields.keys())
@@ -99,10 +121,20 @@ def write_export_csv(
             writer = csv.DictWriter(f, fieldnames=headers)
             writer.writeheader()
             for annotation, violations in rows:
+                extras: dict[str, Any] = {}
+                if task == Task.RETRIEVAL and completeness is not None:
+                    pc = completeness.get(annotation.record_uuid)
+                    if pc is not None:
+                        extras["panel_complete"] = pc.panel_complete
+                        extras["n_annotated_chunks"] = pc.n_annotated_chunks
+                        extras["n_submitted_chunks"] = pc.n_submitted_chunks
+                        extras["n_discarded_chunks"] = pc.n_discarded_chunks
+                        extras["n_records_seen"] = pc.n_records_seen
                 export_row = row_cls(
                     **annotation.model_dump(),
                     constraint_violated=bool(violations),
                     constraint_details=";".join(c.violation_string() for c in violations),
+                    **extras,
                 )
                 raw = export_row.model_dump(mode="json")
                 writer.writerow({k: _to_csv_value(raw[k]) for k in headers})
@@ -144,6 +176,8 @@ def assemble_export_meta(
     n_annotators: dict[Task, int],
     calibration_enabled: dict[Task, bool],
     constraint_summary: dict[str, int],
+    completeness_summary: CompletenessSummary | None = None,
+    completeness_status: str = "not_requested",
 ) -> AnnotationExportMeta:
     """Assemble run-level provenance metadata for an annotation export.
 
@@ -157,6 +191,11 @@ def assemble_export_meta(
         calibration_enabled: Whether the topology declared a calibration
             dataset for each task.
         constraint_summary: Violation count keyed by ``constraint_id``.
+        completeness_summary: Retrieval panel-completeness aggregates;
+            ``None`` unless retrieval was exported and computed successfully.
+        completeness_status: ``"ok"`` / ``"failed"`` / ``"not_requested"``.
+            Disambiguates ``completeness_summary=None`` between "retrieval
+            not in tasks" and "compute_completeness raised".
 
     Returns:
         Provenance sidecar with an internally stamped creation time.
@@ -171,6 +210,8 @@ def assemble_export_meta(
         n_annotators=n_annotators,
         calibration_enabled=calibration_enabled,
         constraint_summary=constraint_summary,
+        completeness_summary=completeness_summary,
+        completeness_status=completeness_status,  # type: ignore[arg-type]
     )
 
 
@@ -203,22 +244,49 @@ def run_export(
             n_annotators={},
             calibration_enabled={},
             constraint_summary={},
+            completeness_status="not_requested",
         )
         write_export_meta(meta, paths.export_meta_json)
         return ExportResult(paths=paths, files={}, row_counts={}, constraint_summary={}, n_annotators={})
 
     user_lookup = build_user_lookup(client)
 
+    # Single retrieval walk shared between the row-emission fetch and the
+    # completeness aggregator. fetch_task for non-retrieval tasks walks
+    # their own datasets as before; only retrieval was doing two scrolls.
+    retrieval_snapshots = walk_retrieval_records(client, settings) if Task.RETRIEVAL in tasks else None
+
     task_rows: dict[Task, list[tuple[AnnotationModel, list[LogicalConstraint]]]] = {}
     for task in tasks:
-        task_rows[task] = fetch_task(client, settings, task, user_lookup, include_discarded=include_discarded)
+        if task == Task.RETRIEVAL and retrieval_snapshots is not None:
+            task_rows[task] = fetch_retrieval_from_records(
+                retrieval_snapshots, user_lookup, include_discarded=include_discarded
+            )
+        else:
+            task_rows[task] = fetch_task(client, settings, task, user_lookup, include_discarded=include_discarded)
+
+    completeness_report: CompletenessReport | None = None
+    completeness_status = "not_requested"
+    if retrieval_snapshots is not None:
+        try:
+            completeness_report = compute_completeness_from_records(retrieval_snapshots)
+            completeness_status = "ok"
+        except Exception:
+            # Completeness is derived (a sidecar summary + extra CSV columns);
+            # an aggregation error must not lose an already-fetched export.
+            # ``completeness_status="failed"`` distinguishes this case from
+            # the "retrieval not requested" path so consumers reading the
+            # sidecar can tell them apart.
+            logger.exception("compute_completeness failed; continuing without panel-completeness sidecar")
+            completeness_status = "failed"
 
     task_paths = {task: getattr(paths, TASK_CSV_ATTR[task]) for task in tasks}
 
     written: list[Path] = []
     try:
         for task in tasks:
-            write_export_csv(task_rows[task], task_paths[task], task)
+            completeness_map = completeness_report.by_uuid if (completeness_report and task == Task.RETRIEVAL) else None
+            write_export_csv(task_rows[task], task_paths[task], task, completeness=completeness_map)
             written.append(task_paths[task])
     except Exception:
         logger.error("Export failed — rolling back %d written file(s)", len(written))
@@ -245,6 +313,8 @@ def run_export(
         n_annotators=n_annotators,
         calibration_enabled=calibration_enabled,
         constraint_summary=constraint_summary,
+        completeness_summary=completeness_report.summary if completeness_report else None,
+        completeness_status=completeness_status,
     )
     write_export_meta(meta, paths.export_meta_json)
 
@@ -254,6 +324,7 @@ def run_export(
         row_counts=row_counts,
         constraint_summary=constraint_summary,
         n_annotators=n_annotators,
+        completeness=completeness_report,
     )
 
 

--- a/src/pragmata/core/annotation/export_runner.py
+++ b/src/pragmata/core/annotation/export_runner.py
@@ -6,7 +6,7 @@ import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import argilla as rg
 
@@ -177,7 +177,7 @@ def assemble_export_meta(
     calibration_enabled: dict[Task, bool],
     constraint_summary: dict[str, int],
     completeness_summary: CompletenessSummary | None = None,
-    completeness_status: str = "not_requested",
+    completeness_status: Literal["ok", "failed", "not_requested"] = "not_requested",
 ) -> AnnotationExportMeta:
     """Assemble run-level provenance metadata for an annotation export.
 
@@ -211,7 +211,7 @@ def assemble_export_meta(
         calibration_enabled=calibration_enabled,
         constraint_summary=constraint_summary,
         completeness_summary=completeness_summary,
-        completeness_status=completeness_status,  # type: ignore[arg-type]
+        completeness_status=completeness_status,
     )
 
 
@@ -266,17 +266,19 @@ def run_export(
             task_rows[task] = fetch_task(client, settings, task, user_lookup, include_discarded=include_discarded)
 
     completeness_report: CompletenessReport | None = None
-    completeness_status = "not_requested"
+    completeness_status: Literal["ok", "failed", "not_requested"] = "not_requested"
     if retrieval_snapshots is not None:
         try:
             completeness_report = compute_completeness_from_records(retrieval_snapshots)
             completeness_status = "ok"
         except Exception:
-            # Completeness is derived (a sidecar summary + extra CSV columns);
-            # an aggregation error must not lose an already-fetched export.
-            # ``completeness_status="failed"`` distinguishes this case from
-            # the "retrieval not requested" path so consumers reading the
-            # sidecar can tell them apart.
+            # Deliberately broad: completeness is a derived artifact (a sidecar
+            # summary + extra CSV columns), so any aggregation failure must not
+            # lose an already-fetched export. We catch ``Exception`` (not
+            # ``BaseException``) on purpose — KeyboardInterrupt/SystemExit still
+            # propagate and abort the run. The failure is logged with a full
+            # traceback below, and ``completeness_status="failed"`` distinguishes
+            # this from the "retrieval not requested" path for sidecar consumers.
             logger.exception("compute_completeness failed; continuing without panel-completeness sidecar")
             completeness_status = "failed"
 

--- a/src/pragmata/core/schemas/annotation_export.py
+++ b/src/pragmata/core/schemas/annotation_export.py
@@ -92,10 +92,35 @@ class GenerationAnnotation(AnnotationBase):
 
 
 class RetrievalExportRow(RetrievalAnnotation):
-    """Full on-disk CSV row for retrieval: extends RetrievalAnnotation with constraint metadata."""
+    """Full on-disk CSV row for retrieval: annotation + constraint + panel-completeness metadata.
+
+    Column order is **annotation fields → constraint columns → completeness columns**.
+    New derived columns APPEND at the tail (keep header diffs minimal for
+    downstream consumers; never reorder existing columns).
+    """
 
     constraint_violated: bool
     constraint_details: str = ""
+    # panel_complete is the STRICT default: True iff every K chunk in the
+    # panel has at least one SUBMITTED response. Discarded responses are
+    # abstentions (pragmata's DiscardReason enum is refusal-only), not
+    # judgements, so they don't count toward "ready for metric scoring".
+    # Permissive derivation in 1 line: `n_annotated_chunks == n_retrieved_chunks`.
+    panel_complete: bool = False
+    # All three counts are DISTINCT chunk_ids in this panel. The sets aren't
+    # disjoint: a chunk with both submitted and discarded responses (from
+    # different annotators) is counted in n_annotated_chunks AND
+    # n_submitted_chunks AND n_discarded_chunks. So
+    # n_submitted + n_discarded >= n_annotated (equality when no mixed chunks).
+    # n_mixed_chunks = n_submitted + n_discarded - n_annotated.
+    n_annotated_chunks: int = 0  # union: chunks with any terminal response
+    n_submitted_chunks: int = 0  # chunks with any submitted response (used by panel_complete)
+    n_discarded_chunks: int = 0  # chunks with any discarded response
+    # n_records_seen = distinct chunk-records observed for this panel. Used
+    # for the integrity check (records_seen != n_retrieved_chunks → records
+    # lost or duplicated upstream). Surfaced per-row so consumers can spot
+    # corrupted panels in dataframe pipelines without re-joining the sidecar.
+    n_records_seen: int = 0
 
 
 class GroundingExportRow(GroundingAnnotation):
@@ -160,6 +185,11 @@ class AnnotationExportMeta(BaseModel):
     n_annotators: dict[Task, NonNegativeInt]
     calibration_enabled: dict[Task, bool] = Field(default_factory=dict)
     constraint_summary: dict[str, NonNegativeInt]
+    # completeness_status disambiguates completeness_summary=None between
+    # "retrieval not in tasks" (not_requested) and "compute_completeness
+    # raised" (failed). When ok, completeness_summary is populated.
+    completeness_summary: CompletenessSummary | None = None
+    completeness_status: Literal["ok", "failed", "not_requested"] = "not_requested"
 
     @model_validator(mode="after")
     def validate_keys_match_tasks(self) -> "AnnotationExportMeta":

--- a/tests/unit/core/annotation/test_export_runner.py
+++ b/tests/unit/core/annotation/test_export_runner.py
@@ -231,6 +231,58 @@ class TestWriteExportCsv:
         for field in grounding_fields:
             assert field in header
 
+    def test_retrieval_default_completeness_columns_when_map_omitted(self, tmp_path: Path) -> None:
+        """Without a completeness map, retrieval rows fall back to schema defaults."""
+        row = _retrieval()
+        out = tmp_path / "out.csv"
+        write_export_csv([(row, [])], out, Task.RETRIEVAL)
+        with out.open() as f:
+            data = list(csv.DictReader(f))
+        assert data[0]["panel_complete"] == "false"
+        assert data[0]["n_annotated_chunks"] == "0"
+
+    def test_retrieval_completeness_columns_stamped_from_map(self, tmp_path: Path) -> None:
+        """Each retrieval row picks up its panel's completeness columns by record_uuid."""
+        from pragmata.core.annotation.completeness import PanelCompleteness
+
+        row = _retrieval()
+        completeness = {
+            row.record_uuid: PanelCompleteness(
+                record_uuid=row.record_uuid,
+                k=5,
+                n_annotated_chunks=3,
+                n_submitted_chunks=2,
+                n_discarded_chunks=1,
+                panel_complete=False,
+                n_records_seen=5,
+            )
+        }
+        out = tmp_path / "out.csv"
+        write_export_csv([(row, [])], out, Task.RETRIEVAL, completeness=completeness)
+        with out.open() as f:
+            data = list(csv.DictReader(f))
+        assert data[0]["panel_complete"] == "false"
+        assert data[0]["n_annotated_chunks"] == "3"
+        assert data[0]["n_submitted_chunks"] == "2"
+        assert data[0]["n_discarded_chunks"] == "1"
+        assert data[0]["n_records_seen"] == "5"
+
+    def test_completeness_map_ignored_for_non_retrieval_tasks(self, tmp_path: Path) -> None:
+        """Passing a completeness map for grounding/generation is a no-op (those rows lack the columns)."""
+        from pragmata.core.annotation.completeness import PanelCompleteness
+
+        row = _grounding()
+        completeness = {
+            row.record_uuid: PanelCompleteness(row.record_uuid, 5, 5, 5, 0, True, 5),
+        }
+        out = tmp_path / "out.csv"
+        # Should not raise even though grounding has no panel_complete column.
+        write_export_csv([(row, [])], out, Task.GROUNDING, completeness=completeness)
+        with out.open() as f:
+            header = next(csv.reader(f))
+        assert "panel_complete" not in header
+        assert "n_annotated_chunks" not in header
+
 
 # ---------------------------------------------------------------------------
 # Export-row schema round-trip via csv_io
@@ -507,6 +559,105 @@ class TestExportMetaSidecar:
 
         payload = json.loads(result.paths.export_meta_json.read_text())
         assert payload["dataset_id"] is None
+
+    def test_sidecar_includes_completeness_summary_when_retrieval_exported(
+        self, tmp_path: Path, mock_client: MagicMock
+    ) -> None:
+        """Retrieval export populates ``completeness_summary`` in the meta sidecar.
+
+        Uses a side_effect-based mock so fetch_task AND compute_completeness
+        each see a fresh iterator over the same records.
+        """
+        from pragmata.api.annotation_export import export_annotations
+
+        records = [
+            _make_record(
+                fields=RETRIEVAL_FIELDS,
+                metadata={**BASE_METADATA, "chunk_id": f"chunk-{i}", "n_retrieved_chunks": 5},
+                responses=_retrieval_responses(_UID1),
+            )
+            for i in range(5)
+        ]
+        dataset = MagicMock()
+        dataset.records.side_effect = lambda *a, **kw: iter(records)
+        _set_production_dataset(mock_client, dataset)
+
+        result = export_annotations(base_dir=tmp_path, export_id="test-run", tasks=[Task.RETRIEVAL])
+
+        payload = json.loads(result.paths.export_meta_json.read_text())
+        summary = payload["completeness_summary"]
+        assert summary is not None
+        assert summary["n_panels"] == 1
+        assert summary["n_complete"] == 1
+        assert summary["fraction_complete"] == 1.0
+        assert summary["by_k_bucket"]["k_eq_5"] == {"n_panels": 1, "n_complete": 1}
+        assert result.completeness is not None
+        assert result.completeness.by_uuid[BASE_METADATA["record_uuid"]].panel_complete is True
+
+    def test_sidecar_completeness_summary_null_when_retrieval_not_exported(
+        self, tmp_path: Path, mock_client: MagicMock
+    ) -> None:
+        """No retrieval in tasks → no completeness pass, summary is null."""
+        from pragmata.api.annotation_export import export_annotations
+
+        result = export_annotations(base_dir=tmp_path, export_id="test-run", tasks=[Task.GROUNDING])
+        payload = json.loads(result.paths.export_meta_json.read_text())
+        assert payload["completeness_summary"] is None
+        assert payload["completeness_status"] == "not_requested"
+        assert result.completeness is None
+
+    def test_sidecar_completeness_status_ok_when_retrieval_succeeds(
+        self, tmp_path: Path, mock_client: MagicMock
+    ) -> None:
+        """Retrieval exported + completeness computed → completeness_status='ok'."""
+        from pragmata.api.annotation_export import export_annotations
+
+        records = [
+            _make_record(
+                fields=RETRIEVAL_FIELDS,
+                metadata={**BASE_METADATA, "chunk_id": f"chunk-{i}", "n_retrieved_chunks": 5},
+                responses=_retrieval_responses(_UID1),
+            )
+            for i in range(5)
+        ]
+        dataset = MagicMock()
+        dataset.records.side_effect = lambda *a, **kw: iter(records)
+        _set_production_dataset(mock_client, dataset)
+
+        result = export_annotations(base_dir=tmp_path, export_id="test-run", tasks=[Task.RETRIEVAL])
+
+        payload = json.loads(result.paths.export_meta_json.read_text())
+        assert payload["completeness_status"] == "ok"
+        assert payload["completeness_summary"] is not None
+
+    def test_sidecar_completeness_status_failed_when_compute_raises(
+        self, tmp_path: Path, mock_client: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Retrieval exported but compute_completeness raised → status='failed', summary=null.
+
+        Disambiguates the failure case from 'retrieval not requested' so
+        downstream consumers reading the sidecar can tell them apart.
+        """
+        import pragmata.core.annotation.export_runner as runner_mod
+        from pragmata.api.annotation_export import export_annotations
+
+        # Force compute_completeness_from_records to raise; export should still succeed.
+        def _boom(_snapshots):
+            raise RuntimeError("synthetic completeness aggregation failure")
+
+        monkeypatch.setattr(runner_mod, "compute_completeness_from_records", _boom)
+
+        dataset = MagicMock()
+        dataset.records.side_effect = lambda *a, **kw: iter([])
+        _set_production_dataset(mock_client, dataset)
+
+        result = export_annotations(base_dir=tmp_path, export_id="test-run", tasks=[Task.RETRIEVAL])
+
+        payload = json.loads(result.paths.export_meta_json.read_text())
+        assert payload["completeness_status"] == "failed"
+        assert payload["completeness_summary"] is None
+        # Primary export artifact still written (failure didn't roll it back).
+        assert result.paths.retrieval_annotation_csv.exists()
 
 
 class TestResolveCalibrationEnabled:

--- a/tests/unit/core/schemas/test_annotation_export.py
+++ b/tests/unit/core/schemas/test_annotation_export.py
@@ -251,17 +251,32 @@ def test_export_row_requires_constraint_violated(valid_retrieval):
 
 
 @pytest.mark.parametrize(
-    ("row_cls", "annotation_cls"),
+    ("row_cls", "annotation_cls", "extra_cols"),
     [
-        (RetrievalExportRow, RetrievalAnnotation),
-        (GroundingExportRow, GroundingAnnotation),
-        (GenerationExportRow, GenerationAnnotation),
+        (
+            RetrievalExportRow,
+            RetrievalAnnotation,
+            [
+                "constraint_violated",
+                "constraint_details",
+                "panel_complete",
+                "n_annotated_chunks",
+                "n_submitted_chunks",
+                "n_discarded_chunks",
+                "n_records_seen",
+            ],
+        ),
+        (GroundingExportRow, GroundingAnnotation, ["constraint_violated", "constraint_details"]),
+        (GenerationExportRow, GenerationAnnotation, ["constraint_violated", "constraint_details"]),
     ],
 )
-def test_export_row_field_order(row_cls, annotation_cls):
-    """Export row fields are annotation fields followed by the two constraint columns, in order."""
+def test_export_row_field_order(row_cls, annotation_cls, extra_cols):
+    """Export row fields are annotation fields followed by the task's tail columns, in order.
+
+    Retrieval gains panel_complete + n_annotated_chunks after the constraint columns.
+    """
     fields = list(row_cls.model_fields.keys())
-    expected = list(annotation_cls.model_fields.keys()) + ["constraint_violated", "constraint_details"]
+    expected = list(annotation_cls.model_fields.keys()) + extra_cols
     assert fields == expected
 
 


### PR DESCRIPTION
**Stack (6 PRs):** #246 → #247 → #268 → #248 → #269 → #249

**This PR (3/6):** Split out of #247 (was 1001 lines / XL). Wires the panel-completeness calculator (#247) into the retrieval export path. Stacked on #247.

---

## Scope

### Schema
- `core/schemas/annotation_export.py`:
  - `RetrievalExportRow` += `panel_complete: bool`, `n_annotated_chunks: int`, `n_submitted_chunks: int`, `n_discarded_chunks: int`, `n_records_seen: int`. All defaulted; appended at the tail so existing column order is preserved.
  - New `KBucketStat` (per-K-bucket panel counts) and `CompletenessSummary` (aggregates + `by_k_bucket` cross-tab + full per-K histogram) Pydantic models.
  - `AnnotationExportMeta` += `completeness_summary: CompletenessSummary | None` and `completeness_status: Literal["ok","failed","not_requested"]`.

### Single-walk retrieval pipeline
- `core/annotation/export_fetcher.py`: new `walk_retrieval_records` (one Argilla scroll per dataset, no status filter — sees discards-only records too so the integrity check has the full record set) + `RetrievalRecordSnapshot` dataclass + `fetch_retrieval_from_records` (status filter applied in Python at typed-row construction).
- `core/annotation/export_runner.py`: when `Task.RETRIEVAL in tasks`, walks once and feeds both the typed-row projection and the completeness aggregator. `compute_completeness` failures degrade the sidecar (sets `completeness_status="failed"`) without losing the already-fetched export.

### API
- `annotation/__init__.py`: lazy re-exports for `CompletenessSummary`, `KBucketStat`.

### Tests
- `test_export_runner.py`: `write_export_csv` stamps completeness columns by `record_uuid`; sidecar carries `completeness_summary`; `completeness_status` ok/failed/not_requested set explicitly.
- `test_annotation_export.py`: `RetrievalExportRow` field-order locked.

## Why

The retriever is threshold-based, so dropping partial panels biases the metrics toward small K (MNAR). Surfacing both per-row predicate columns AND a bucketed sidecar aggregate lets the eval pipeline either filter complete panels per-K or apply condensed-list scoring without re-querying the data layer.

The single-walk shape (one retrieval scroll feeds both fetch_task and compute_completeness) costs one extra in-memory pass over already-fetched records but spares the Argilla server a second full scroll per export — meaningful on the in-flight batches (~hundreds of panels).

The STRICT `panel_complete` policy question (which shape to ship — this PR assumes (A) from #247) is discussed on #247, since that's where the predicate is actually computed; this PR just surfaces it as a column.

## Test plan
- [ ] `uv run python -m pytest tests/unit/core/annotation/test_export_runner.py tests/unit/core/schemas/test_annotation_export.py`