### PR TITLE
feat(annotation): add shared uncertainty helpers (Wilson + bootstrap)

### DIFF
--- a/src/pragmata/core/annotation/iaa.py
+++ b/src/pragmata/core/annotation/iaa.py
@@ -3,6 +3,8 @@
 import numpy as np
 from numpy.typing import NDArray
 
+from pragmata.core.annotation.uncertainty import percentile_bootstrap
+
 
 def krippendorff_alpha_nominal(data: NDArray[np.floating]) -> float:
     """Compute Krippendorff's alpha for nominal (binary/categorical) data.
@@ -129,22 +131,13 @@ def bootstrap_alpha(
     Returns:
         ``(ci_lower, ci_upper)`` tuple.
     """
-    rng = np.random.default_rng(seed)
-    n_items = data.shape[1]
-    alphas = np.empty(n_resamples)
-    for i in range(n_resamples):
-        indices = rng.integers(0, n_items, size=n_items)
-        alphas[i] = krippendorff_alpha_nominal(data[:, indices])
-
-    # Drop NaN resamples (can occur with degenerate samples).
-    alphas = alphas[~np.isnan(alphas)]
-    if len(alphas) == 0:
-        return (float("nan"), float("nan"))
-
-    tail = (1.0 - ci) / 2.0
-    lower = float(np.percentile(alphas, tail * 100))
-    upper = float(np.percentile(alphas, (1.0 - tail) * 100))
-    return lower, upper
+    return percentile_bootstrap(
+        data.shape[1],
+        lambda indices: krippendorff_alpha_nominal(data[:, indices]),
+        n_resamples=n_resamples,
+        ci=ci,
+        seed=seed,
+    )
 
 
 def percentage_agreement(data: NDArray[np.floating]) -> float:

--- a/src/pragmata/core/annotation/iaa.py
+++ b/src/pragmata/core/annotation/iaa.py
@@ -135,7 +135,7 @@ def bootstrap_alpha(
         data.shape[1],
         lambda indices: krippendorff_alpha_nominal(data[:, indices]),
         n_resamples=n_resamples,
-        ci=ci,
+        alpha=1.0 - ci,
         seed=seed,
     )
 

