### PR TITLE
feat(annotation): status API + CLI command

### DIFF
--- a/src/pragmata/annotation/__init__.py
+++ b/src/pragmata/annotation/__init__.py
@@ -15,30 +15,36 @@ from typing import TYPE_CHECKING
 
 __all__ = [
     "ExportResult",
+    "HeadlineTotals",
     "IaaReport",
     "ImportResult",
     "Locale",
     "SetupResult",
+    "StatusReport",
     "Task",
     "UserSpec",
     "compute_iaa",
     "export_annotations",
     "import_records",
+    "report_status",
     "setup",
     "teardown",
 ]
 
 _LAZY: dict[str, tuple[str, str]] = {
     "ExportResult": ("pragmata.core.annotation.export_runner", "ExportResult"),
+    "HeadlineTotals": ("pragmata.core.annotation.panel_status", "HeadlineTotals"),
     "IaaReport": ("pragmata.core.schemas.iaa_report", "IaaReport"),
     "ImportResult": ("pragmata.api.annotation_import", "ImportResult"),
     "Locale": ("pragmata.core.schemas.annotation_task", "Locale"),
     "SetupResult": ("pragmata.core.annotation.setup", "SetupResult"),
+    "StatusReport": ("pragmata.core.annotation.panel_status", "StatusReport"),
     "Task": ("pragmata.core.schemas.annotation_task", "Task"),
     "UserSpec": ("pragmata.core.settings.annotation_settings", "UserSpec"),
     "compute_iaa": ("pragmata.api.annotation_iaa", "compute_iaa"),
     "export_annotations": ("pragmata.api.annotation_export", "export_annotations"),
     "import_records": ("pragmata.api.annotation_import", "import_records"),
+    "report_status": ("pragmata.api.annotation_status", "report_status"),
     "setup": ("pragmata.api.annotation_setup", "setup"),
     "teardown": ("pragmata.api.annotation_setup", "teardown"),
 }
@@ -65,7 +71,10 @@ if TYPE_CHECKING:
     from pragmata.api.annotation_import import import_records as import_records
     from pragmata.api.annotation_setup import setup as setup
     from pragmata.api.annotation_setup import teardown as teardown
+    from pragmata.api.annotation_status import report_status as report_status
     from pragmata.core.annotation.export_runner import ExportResult as ExportResult
+    from pragmata.core.annotation.panel_status import HeadlineTotals as HeadlineTotals
+    from pragmata.core.annotation.panel_status import StatusReport as StatusReport
     from pragmata.core.annotation.setup import SetupResult as SetupResult
     from pragmata.core.schemas.annotation_task import Locale as Locale
     from pragmata.core.schemas.annotation_task import Task as Task

--- a/src/pragmata/api/annotation_status.py
+++ b/src/pragmata/api/annotation_status.py
@@ -1,0 +1,53 @@
+"""Annotation status API - live per-panel completeness report.
+
+Pure read and config-free: resolves Argilla credentials, then walks the live
+retrieval datasets (optionally narrowed by workspace) with no local topology
+config. The optional ``--tag-partial-panels`` advisory write ships in a
+follow-up PR so the read path carries no Argilla mutation surface.
+"""
+
+import logging
+import os
+
+from pragmata.core.annotation.client import resolve_argilla_client
+from pragmata.core.annotation.panel_status import StatusReport, compute_panel_status, compute_task_progress
+from pragmata.core.settings.settings_base import UNSET, Unset, resolve_api_key
+
+logger = logging.getLogger(__name__)
+
+
+def report_status(
+    *,
+    api_url: str | Unset = UNSET,
+    api_key: str | Unset = UNSET,
+    workspace: str | None = None,
+) -> StatusReport:
+    """Fetch live retrieval panel status from Argilla (config-free).
+
+    Credential resolution (config-free):
+    - ``api_url``: kwarg > ``ARGILLA_API_URL`` env
+    - ``api_key``: kwarg > ``ARGILLA_API_KEY`` env (secrets never live in config)
+
+    Args:
+        api_url: Argilla server URL.
+        api_key: Argilla API key.
+        workspace: If set, only datasets in this Argilla workspace.
+
+    Returns:
+        ``StatusReport`` with the all-task ``progress`` summary plus the
+        retrieval per-panel facts.
+    """
+    url = api_url if isinstance(api_url, str) else os.environ.get("ARGILLA_API_URL")
+    key = api_key if isinstance(api_key, str) else resolve_api_key("argilla")
+    client = resolve_argilla_client(url, key)
+    progress = compute_task_progress(client, workspace=workspace)
+    report = compute_panel_status(client, workspace=workspace).with_progress(progress)
+    logger.info(
+        "Status: %d panels, %d complete (%.0f%%), %d overlap-satisfied, %d integrity warnings",
+        report.n_panels,
+        report.n_complete,
+        100.0 * report.n_complete / report.n_panels if report.n_panels else 0.0,
+        report.n_overlap_satisfied,
+        report.n_integrity_warnings,
+    )
+    return report

