### PR TITLE
chore: migrate evaluator training to tlmtc 0.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ type = [
 ]
 annotation = ["argilla>=2.0,<3.0",]
 querygen = ["sentence-transformers>=3.0,<6.0",]
-eval = ["tlmtc[full]>=0.3,<1.0",]
+eval = ["tlmtc[train]>=0.4,<1.0",]
 cohere = ["langchain-cohere>=0.5,<1.0"]
 deepseek = ["langchain-deepseek>=1.0,<2.0"]
 openai = ["langchain-openai>=1.2,<2.0"]

--- a/src/pragmata/api/eval.py
+++ b/src/pragmata/api/eval.py
@@ -27,7 +27,6 @@ def train_evaluator(
     proxy_checkpoint: str | Unset = UNSET,
     scale_learning_rate: bool | Unset = UNSET,
     sequence_length: int | Unset = UNSET,
-    trust_remote_code: bool | Unset = UNSET,
     train_kwargs: dict[str, Any] | Unset = UNSET,
 ) -> Any:
     """Train a supervised evaluator model from labeled Pragmata eval data.
@@ -47,17 +46,14 @@ def train_evaluator(
         target_name: Display name passed to tlmtc for logs and reports.
             Defaults to a task-specific evaluation label, e.g. "Retrieval evaluation".
         checkpoint: Target checkpoint used for final fine-tuning. Defaults to
-            ``"EuroBERT/EuroBERT-610m"``.
+            ``"jhu-clsp/mmBERT-base"``.
         proxy_checkpoint: Proxy checkpoint used for hyperparameter tuning.
-            Defaults to ``"EuroBERT/EuroBERT-210m"``.
+            Defaults to ``"jhu-clsp/mmBERT-small"``.
         scale_learning_rate: Whether tlmtc should scale a proxy-tuned learning
             rate for the target checkpoint. Defaults to ``True`` because the
             default proxy and target checkpoints differ.
         sequence_length: Maximum combined tokenized sequence length passed to
             tlmtc for ``text`` and ``text_pair``. Defaults to ``1024``.
-        trust_remote_code: Whether Hugging Face loading may execute custom
-            checkpoint code. Defaults to ``True`` because it is required by the
-            default checkpoint and proxy checkpoint.
         train_kwargs: Additional tlmtc-owned keyword arguments passed through to
             ``tlmtc.train_tlmtc``.
 
@@ -80,7 +76,6 @@ def train_evaluator(
             "proxy_checkpoint": proxy_checkpoint,
             "scale_learning_rate": scale_learning_rate,
             "sequence_length": sequence_length,
-            "trust_remote_code": trust_remote_code,
             "train_kwargs": train_kwargs,
         },
     )
@@ -111,7 +106,6 @@ def train_evaluator(
         proxy_checkpoint=settings.proxy_checkpoint,
         scale_learning_rate=settings.scale_learning_rate,
         sequence_length=settings.sequence_length,
-        trust_remote_code=settings.trust_remote_code,
         train_kwargs=settings.train_kwargs,
     )
     export_eval_train_meta(

--- a/src/pragmata/cli/commands/eval.py
+++ b/src/pragmata/cli/commands/eval.py
@@ -61,11 +61,6 @@ def train_evaluator_command(
         "--sequence-length",
         help="Maximum combined tokenized sequence length for text and text_pair.",
     ),
-    trust_remote_code: bool | None = typer.Option(
-        None,
-        "--trust-remote-code/--no-trust-remote-code",
-        help="Allow or disallow Hugging Face custom checkpoint code execution.",
-    ),
     train_kwargs: str | None = typer.Option(
         None,
         "--train-kwargs",
@@ -84,7 +79,6 @@ def train_evaluator_command(
         proxy_checkpoint=UNSET if proxy_checkpoint is None else proxy_checkpoint,
         scale_learning_rate=UNSET if scale_learning_rate is None else scale_learning_rate,
         sequence_length=UNSET if sequence_length is None else sequence_length,
-        trust_remote_code=UNSET if trust_remote_code is None else trust_remote_code,
         train_kwargs=parse_cli_value(train_kwargs),
     )
 

--- a/src/pragmata/core/eval/tlmtc_adapters.py
+++ b/src/pragmata/core/eval/tlmtc_adapters.py
@@ -15,7 +15,6 @@ _RESERVED_TRAIN_KWARGS = frozenset(
         "proxy_checkpoint",
         "scale_learning_rate",
         "sequence_length",
-        "trust_remote_code",
     }
 )
 
@@ -29,7 +28,6 @@ def run_tlmtc_train(
     proxy_checkpoint: str,
     scale_learning_rate: bool,
     sequence_length: int,
-    trust_remote_code: bool,
     train_kwargs: dict[str, Any],
 ) -> Any:
     """Train a pragmata evaluator model through tlmtc.