--- a/src/pragmata/core/annotation/uncertainty.py
+++ b/src/pragmata/core/annotation/uncertainty.py
@@ -1,0 +1,91 @@
+"""Shared uncertainty helpers for annotation and eval reporting.
+
+Confidence-interval primitives reused across reporting stacks: IAA bootstraps
+Krippendorff's alpha (:func:`percentile_bootstrap`), and eval scoring attaches a
+CI to every metric - Wilson intervals for proportions
+(:func:`wilson_interval`), percentile bootstrap for continuous per-query means.
+
+Kept dependency-light: NumPy plus the stdlib normal quantile, no SciPy. Lives
+under ``core.annotation`` because the bootstrap logic originated in ``iaa.py``;
+eval imports from here. Promote to a broader ``core.stats`` only if a wider
+stats surface later emerges.
+"""
+
+from collections.abc import Callable
+from statistics import NormalDist
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+def wilson_interval(successes: int, n: int, *, ci: float = 0.95) -> tuple[float, float]:
+    """Wilson score interval for a binomial proportion.
+
+    Preferred over the normal approximation at small ``n`` and for extreme
+    proportions (all-0 / all-1): it stays within ``[0, 1]`` and remains a
+    positive-width interval instead of collapsing, which is why proportion
+    metrics use it rather than bootstrapping.
+
+    Args:
+        successes: Number of positive outcomes (``0 <= successes <= n``).
+        n: Number of trials (the effective denominator).
+        ci: Confidence level (e.g. 0.95 for a 95% interval).
+
+    Returns:
+        ``(ci_lower, ci_upper)`` clamped to ``[0, 1]``. Returns
+        ``(nan, nan)`` when ``n <= 0``.
+    """
+    if n <= 0:
+        return (float("nan"), float("nan"))
+
+    z = NormalDist().inv_cdf(1.0 - (1.0 - ci) / 2.0)
+    p_hat = successes / n
+    z2 = z * z
+    denom = 1.0 + z2 / n
+    center = (p_hat + z2 / (2.0 * n)) / denom
+    half = (z / denom) * np.sqrt(p_hat * (1.0 - p_hat) / n + z2 / (4.0 * n * n))
+    lower = max(0.0, center - half)
+    upper = min(1.0, center + half)
+    return (float(lower), float(upper))
+
+
+def percentile_bootstrap(
+    n_units: int,
+    statistic: Callable[[NDArray[np.intp]], float],
+    *,
+    n_resamples: int = 1000,
+    ci: float = 0.95,
+    seed: int | None = None,
+) -> tuple[float, float]:
+    """Percentile-bootstrap confidence interval over a resampling unit.
+
+    Resamples unit indices ``[0, n_units)`` with replacement, applies
+    ``statistic`` to each resample, and takes percentile cut-points. NaN
+    replicates (from degenerate resamples) are dropped, matching the IAA
+    bootstrap.
+
+    Args:
+        n_units: Number of resampling units (e.g. queries, items).
+        statistic: Maps a resample's index array to a scalar estimate; may
+            return ``nan`` for a degenerate resample.
+        n_resamples: Number of bootstrap iterations.
+        ci: Confidence level (e.g. 0.95 for a 95% interval).
+        seed: Optional RNG seed for reproducibility.
+
+    Returns:
+        ``(ci_lower, ci_upper)``. Returns ``(nan, nan)`` when every replicate
+        is NaN.
+    """
+    rng = np.random.default_rng(seed)
+    values = np.empty(n_resamples)
+    for i in range(n_resamples):
+        indices = rng.integers(0, n_units, size=n_units)
+        values[i] = statistic(indices)
+
+    values = values[~np.isnan(values)]
+    if len(values) == 0:
+        return (float("nan"), float("nan"))
+
+    tail = (1.0 - ci) / 2.0
+    lower, upper = np.percentile(values, [tail * 100.0, (1.0 - tail) * 100.0])
+    return (float(lower), float(upper))

--- a/src/pragmata/core/annotation/uncertainty.py
+++ b/src/pragmata/core/annotation/uncertainty.py
@@ -18,7 +18,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 
-def wilson_interval(successes: int, n: int, *, ci: float = 0.95) -> tuple[float, float]:
+def wilson_interval(successes: int, n: int, *, alpha: float = 0.05) -> tuple[float, float]:
     """Wilson score interval for a binomial proportion.
 
     Preferred over the normal approximation at small ``n`` and for extreme
@@ -29,16 +29,22 @@ def wilson_interval(successes: int, n: int, *, ci: float = 0.95) -> tuple[float,
     Args:
         successes: Number of positive outcomes (``0 <= successes <= n``).
         n: Number of trials (the effective denominator).
-        ci: Confidence level (e.g. 0.95 for a 95% interval).
+        alpha: Significance level; the interval is at confidence ``1 - alpha``
+            (e.g. ``alpha=0.05`` for a 95% interval).
 
     Returns:
         ``(ci_lower, ci_upper)`` clamped to ``[0, 1]``. Returns
         ``(nan, nan)`` when ``n <= 0``.
+
+    Raises:
+        ValueError: If ``successes`` is not in ``[0, n]``.
     """
     if n <= 0:
         return (float("nan"), float("nan"))
+    if not 0 <= successes <= n:
+        raise ValueError(f"successes must be in [0, {n}], got {successes}")
 
-    z = NormalDist().inv_cdf(1.0 - (1.0 - ci) / 2.0)
+    z = NormalDist().inv_cdf(1.0 - alpha / 2.0)
     p_hat = successes / n
     z2 = z * z
     denom = 1.0 + z2 / n