--- a/src/pragmata/cli/commands/annotation.py
+++ b/src/pragmata/cli/commands/annotation.py
@@ -214,6 +214,102 @@ def export_command(
         typer.echo(f"  {path}")
 
 
+def _render_table(headers: list[str], rows: list[tuple[str, ...]], aligns: str) -> list[str]:
+    """Aligned fixed-width table as a list of lines.
+
+    ``aligns`` is one char per column: 'l' (left) or 'r' (right).
+    """
+    widths = [len(h) for h in headers]
+    for row in rows:
+        for i, cell in enumerate(row):
+            widths[i] = max(widths[i], len(cell))
+
+    def _fmt(cells: tuple[str, ...]) -> str:
+        return "  ".join(
+            cell.rjust(widths[i]) if aligns[i] == "r" else cell.ljust(widths[i]) for i, cell in enumerate(cells)
+        ).rstrip()
+
+    return [_fmt(tuple(headers)), *[_fmt(r) for r in rows]]
+
+
+@annotation_app.command("status")
+def status_command(
+    api_url: str | None = _api_url_opt,
+    api_key: str | None = _api_key_opt,
+    workspace: str | None = typer.Option(
+        None, "--workspace", help="Only datasets in this Argilla workspace. Default: all workspaces."
+    ),
+    by_workspace: bool = typer.Option(False, "--by-workspace", help="Add a per-workspace progress breakdown."),
+    by_dataset: bool = typer.Option(False, "--by-dataset", help="Add a per-dataset progress breakdown."),
+) -> None:
+    """Report live annotation progress across all tasks, plus retrieval panel-completeness.
+
+    Config-free: walks every Argilla dataset. Record progress (total / completed)
+    is shown per task; the retrieval row also carries panel-completeness. Add
+    --by-workspace / --by-dataset for finer breakdowns.
+    """
+    from pragmata import annotation
+
+    report = annotation.report_status(
+        api_url=UNSET if api_url is None else api_url,
+        api_key=UNSET if api_key is None else api_key,
+        workspace=workspace,
+    )
+
+    def _num(n: int) -> str:
+        return f"{n:,}"
+
+    def _pct(done: int, total: int) -> str:
+        return f"{round(100 * done / total)}%" if total else "0%"
+
+    prog = report.progress
+    g = prog.grand
+    typer.echo(
+        f"records: {_num(g.total)} total · {_num(g.completed)} completed "
+        f"({_pct(g.completed, g.total)}) · {_num(g.pending)} pending"
+    )
+    typer.echo("")
+
+    # By task (default). The retrieval row carries panel-completeness; other
+    # tasks are single-record and have no panels ("-").
+    task_rows: list[tuple[str, ...]] = []
+    for row in prog.by_task:
+        if row.task == "retrieval":
+            panels = (_num(report.n_panels), _num(report.n_complete), _num(report.n_overlap_satisfied))
+        else:
+            panels = ("–", "–", "–")
+        task_rows.append((row.label, _num(row.total), _num(row.completed), _pct(row.completed, row.total), *panels))
+    for line in _render_table(["TASK", "TOTAL", "COMPLETED", "%", "PANELS", "COMPL", "OVERLAP"], task_rows, "lrrrrrr"):
+        typer.echo(line)
+
+    if by_workspace:
+        typer.echo("")
+        ws_rows = [
+            (row.label, row.task, _num(row.total), _num(row.completed), _pct(row.completed, row.total))
+            for row in prog.by_workspace
+        ]
+        for line in _render_table(["WORKSPACE", "TASK", "TOTAL", "COMPL", "%"], ws_rows, "llrrr"):
+            typer.echo(line)
+
+    if by_dataset:
+        typer.echo("")
+        ds_rows = [
+            (row.label, _num(row.total), _num(row.completed), _pct(row.completed, row.total)) for row in prog.by_dataset
+        ]
+        for line in _render_table(["DATASET", "TOTAL", "COMPL", "%"], ds_rows, "lrrr"):
+            typer.echo(line)
+
+    if report.n_integrity_warnings:
+        typer.echo("")
+        typer.echo(f"integrity warnings: {report.n_integrity_warnings} panel(s) (records != n_retrieved_chunks)")
+        typer.echo(
+            "  note: panel_complete uses live record-count K; the export sidecar uses the metadata K, "
+            "so flagged panels may read panel_complete=False in retrieval.csv even if shown complete above."
+        )
+    if report.n_orphans_skipped:
+        typer.echo(f"orphans skipped: {report.n_orphans_skipped} record(s) with empty record_uuid")
+
+
 @annotation_app.command("iaa")
 def iaa_command(
     export_id: str = typer.Argument(..., help="Export run identifier whose CSVs to analyse."),

--- a/src/pragmata/cli/commands/annotation.py
+++ b/src/pragmata/cli/commands/annotation.py
@@ -1,5 +1,7 @@
 """CLI commands for annotation pipeline."""
 
+from collections.abc import Sequence
+
 import typer
 
 from pragmata.api import UNSET
@@ -214,7 +216,7 @@ def export_command(
         typer.echo(f"  {path}")
 
 
-def _render_table(headers: list[str], rows: list[tuple[str, ...]], aligns: str) -> list[str]:
+def _render_table(headers: list[str], rows: Sequence[tuple[str, ...]], aligns: str) -> list[str]:
     """Aligned fixed-width table as a list of lines.
 
     ``aligns`` is one char per column: 'l' (left) or 'r' (right).
@@ -263,6 +265,7 @@ def status_command(
         return f"{round(100 * done / total)}%" if total else "0%"
 
     prog = report.progress
+    assert prog is not None  # report_status always attaches the all-task progress
     g = prog.grand
     typer.echo(
         f"records: {_num(g.total)} total · {_num(g.completed)} completed "
@@ -279,7 +282,9 @@ def status_command(
         else:
             panels = ("–", "–", "–")
         task_rows.append((row.label, _num(row.total), _num(row.completed), _pct(row.completed, row.total), *panels))
-    for line in _render_table(["TASK", "TOTAL", "COMPLETED", "%", "PANELS", "COMPL", "OVERLAP"], task_rows, "lrrrrrr"):
+    for line in _render_table(
+        ["TASK", "TOTAL", "COMPLETED", "%", "PANELS", "PANEL-COMPL", "OVERLAP"], task_rows, "lrrrrrr"
+    ):
         typer.echo(line)
 
     if by_workspace:

--- a/tests/test_facade_lazy.py
+++ b/tests/test_facade_lazy.py
@@ -117,15 +117,18 @@ def test_dir_returns_public_surface() -> None:
 
     expected = {
         "ExportResult",
+        "HeadlineTotals",
         "IaaReport",
         "ImportResult",
         "Locale",
         "SetupResult",
+        "StatusReport",
         "Task",
         "UserSpec",
         "compute_iaa",
         "export_annotations",
         "import_records",
+        "report_status",
         "setup",
         "teardown",
     }

--- a/tests/unit/api/test_status_api.py
+++ b/tests/unit/api/test_status_api.py
@@ -1,0 +1,79 @@
+"""Tests for the annotation status API — Argilla client is fully mocked."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+WS = "dom_retrieval"
+
+
+@pytest.fixture()
+def mock_client(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    client = MagicMock()
+    client.datasets = []  # config-free: an iterable of dataset handles
+
+    import pragmata.api.annotation_status as status_module
+
+    monkeypatch.setattr(status_module, "resolve_argilla_client", lambda api_url, api_key: client)
+    monkeypatch.delenv("ARGILLA_API_URL", raising=False)
+    return client
+
+
+def _record(
+    *,
+    record_id: str = "rec-x",
+    record_uuid: str = "u1",
+    chunk_id: str = "c1",
+    n_retrieved_chunks: int = 5,
+    response_statuses: list[str] | None = None,
+) -> MagicMock:
+    metadata = {
+        "record_uuid": record_uuid,
+        "chunk_id": chunk_id,
+        "n_retrieved_chunks": n_retrieved_chunks,
+    }
+    rec = MagicMock()
+    rec.id = record_id
+    rec.metadata = metadata
+    responses = []
+    for s in response_statuses or []:
+        r = MagicMock()
+        r.status = s
+        responses.append(r)
+    rec.responses = responses
+    return rec
+
+
+def _dataset(
+    name: str, records: list[MagicMock], *, workspace: str = WS, min_submitted: int = 1, progress: dict | None = None
+) -> MagicMock:
+    ds = MagicMock()
+    ds.name = name
+    ds.workspace.name = workspace
+    ds.records.side_effect = lambda *a, **kw: iter(records)
+    ds.progress.return_value = progress or {"total": 0, "completed": 0, "pending": 0}
+    ds.settings.distribution.min_submitted = min_submitted
+    return ds
+
+
+class TestReportStatus:
+    def test_empty_server_reports_zero(self, mock_client: MagicMock) -> None:
+        from pragmata.api.annotation_status import report_status
+
+        report = report_status(api_key="test-key")
+        assert report.n_panels == 0
+        assert report.n_complete == 0
+
+    def test_panel_facts_returned(self, mock_client: MagicMock) -> None:
+        from pragmata.api.annotation_status import report_status
+
+        records = [_record(chunk_id=f"c{i}", response_statuses=["submitted"]) for i in range(5)]
+        mock_client.datasets = [
+            _dataset("retrieval_production", records, progress={"total": 5, "completed": 5, "pending": 0})
+        ]
+
+        report = report_status(api_key="test-key")
+        assert report.n_panels == 1
+        assert report.n_complete == 1
+        assert report.panels[(WS, "u1")].panel_complete is True
+        assert report.headline.total == 5

--- a/tests/unit/cli/test_cli_annotation.py
+++ b/tests/unit/cli/test_cli_annotation.py
@@ -49,6 +49,83 @@ def _make_report(*, alpha: float | None = 0.6, ci_lower: float | None = 0.3, ci_
     )
 
 
+class TestStatusCommand:
+    def _stub_report(
+        self,
+        *,
+        n_panels: int = 2,
+        n_complete: int = 1,
+        n_overlap_satisfied: int = 1,
+        n_integrity_warnings: int = 0,
+        n_orphans_skipped: int = 0,
+    ):
+        from pragmata.core.annotation.panel_status import (
+            HeadlineTotals,
+            ProgressReport,
+            ProgressRow,
+            StatusReport,
+        )
+
+        progress = ProgressReport(
+            grand=HeadlineTotals(total=100, completed=20, pending=80),
+            by_task=[
+                ProgressRow(label="retrieval", task="retrieval", total=60, completed=10, pending=50),
+                ProgressRow(label="grounding", task="grounding", total=20, completed=4, pending=16),
+                ProgressRow(label="generation", task="generation", total=20, completed=6, pending=14),
+            ],
+            by_workspace=[ProgressRow(label="ws1_retrieval", task="retrieval", total=60, completed=10, pending=50)],
+            by_dataset=[
+                ProgressRow(
+                    label="ws1_retrieval/retrieval_production", task="retrieval", total=60, completed=10, pending=50
+                )
+            ],
+        )
+        return StatusReport(
+            panels={},
+            headline=HeadlineTotals(total=60, completed=10, pending=50),
+            n_panels=n_panels,
+            n_complete=n_complete,
+            n_overlap_satisfied=n_overlap_satisfied,
+            n_integrity_warnings=n_integrity_warnings,
+            n_orphans_skipped=n_orphans_skipped,
+        ).with_progress(progress)
+
+    @patch("pragmata.annotation.report_status")
+    def test_status_shows_all_tasks_and_panels(self, mock_status):
+        mock_status.return_value = self._stub_report()
+        result = runner.invoke(app, ["annotation", "status"])
+        assert result.exit_code == 0
+        assert "records: 100 total" in result.output
+        assert "20 completed" in result.output
+        for task in ("retrieval", "grounding", "generation"):
+            assert task in result.output  # all three tasks displayed
+        assert "PANELS" in result.output
+        assert "–" in result.output  # non-retrieval tasks show a dash for panels
+
+    @patch("pragmata.annotation.report_status")
+    def test_status_reports_integrity_warnings_when_present(self, mock_status):
+        mock_status.return_value = self._stub_report(n_integrity_warnings=3)
+        result = runner.invoke(app, ["annotation", "status"])
+        assert result.exit_code == 0
+        assert "integrity warnings: 3" in result.output
+
+    @patch("pragmata.annotation.report_status")
+    def test_status_by_workspace_and_by_dataset_flags(self, mock_status):
+        mock_status.return_value = self._stub_report()
+        out_ws = runner.invoke(app, ["annotation", "status", "--by-workspace"]).output
+        assert "WORKSPACE" in out_ws and "ws1_retrieval" in out_ws
+        out_ds = runner.invoke(app, ["annotation", "status", "--by-dataset"]).output
+        assert "DATASET" in out_ds and "retrieval_production" in out_ds
+
+    @patch("pragmata.annotation.report_status")
+    def test_status_threads_defaults(self, mock_status):
+        mock_status.return_value = self._stub_report()
+        runner.invoke(app, ["annotation", "status"])
+        kwargs = mock_status.call_args.kwargs
+        assert kwargs["api_url"] is UNSET
+        assert kwargs["workspace"] is None
+
+
 class TestIaaCommand:
     @patch("pragmata.annotation.compute_iaa")
     def test_displays_alpha_with_ci(self, mock_iaa):


### PR DESCRIPTION
**Stack (6 PRs):** #246 → #247 → #268 → #248 → #269 → #249

**This PR (5/6):** Split out of #248 (was 975 lines / L). Exposes the panel-status core engine (#248) as a CLI command and API function. Stacked on #248.

---

## Scope

- **New `pragmata annotation status` CLI**: reads live retrieval datasets and reports per-panel completeness across prod + cal in one call, plus the all-task record-progress summary (total/completed across retrieval/grounding/generation) as an aligned table, grouped by task by default, with `--by-workspace` / `--by-dataset` for finer breakdowns. Pure read; no Argilla mutations.
- CLI: `--workspace` to scope; credentials via `--api-url/--api-key` or env.
- `api/annotation_status.py`: `report_status()` wraps `compute_panel_status` + `compute_task_progress` for the CLI/API surface.

### API
- `annotation/__init__.py`: lazy re-exports for `HeadlineTotals`, `PanelStatus`, `StatusReport`, `report_status`.

### Tests
- `test_status_api.py`: `report_status()` assembly of panel + progress reports.
- `test_cli_annotation.py`: CLI output formatting, `--workspace` scoping, `--by-workspace`/`--by-dataset` breakdowns.

The `--tag-partial-panels` advisory write ships in #249.

## Test plan
- [ ] `uv run python -m pytest tests/unit/api/test_status_api.py tests/unit/cli/test_cli_annotation.py`