@@ -45,8 +43,6 @@ def run_tlmtc_train(
         scale_learning_rate: Whether to scale the proxy-tuned learning rate for
             the target checkpoint.
         sequence_length: Maximum tokenized sequence length.
-        trust_remote_code: Whether Hugging Face loading may execute custom
-            checkpoint code.
         train_kwargs: Additional tlmtc-owned keyword arguments. Keys managed by
             pragmata are rejected.
 
@@ -79,7 +75,6 @@ def run_tlmtc_train(
         "proxy_checkpoint": proxy_checkpoint,
         "scale_learning_rate": scale_learning_rate,
         "sequence_length": sequence_length,
-        "trust_remote_code": trust_remote_code,
     }
     train_args.update(train_kwargs)
 

--- a/src/pragmata/core/settings/eval_settings.py
+++ b/src/pragmata/core/settings/eval_settings.py
@@ -42,10 +42,8 @@ class EvalTrainSettings(ResolveSettings):
         scale_learning_rate: Whether tlmtc should scale a proxy-tuned learning
             rate for the target checkpoint.
         sequence_length: Maximum tokenized sequence length passed to tlmtc.
-            Defaults to 1024 for paired RAG text with long-context EuroBERT
+            Defaults to 1024 for paired RAG text with long-context mmBERT
             checkpoints.
-        trust_remote_code: Whether Hugging Face loading may execute custom remote
-            code for the selected checkpoints.
         train_kwargs: Additional `train_tlmtc`-specific keyword arguments passed
             through to the tlmtc API. Use this for tlmtc-owned options.
     """
@@ -55,11 +53,10 @@ class EvalTrainSettings(ResolveSettings):
     export_id: str | None = None
     task: Task
     target_name: str | None = Field(default=None, min_length=1)
-    checkpoint: str = Field(default="EuroBERT/EuroBERT-610m", min_length=1)
-    proxy_checkpoint: str = Field(default="EuroBERT/EuroBERT-210m", min_length=1)
+    checkpoint: str = Field(default="jhu-clsp/mmBERT-base", min_length=1)
+    proxy_checkpoint: str = Field(default="jhu-clsp/mmBERT-small", min_length=1)
     scale_learning_rate: bool = True
     sequence_length: PositiveInt = 1024
-    trust_remote_code: bool = True
     train_kwargs: dict[str, Any] = Field(default_factory=dict)
 
     @model_validator(mode="after")

--- a/tests/integration/test_eval.py
+++ b/tests/integration/test_eval.py
@@ -260,7 +260,6 @@ def _train_evaluator(
         proxy_checkpoint=_TINY_CHECKPOINT,
         scale_learning_rate=False,
         sequence_length=64,
-        trust_remote_code=False,
         train_kwargs=_fast_train_kwargs(
             run_id=run_id,
             transfer_learning=transfer_learning,

--- a/tests/unit/api/test_eval.py
+++ b/tests/unit/api/test_eval.py
@@ -76,11 +76,10 @@ def test_train_evaluator_orchestrates_direct_labeled_input(
     assert {key: value for key, value in calls["train"].items() if key != "labeled_data"} == {
         "work_dir": tmp_path.resolve() / "eval",
         "target_name": "Retrieval evaluation",
-        "checkpoint": "EuroBERT/EuroBERT-610m",
-        "proxy_checkpoint": "EuroBERT/EuroBERT-210m",
+        "checkpoint": "jhu-clsp/mmBERT-base",
+        "proxy_checkpoint": "jhu-clsp/mmBERT-small",
         "scale_learning_rate": True,
         "sequence_length": 1024,
-        "trust_remote_code": True,
         "train_kwargs": {"run_id": "train-run-1", "verbosity": "quiet"},
     }
     assert calls["export"]["meta"].model_dump(exclude={"created_at"}) == {
@@ -108,9 +107,9 @@ def test_train_evaluator_combines_config_and_explicit_overrides(
             target_name: Config target
             scale_learning_rate: false
             sequence_length: 512
-            trust_remote_code: false
             train_kwargs:
               batch_size: 8
+              trust_remote_code: false
             """
         ),
         encoding="utf-8",