@@ -54,7 +60,7 @@ def percentile_bootstrap(
     statistic: Callable[[NDArray[np.intp]], float],
     *,
     n_resamples: int = 1000,
-    ci: float = 0.95,
+    alpha: float = 0.05,
     seed: int | None = None,
 ) -> tuple[float, float]:
     """Percentile-bootstrap confidence interval over a resampling unit.
@@ -69,7 +75,8 @@ def percentile_bootstrap(
         statistic: Maps a resample's index array to a scalar estimate; may
             return ``nan`` for a degenerate resample.
         n_resamples: Number of bootstrap iterations.
-        ci: Confidence level (e.g. 0.95 for a 95% interval).
+        alpha: Significance level; the interval is at confidence ``1 - alpha``
+            (e.g. ``alpha=0.05`` for a 95% interval).
         seed: Optional RNG seed for reproducibility.
 
     Returns:
@@ -86,6 +93,6 @@ def percentile_bootstrap(
     if len(values) == 0:
         return (float("nan"), float("nan"))
 
-    tail = (1.0 - ci) / 2.0
+    tail = alpha / 2.0
     lower, upper = np.percentile(values, [tail * 100.0, (1.0 - tail) * 100.0])
     return (float(lower), float(upper))

--- a/tests/unit/core/annotation/test_uncertainty.py
+++ b/tests/unit/core/annotation/test_uncertainty.py
@@ -73,9 +73,15 @@ class TestWilsonInterval:
         assert math.isnan(lower)
         assert math.isnan(upper)
 
-    def test_ci_level_widens_interval(self):
-        narrow = wilson_interval(8, 20, ci=0.90)
-        wide = wilson_interval(8, 20, ci=0.99)
+    @pytest.mark.parametrize("successes", [-1, 11])
+    def test_rejects_successes_out_of_range(self, successes):
+        with pytest.raises(ValueError, match="successes must be in"):
+            wilson_interval(successes, 10)
+
+    def test_smaller_alpha_widens_interval(self):
+        # Smaller alpha -> higher confidence -> wider interval.
+        wide = wilson_interval(8, 20, alpha=0.01)
+        narrow = wilson_interval(8, 20, alpha=0.10)
         assert wide[0] < narrow[0]
         assert wide[1] > narrow[1]
 
@@ -152,11 +158,16 @@ class TestBootstrapAlphaRegression:
         )
 
     def test_delegates_faithfully(self):
-        """Delegation matches a direct percentile_bootstrap call, same seed."""
+        """Delegation matches a direct percentile_bootstrap call at the same alpha/seed.
+
+        ``bootstrap_alpha`` converts its ``ci`` to ``alpha = 1 - ci``, so the
+        direct call must use the same expression for a bit-exact comparison.
+        """
         direct = percentile_bootstrap(
             REFERENCE_DATA.shape[1],
             lambda idx: krippendorff_alpha_nominal(REFERENCE_DATA[:, idx]),
             n_resamples=100,
+            alpha=1.0 - 0.95,
             seed=42,
         )
         assert bootstrap_alpha(REFERENCE_DATA, n_resamples=100, seed=42) == direct

--- a/tests/unit/core/annotation/test_uncertainty.py
+++ b/tests/unit/core/annotation/test_uncertainty.py
@@ -1,0 +1,162 @@
+"""Unit tests for the shared uncertainty helpers.
+
+Covers the Wilson score interval and the generic percentile bootstrap, plus a
+golden-value regression lock proving the ``bootstrap_alpha`` refactor onto
+``percentile_bootstrap`` is behaviourally identical to the pre-refactor code.
+"""
+
+import math
+from itertools import count
+
+import numpy as np
+import pytest
+
+from pragmata.core.annotation.iaa import bootstrap_alpha, krippendorff_alpha_nominal
+from pragmata.core.annotation.uncertainty import percentile_bootstrap, wilson_interval
+
+NaN = np.nan
+
+# 4 annotators x 12 binary items with missing data (alpha ~= 0.4907); shared
+# with test_iaa.py.
+REFERENCE_DATA = np.array(
+    [
+        [0, 1, 0, 0, 0, 0, 0, 0, 1, 0, NaN, NaN],
+        [0, 1, 1, 0, 0, 1, 0, 0, 0, 0, NaN, NaN],
+        [NaN, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0],
+        [0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, NaN],
+    ]
+)
+SIMPLE_DATA = np.array([[1, 0, 1, 0, 1, 0], [1, 0, 0, 0, 1, 0]], dtype=float)
+
+
+class TestWilsonInterval:
+    """Tests for the Wilson score interval."""
+
+    def test_reference_value(self):
+        """8 successes out of 10 at 95%.
+
+        Validated against R ``Hmisc::binconf(8, 10, method="wilson")`` and the
+        textbook Wilson formula: ~(0.4901, 0.9433).
+        """
+        lower, upper = wilson_interval(8, 10)
+        assert lower == pytest.approx(0.4901, abs=0.001)
+        assert upper == pytest.approx(0.9433, abs=0.001)
+
+    def test_point_within_interval(self):
+        lower, upper = wilson_interval(5, 10)
+        assert lower <= 0.5 <= upper
+
+    def test_all_successes_upper_clamped(self):
+        """All-1 stays informative: positive-width, upper clamps to 1.0."""
+        lower, upper = wilson_interval(10, 10)
+        assert 0.0 < lower < 1.0
+        assert upper == pytest.approx(1.0)
+        assert lower == pytest.approx(0.7224, abs=0.001)
+
+    def test_zero_successes_lower_clamped(self):
+        """All-0 mirrors all-1: lower clamps to 0.0, upper positive."""
+        lower, upper = wilson_interval(0, 10)
+        assert lower == pytest.approx(0.0, abs=1e-9)
+        assert 0.0 < upper < 1.0
+
+    def test_ordering_and_bounds(self):
+        for successes in range(0, 11):
+            lower, upper = wilson_interval(successes, 10)
+            assert 0.0 <= lower <= upper <= 1.0
+
+    def test_single_trial(self):
+        lower, upper = wilson_interval(1, 1)
+        assert 0.0 <= lower <= upper <= 1.0
+
+    def test_zero_n_returns_nan(self):
+        lower, upper = wilson_interval(0, 0)
+        assert math.isnan(lower)
+        assert math.isnan(upper)
+
+    def test_ci_level_widens_interval(self):
+        narrow = wilson_interval(8, 20, ci=0.90)
+        wide = wilson_interval(8, 20, ci=0.99)
+        assert wide[0] < narrow[0]
+        assert wide[1] > narrow[1]
+
+
+class TestPercentileBootstrap:
+    """Tests for the generic percentile bootstrap."""
+
+    def test_constant_statistic(self):
+        lower, upper = percentile_bootstrap(5, lambda _idx: 0.7, n_resamples=50, seed=1)
+        assert lower == pytest.approx(0.7)
+        assert upper == pytest.approx(0.7)
+
+    def test_all_nan_returns_nan(self):
+        lower, upper = percentile_bootstrap(5, lambda _idx: float("nan"), n_resamples=50, seed=1)
+        assert math.isnan(lower)
+        assert math.isnan(upper)
+
+    def test_nan_replicates_dropped(self):
+        """Degenerate replicates are dropped, not propagated."""
+        counter = count(1)
+
+        def statistic(_idx):
+            return float("nan") if next(counter) <= 3 else 1.0
+
+        lower, upper = percentile_bootstrap(5, statistic, n_resamples=10, seed=1)
+        assert (lower, upper) == (1.0, 1.0)
+
+    def test_indices_within_range(self):
+        maxes: list[int] = []
+
+        def statistic(idx):
+            maxes.append(int(idx.max()))
+            assert idx.min() >= 0
+            return float(idx.mean())
+
+        percentile_bootstrap(7, statistic, n_resamples=20, seed=2)
+        assert max(maxes) < 7
+
+    def test_seed_reproducibility(self):
+        data = np.array([0.1, 0.5, 0.9, 0.2, 0.7])
+
+        def statistic(idx):
+            return float(data[idx].mean())
+
+        r1 = percentile_bootstrap(5, statistic, n_resamples=100, seed=99)
+        r2 = percentile_bootstrap(5, statistic, n_resamples=100, seed=99)
+        assert r1 == r2
+
+    def test_ordering(self):
+        data = np.array([0.0, 0.25, 0.5, 0.75, 1.0])
+        lower, upper = percentile_bootstrap(5, lambda idx: float(data[idx].mean()), n_resamples=200, seed=3)
+        assert lower <= upper
+        assert not math.isnan(lower)
+
+
+class TestBootstrapAlphaRegression:
+    """Locks the ``bootstrap_alpha`` -> ``percentile_bootstrap`` refactor.
+
+    Golden values were captured from the pre-refactor implementation. PCG64 and
+    ``np.percentile`` are stable across versions, so exact equality is a tight,
+    safe lock that fails if the refactor drifts.
+    """
+
+    def test_golden_reference_dataset(self):
+        assert bootstrap_alpha(REFERENCE_DATA, n_resamples=100, seed=42) == (
+            -7.827072323607348e-16,
+            0.8571428571428571,
+        )
+
+    def test_golden_simple_dataset(self):
+        assert bootstrap_alpha(SIMPLE_DATA, n_resamples=200, seed=42) == (
+            -0.09999999999999987,
+            1.0,
+        )
+
+    def test_delegates_faithfully(self):
+        """Delegation matches a direct percentile_bootstrap call, same seed."""
+        direct = percentile_bootstrap(
+            REFERENCE_DATA.shape[1],
+            lambda idx: krippendorff_alpha_nominal(REFERENCE_DATA[:, idx]),
+            n_resamples=100,
+            seed=42,
+        )
+        assert bootstrap_alpha(REFERENCE_DATA, n_resamples=100, seed=42) == direct


### PR DESCRIPTION
## Summary

First PR of eval-scoring stack (design: `docs/design/eval-scoring-metrics.md`). Extracts ci primitives into shared module so eval scoring and IAA share one implementation:

- New `core/annotation/uncertainty.py` w/ `wilson_interval(successes, n, *, ci)` and generic `percentile_bootstrap(n_units, statistic, *, n_resamples, ci, seed)` (cluster/percentile bootstrap over a resampling unit).
- Refactors `iaa.py:bootstrap_alpha` to delegate to `percentile_bootstrap`. The RNG call sequence is preserved, so results are bit-identical — locked by a golden-value regression test captured from the pre-refactor code.
- NB `wilson_interval` has no caller yet; it is the primitive the incoming scoring layer uses for the proportion metrics.

Module lives under `core/annotation` (where the bootstrap logic originated); eval will import from here. Kept dependency-light — NumPy plus the stdlib normal quantile, no SciPy.

## Test plan

- [x] `pytest tests/unit/core/annotation/test_uncertainty.py` — Wilson reference value (8/10 → ~[0.490, 0.943]), clamping at all-0/all-1, bootstrap seed reproducibility, NaN-replicate drop, golden regression lock.
- [x] `pytest tests/unit/core/annotation/test_iaa.py tests/unit/core/annotation/test_iaa_runner.py` — existing IAA suite unaffected by the refactor.
- [x] Drove `pragmata annotation iaa` end-to-end: CI values render, seed-reproducible, widen with `--ci`, shift with `--seed`, `--n-resamples 1` edge handled.
- [x] CI passes.