### PR TITLE
feat: add eval train command

### DIFF
--- a/src/pragmata/api/eval.py
+++ b/src/pragmata/api/eval.py
@@ -67,7 +67,7 @@ def train_evaluator(
     """
     settings = EvalTrainSettings.resolve(
         config=load_config_file(config_path) if isinstance(config_path, (str, Path)) else None,
-        env=None, # Environment-derived settings are not wired for train_evaluator yet.
+        env=None,  # Environment-derived settings are not wired for train_evaluator yet.
         overrides={
             "base_dir": base_dir,
             "labeled_data_path": labeled_data_path,

--- a/src/pragmata/api/eval.py
+++ b/src/pragmata/api/eval.py
@@ -67,7 +67,7 @@ def train_evaluator(
     """
     settings = EvalTrainSettings.resolve(
         config=load_config_file(config_path) if isinstance(config_path, (str, Path)) else None,
-        env=None,  # Environment-derived settings are not wired for train_evaluator yet.
+        env=None, # Environment-derived settings are not wired for train_evaluator yet.
         overrides={
             "base_dir": base_dir,
             "labeled_data_path": labeled_data_path,

--- a/src/pragmata/cli/app.py
+++ b/src/pragmata/cli/app.py
@@ -6,10 +6,12 @@ import typer
 
 from pragmata.api import get_version
 from pragmata.cli.commands.annotation import annotation_app
+from pragmata.cli.commands.eval import eval_app
 from pragmata.cli.commands.querygen import querygen_app
 
 app = typer.Typer(add_completion=False)
 app.add_typer(annotation_app, name="annotation")
+app.add_typer(eval_app, name="eval")
 app.add_typer(querygen_app, name="querygen")
 
 

--- a/src/pragmata/cli/commands/eval.py
+++ b/src/pragmata/cli/commands/eval.py
@@ -91,3 +91,4 @@ def train_evaluator_command(
     typer.echo("Evaluator training run complete.")
     typer.echo(f"run_id: {result.paths.run_id}")
     typer.echo(f"run_directory: {result.paths.run_dir}")
+    typer.echo(f"model_directory: {result.paths.model_dir}")

--- a/src/pragmata/cli/commands/eval.py
+++ b/src/pragmata/cli/commands/eval.py
@@ -1,0 +1,93 @@
+"""CLI commands for evaluation workflows."""
+
+import typer
+
+from pragmata import eval
+from pragmata.api import UNSET
+from pragmata.cli.parsing import parse_cli_value
+
+eval_app = typer.Typer(help="Evaluation commands.")
+
+
+@eval_app.command("train-evaluator")
+def train_evaluator_command(
+    labeled_data_path: str | None = typer.Option(
+        None,
+        "--labeled-data-path",
+        help="Path to labeled eval training CSV. If omitted, an annotation export is used.",
+    ),
+    export_id: str | None = typer.Option(
+        None,
+        "--export-id",
+        help="Annotation export identifier. Ignored when --labeled-data-path is provided.",
+    ),
+    task: str | None = typer.Option(
+        None,
+        "--task",
+        help="Eval task to train for: retrieval, grounding, or generation.",
+    ),
+    base_dir: str | None = typer.Option(
+        None,
+        "--base-dir",
+        help="Workspace base directory. Defaults to current working directory.",
+    ),
+    config_path: str | None = typer.Option(
+        None,
+        "--config",
+        help="Path to the config file.",
+    ),
+    target_name: str | None = typer.Option(
+        None,
+        "--target-name",
+        help="Display name passed to tlmtc logs and reports.",
+    ),
+    checkpoint: str | None = typer.Option(
+        None,
+        "--checkpoint",
+        help="Target Hugging Face checkpoint used for final fine-tuning.",
+    ),
+    proxy_checkpoint: str | None = typer.Option(
+        None,
+        "--proxy-checkpoint",
+        help="Proxy Hugging Face checkpoint used for hyperparameter tuning.",
+    ),
+    scale_learning_rate: bool | None = typer.Option(
+        None,
+        "--scale-learning-rate/--no-scale-learning-rate",
+        help="Enable or disable tlmtc learning-rate scaling between proxy and target checkpoints.",
+    ),
+    sequence_length: int | None = typer.Option(
+        None,
+        "--sequence-length",
+        help="Maximum combined tokenized sequence length for text and text_pair.",
+    ),
+    trust_remote_code: bool | None = typer.Option(
+        None,
+        "--trust-remote-code/--no-trust-remote-code",
+        help="Allow or disallow Hugging Face custom checkpoint code execution.",
+    ),
+    train_kwargs: str | None = typer.Option(
+        None,
+        "--train-kwargs",
+        help="Additional tlmtc train_tlmtc keyword arguments. Accepts a JSON object.",
+    ),
+) -> None:
+    """Train a supervised evaluator model."""
+    result = eval.train_evaluator(
+        labeled_data_path=UNSET if labeled_data_path is None else labeled_data_path,
+        export_id=UNSET if export_id is None else export_id,
+        task=UNSET if task is None else task,
+        base_dir=UNSET if base_dir is None else base_dir,
+        config_path=UNSET if config_path is None else config_path,
+        target_name=UNSET if target_name is None else target_name,
+        checkpoint=UNSET if checkpoint is None else checkpoint,
+        proxy_checkpoint=UNSET if proxy_checkpoint is None else proxy_checkpoint,
+        scale_learning_rate=UNSET if scale_learning_rate is None else scale_learning_rate,
+        sequence_length=UNSET if sequence_length is None else sequence_length,
+        trust_remote_code=UNSET if trust_remote_code is None else trust_remote_code,
+        train_kwargs=parse_cli_value(train_kwargs),
+    )
+
+    typer.echo("Evaluator training run complete.")
+    typer.echo(f"run_id: {result.paths.run_id}")
+    typer.echo(f"run_directory: {result.paths.run_dir}")

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -1,0 +1,11 @@
+"""Shared helpers for CLI unit tests."""
+
+import re
+
+
+ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def strip_ansi(text: str) -> str:
+    """Remove ANSI color escapes from CLI output."""
+    return ANSI_ESCAPE_RE.sub("", text)

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -2,7 +2,6 @@
 
 import re
 
-
 ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 

--- a/tests/unit/cli/test_cli_eval.py
+++ b/tests/unit/cli/test_cli_eval.py
@@ -1,6 +1,5 @@
 """Tests CLI commands for evaluation workflows."""
 
-import re
 from pathlib import Path
 from typing import Any
 
@@ -10,20 +9,16 @@ from typer.testing import CliRunner
 from pragmata.api import UNSET
 from pragmata.cli.app import app
 from pragmata.cli.commands.eval import eval_app
+from tests.unit.cli.conftest import strip_ansi
 
 runner = CliRunner()
-
-ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
-
-
-def strip_ansi(text: str) -> str:
-    return ANSI_ESCAPE_RE.sub("", text)
 
 
 class _TrainResult:
     class _Paths:
         run_id = "train-run-123"
         run_dir = Path("workspace/eval/train_outputs/train-run-123")
+        model_dir = Path("workspace/eval/train_outputs/train-run-123/model")
 
     paths = _Paths()
 
@@ -220,3 +215,5 @@ class TestTrainEvaluatorCommand:
         assert "run_id: train-run-123" in result.output
         assert "run_directory:" in result.output
         assert "workspace/eval/train_outputs/train-run-123" in result.output
+        assert "model_directory:" in result.output
+        assert "workspace/eval/train_outputs/train-run-123/model" in result.output

--- a/tests/unit/cli/test_cli_eval.py
+++ b/tests/unit/cli/test_cli_eval.py
@@ -1,0 +1,222 @@
+"""Tests CLI commands for evaluation workflows."""
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from pragmata.api import UNSET
+from pragmata.cli.app import app
+from pragmata.cli.commands.eval import eval_app
+
+runner = CliRunner()
+
+ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def strip_ansi(text: str) -> str:
+    return ANSI_ESCAPE_RE.sub("", text)
+
+
+class _TrainResult:
+    class _Paths:
+        run_id = "train-run-123"
+        run_dir = Path("workspace/eval/train_outputs/train-run-123")
+
+    paths = _Paths()
+
+
+def test_eval_command_registered() -> None:
+    result = runner.invoke(app, ["--help"])
+
+    assert result.exit_code == 0
+    assert "eval" in result.output
+
+
+class TestTrainEvaluatorCommand:
+    """Tests for the eval train-evaluator CLI command."""
+
+    def test_root_app_help_available(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("COLUMNS", "200")
+        result = runner.invoke(app, ["eval", "train-evaluator", "--help"], color=False)
+        output = strip_ansi(result.output)
+
+        assert result.exit_code == 0
+        assert "Train a supervised evaluator model." in output
+        assert "--train-kwargs" in output
+
+    def test_help_available(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("COLUMNS", "200")
+        result = runner.invoke(eval_app, ["--help"], color=False)
+        output = strip_ansi(result.output)
+
+        assert result.exit_code == 0
+        assert "Train a supervised evaluator model." in output
+        assert "--labeled-data-path" in output
+        assert "--export-id" in output
+        assert "--task" in output
+        assert "--target-name" in output
+        assert "--checkpoint" in output
+        assert "--proxy-checkpoint" in output
+        assert "--scale-learning-rate" in output
+        assert "--no-scale-learning-rate" in output
+        assert "--sequence-length" in output
+        assert "--trust-remote-code" in output
+        assert "--no-trust-remote-code" in output
+        assert "--train-kwargs" in output
+
+    def test_maps_omitted_options_to_unset(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_train_evaluator(**kwargs: Any) -> _TrainResult:
+            captured.update(kwargs)
+            return _TrainResult()
+
+        monkeypatch.setattr("pragmata.eval.train_evaluator", fake_train_evaluator)
+
+        result = runner.invoke(eval_app, [])
+
+        expected_keys = {
+            "labeled_data_path",
+            "export_id",
+            "task",
+            "base_dir",
+            "config_path",
+            "target_name",
+            "checkpoint",
+            "proxy_checkpoint",
+            "scale_learning_rate",
+            "sequence_length",
+            "trust_remote_code",
+            "train_kwargs",
+        }
+
+        assert result.exit_code == 0
+        assert set(captured) == expected_keys
+
+        for key in expected_keys:
+            assert captured[key] is UNSET
+
+    def test_delegates_to_public_api(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_train_evaluator(**kwargs: Any) -> _TrainResult:
+            captured.update(kwargs)
+            return _TrainResult()
+
+        monkeypatch.setattr("pragmata.eval.train_evaluator", fake_train_evaluator)
+
+        result = runner.invoke(
+            eval_app,
+            [
+                "--labeled-data-path",
+                "exports/retrieval.csv",
+                "--export-id",
+                "ignored-export",
+                "--task",
+                "retrieval",
+                "--base-dir",
+                "workspace",
+                "--config",
+                "eval.yml",
+                "--target-name",
+                "Retrieval quality",
+                "--checkpoint",
+                "target/checkpoint",
+                "--proxy-checkpoint",
+                "proxy/checkpoint",
+                "--sequence-length",
+                "2048",
+                "--train-kwargs",
+                '{"run_id": "custom-run", "verbosity": "quiet"}',
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert captured == {
+            "labeled_data_path": "exports/retrieval.csv",
+            "export_id": "ignored-export",
+            "task": "retrieval",
+            "base_dir": "workspace",
+            "config_path": "eval.yml",
+            "target_name": "Retrieval quality",
+            "checkpoint": "target/checkpoint",
+            "proxy_checkpoint": "proxy/checkpoint",
+            "scale_learning_rate": UNSET,
+            "sequence_length": 2048,
+            "trust_remote_code": UNSET,
+            "train_kwargs": {"run_id": "custom-run", "verbosity": "quiet"},
+        }
+
+    def test_forwards_boolean_flags(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_train_evaluator(**kwargs: Any) -> _TrainResult:
+            captured.update(kwargs)
+            return _TrainResult()
+
+        monkeypatch.setattr("pragmata.eval.train_evaluator", fake_train_evaluator)
+
+        result = runner.invoke(
+            eval_app,
+            [
+                "--no-scale-learning-rate",
+                "--trust-remote-code",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert captured["scale_learning_rate"] is False
+        assert captured["trust_remote_code"] is True
+
+    def test_scale_learning_rate_flag_true(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_train_evaluator(**kwargs: Any) -> _TrainResult:
+            captured.update(kwargs)
+            return _TrainResult()
+
+        monkeypatch.setattr("pragmata.eval.train_evaluator", fake_train_evaluator)
+
+        result = runner.invoke(eval_app, ["--scale-learning-rate", "--no-trust-remote-code"])
+
+        assert result.exit_code == 0
+        assert captured["scale_learning_rate"] is True
+        assert captured["trust_remote_code"] is False
+
+    def test_prints_run_summary(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def fake_train_evaluator(**kwargs: Any) -> _TrainResult:
+            return _TrainResult()
+
+        monkeypatch.setattr("pragmata.eval.train_evaluator", fake_train_evaluator)
+
+        result = runner.invoke(eval_app, [])
+
+        assert result.exit_code == 0
+        assert "Evaluator training run complete." in result.output
+        assert "run_id: train-run-123" in result.output
+        assert "run_directory:" in result.output
+        assert "workspace/eval/train_outputs/train-run-123" in result.output

--- a/tests/unit/cli/test_cli_querygen.py
+++ b/tests/unit/cli/test_cli_querygen.py
@@ -1,20 +1,14 @@
 """Tests CLI command for synthetic query generation."""
 
-import re
 from pathlib import Path
 
 from typer.testing import CliRunner
 
 from pragmata.api import UNSET
 from pragmata.cli.app import app
+from tests.unit.cli.conftest import strip_ansi
 
 runner = CliRunner()
-
-ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
-
-
-def strip_ansi(text: str) -> str:
-    return ANSI_ESCAPE_RE.sub("", text)
 
 
 class _PreparedResult:


### PR DESCRIPTION
### Summary

Adds CLI support for training `pragmata` eval models.

The new `pragmata eval train-evaluator` command delegates to the public `pragmata.eval.train_evaluator` API, preserving the API-owned orchestration while exposing the train workflow through the Typer CLI.

### Key changes

- Add `src/pragmata/cli/commands/eval.py`.
- Register the `eval` command group on the root CLI app.
- Add `eval train-evaluator` options
- Map omitted options to `UNSET`.
- Parse `--train-kwargs` as JSON through the existing CLI parsing helper.
- Print a concise run summary with the returned `run_id` and `run_directory`.

### Tests

- Add unit tests for the eval train CLI command.
- Cover root `eval` command registration.
- Cover registered `eval train-evaluator --help`.
- Cover omitted-option `UNSET` mapping.
- Cover explicit option forwarding to `pragmata.eval.train_evaluator`.
- Cover boolean flag forwarding.
- Cover JSON parsing for `--train-kwargs`.
- Cover CLI run summary output.