@@ -150,8 +149,7 @@ def test_train_evaluator_combines_config_and_explicit_overrides(
         "proxy_checkpoint": "config/proxy",
         "scale_learning_rate": False,
         "sequence_length": 2048,
-        "trust_remote_code": False,
-        "train_kwargs": {"batch_size": 16, "run_id": "override-run"},
+        "train_kwargs": {"batch_size": 16, "trust_remote_code": False, "run_id": "override-run"},
     }
 
 

--- a/tests/unit/cli/test_cli_eval.py
+++ b/tests/unit/cli/test_cli_eval.py
@@ -64,8 +64,7 @@ class TestTrainEvaluatorCommand:
         assert "--scale-learning-rate" in output
         assert "--no-scale-learning-rate" in output
         assert "--sequence-length" in output
-        assert "--trust-remote-code" in output
-        assert "--no-trust-remote-code" in output
+        assert "--trust-remote-code" not in output
         assert "--train-kwargs" in output
 
     def test_maps_omitted_options_to_unset(
@@ -93,7 +92,6 @@ class TestTrainEvaluatorCommand:
             "proxy_checkpoint",
             "scale_learning_rate",
             "sequence_length",
-            "trust_remote_code",
             "train_kwargs",
         }
 
@@ -153,7 +151,6 @@ class TestTrainEvaluatorCommand:
             "proxy_checkpoint": "proxy/checkpoint",
             "scale_learning_rate": UNSET,
             "sequence_length": 2048,
-            "trust_remote_code": UNSET,
             "train_kwargs": {"run_id": "custom-run", "verbosity": "quiet"},
         }
 
@@ -173,13 +170,11 @@ class TestTrainEvaluatorCommand:
             eval_app,
             [
                 "--no-scale-learning-rate",
-                "--trust-remote-code",
             ],
         )
 
         assert result.exit_code == 0
         assert captured["scale_learning_rate"] is False
-        assert captured["trust_remote_code"] is True
 
     def test_scale_learning_rate_flag_true(
         self,
@@ -193,11 +188,10 @@ class TestTrainEvaluatorCommand:
 
         monkeypatch.setattr("pragmata.eval.train_evaluator", fake_train_evaluator)
 
-        result = runner.invoke(eval_app, ["--scale-learning-rate", "--no-trust-remote-code"])
+        result = runner.invoke(eval_app, ["--scale-learning-rate"])
 
         assert result.exit_code == 0
         assert captured["scale_learning_rate"] is True
-        assert captured["trust_remote_code"] is False
 
     def test_prints_run_summary(
         self,

--- a/tests/unit/core/eval/test_tlmtc_adapters.py
+++ b/tests/unit/core/eval/test_tlmtc_adapters.py
@@ -22,11 +22,10 @@ def _run_tlmtc_train_kwargs(
         "labeled_data": Path("train.csv"),
         "work_dir": Path("eval"),
         "target_name": "Retrieval evaluation",
-        "checkpoint": "EuroBERT/EuroBERT-610m",
-        "proxy_checkpoint": "EuroBERT/EuroBERT-210m",
+        "checkpoint": "jhu-clsp/mmBERT-base",
+        "proxy_checkpoint": "jhu-clsp/mmBERT-small",
         "scale_learning_rate": True,
         "sequence_length": 1024,
-        "trust_remote_code": True,
         "train_kwargs": train_kwargs or {},
     }
 
@@ -52,6 +51,7 @@ def test_run_tlmtc_train_merges_curated_args_and_train_kwargs(
                 "run_id": "custom-run",
                 "batch_size": 8,
                 "verbosity": "quiet",
+                "trust_remote_code": False,
             }
         )
     )
@@ -61,14 +61,14 @@ def test_run_tlmtc_train_merges_curated_args_and_train_kwargs(
         "labeled_data": Path("train.csv"),
         "work_dir": Path("eval"),
         "target_name": "Retrieval evaluation",
-        "checkpoint": "EuroBERT/EuroBERT-610m",
-        "proxy_checkpoint": "EuroBERT/EuroBERT-210m",
+        "checkpoint": "jhu-clsp/mmBERT-base",
+        "proxy_checkpoint": "jhu-clsp/mmBERT-small",
         "scale_learning_rate": True,
         "sequence_length": 1024,
-        "trust_remote_code": True,
         "run_id": "custom-run",
         "batch_size": 8,
         "verbosity": "quiet",
+        "trust_remote_code": False,
     }
 
 
@@ -94,11 +94,10 @@ def test_run_tlmtc_train_forwards_dedicated_args_when_train_kwargs_empty(
         "labeled_data": Path("train.csv"),
         "work_dir": Path("eval"),
         "target_name": "Retrieval evaluation",
-        "checkpoint": "EuroBERT/EuroBERT-610m",
-        "proxy_checkpoint": "EuroBERT/EuroBERT-210m",
+        "checkpoint": "jhu-clsp/mmBERT-base",
+        "proxy_checkpoint": "jhu-clsp/mmBERT-small",
         "scale_learning_rate": True,
         "sequence_length": 1024,
-        "trust_remote_code": True,
     }
 
 

--- a/tests/unit/core/settings/test_eval_settings.py
+++ b/tests/unit/core/settings/test_eval_settings.py
@@ -88,11 +88,10 @@ def test_eval_train_settings_construction_with_defaults() -> None:
     assert settings.export_id is None
     assert settings.task == Task.RETRIEVAL
     assert settings.target_name == "Retrieval evaluation"
-    assert settings.checkpoint == "EuroBERT/EuroBERT-610m"
-    assert settings.proxy_checkpoint == "EuroBERT/EuroBERT-210m"
+    assert settings.checkpoint == "jhu-clsp/mmBERT-base"
+    assert settings.proxy_checkpoint == "jhu-clsp/mmBERT-small"
     assert settings.scale_learning_rate is True
     assert settings.sequence_length == 1024
-    assert settings.trust_remote_code is True
     assert settings.train_kwargs == {}
 
 
@@ -121,7 +120,6 @@ def test_eval_train_settings_accepts_export_id_and_train_kwargs() -> None:
             "proxy_checkpoint": "custom/proxy",
             "scale_learning_rate": False,
             "sequence_length": 384,
-            "trust_remote_code": False,
             "train_kwargs": {
                 "run_id": "custom-train-run",
                 "batch_size": 8,
@@ -136,7 +134,6 @@ def test_eval_train_settings_accepts_export_id_and_train_kwargs() -> None:
     assert settings.proxy_checkpoint == "custom/proxy"
     assert settings.scale_learning_rate is False
     assert settings.sequence_length == 384
-    assert settings.trust_remote_code is False
     assert settings.train_kwargs == {
         "run_id": "custom-train-run",
         "batch_size": 8,

--- a/uv.lock
+++ b/uv.lock
@@ -2536,11 +2536,11 @@ dev = [
     { name = "pytest" },
     { name = "ruff" },
     { name = "sentence-transformers" },
-    { name = "tlmtc", extra = ["full"] },
+    { name = "tlmtc", extra = ["train"] },
     { name = "types-pyyaml" },
 ]
 eval = [
-    { name = "tlmtc", extra = ["full"] },
+    { name = "tlmtc", extra = ["train"] },
 ]
 everything = [
     { name = "argilla" },
@@ -2550,12 +2550,12 @@ everything = [
     { name = "langchain-google-genai" },
     { name = "langchain-openai" },
     { name = "sentence-transformers" },
-    { name = "tlmtc", extra = ["full"] },
+    { name = "tlmtc", extra = ["train"] },
 ]
 full = [
     { name = "argilla" },
     { name = "sentence-transformers" },
-    { name = "tlmtc", extra = ["full"] },
+    { name = "tlmtc", extra = ["train"] },
 ]
 google-genai = [
     { name = "langchain-google-genai" },
@@ -2601,7 +2601,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0,<7.0" },
     { name = "ruff", marker = "extra == 'lint'", specifier = ">=0.14,<1.0" },
     { name = "sentence-transformers", marker = "extra == 'querygen'", specifier = ">=3.0,<6.0" },
-    { name = "tlmtc", extras = ["full"], marker = "extra == 'eval'", specifier = ">=0.3,<1.0" },
+    { name = "tlmtc", extras = ["train"], marker = "extra == 'eval'", specifier = ">=0.4,<1.0" },
     { name = "typer", specifier = ">=0.9,<1.0" },
     { name = "types-pyyaml", marker = "extra == 'type'" },
 ]
@@ -3472,36 +3472,36 @@ wheels = [
 
 [[package]]
 name = "tlmtc"
-version = "0.3.0"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/bb/903d11f82e311cd2045df1ee952ab5982955197ed901cc430da4329b0d7a/tlmtc-0.4.0.tar.gz", hash = "sha256:47764f454342ebff27c2f33e33477c40f44c7489831a126d85fb2df6eec8e044", size = 1291686, upload-time = "2026-07-13T13:15:07.356Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/e6/060d56c65705a1dfe14ec82406b8ba85ceff792caf4cf028c8a246ac865c/tlmtc-0.4.0-py3-none-any.whl", hash = "sha256:d56af3068f763cadf31bd145bb72e331bf17ec45a48bd5a7c736317d9e974081", size = 63803, upload-time = "2026-07-13T13:15:05.967Z" },
+]
+
+[package.optional-dependencies]
+train = [
+    { name = "accelerate" },
     { name = "datasets" },
     { name = "great-tables" },
     { name = "huggingface-hub" },
     { name = "iterative-stratification" },
     { name = "matplotlib" },
-    { name = "numpy" },
     { name = "optuna" },
-    { name = "pandas" },
     { name = "pandera", extra = ["pandas"] },
+    { name = "peft" },
     { name = "pyarrow" },
-    { name = "pydantic" },
-    { name = "pyyaml" },
     { name = "scikit-learn" },
     { name = "seaborn" },
-    { name = "transformers" },
-    { name = "typer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/82/eadeabad209aa1dfd0183115c83c6121276e5782178f9a3b9b119698d9d1/tlmtc-0.3.0.tar.gz", hash = "sha256:bc77ba950a8c2bb41c052e13bc083e00268add2bb5406dda0842e6c139c09b96", size = 1259235, upload-time = "2026-06-28T18:42:23.412Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/6d/fe1825b1b9407ecc4386c5bec76477c95e27515e38a0dec63b112a22ddc8/tlmtc-0.3.0-py3-none-any.whl", hash = "sha256:62aecfae8c41abe50e8699ee6df6e23b3fd051b8c25df3c4a230ff93a1189a8c", size = 56503, upload-time = "2026-06-28T18:42:21.87Z" },
-]
-
-[package.optional-dependencies]
-full = [
-    { name = "accelerate" },
-    { name = "peft" },
     { name = "torch" },
+    { name = "transformers" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Summary

Migrates evaluator training to `tlmtc` 0.4 and replaces the removed `full` dependency extra with the training-specific `train` extra.

The default evaluator checkpoints move from EuroBERT to mmBERT because the EuroBERT checkpoints have proven fragile and require `trust_remote_code=True`. The mmBERT alternatives are smaller, fully multilingual, based on a modern BERT architecture, support sequences of up to 8,192 tokens, and provide stronger performance without requiring remote checkpoint code.

The dedicated `trust_remote_code` setting is removed so normal training inherits tlmtc's safer `False` default, while advanced callers can still override it through `train_kwargs`.

### Changes

- Update the eval dependency to `tlmtc[train]>=0.4,<1.0`.
- Refresh the lockfile to resolve `tlmtc` 0.4.0 and its training dependency surface.
- Change the default target checkpoint to `jhu-clsp/mmBERT-base`.
- Change the default proxy checkpoint to `jhu-clsp/mmBERT-small`.
- Remove `trust_remote_code` from `EvalTrainSettings`.
- Remove the dedicated `trust_remote_code` argument from the evaluator API and CLI.
- Stop explicitly forwarding `trust_remote_code` through the tlmtc adapter.
- Allow explicit `trust_remote_code` overrides to pass through `train_kwargs`.
- Update evaluator documentation and tests for the new defaults and API surface.

### Testing

- Updated settings, API, CLI, adapter, and integration coverage.
- Covered forwarding `trust_remote_code` through `train_kwargs`.