### PR TITLE
feat(eval): add dedicated eval score input schemas

### DIFF
--- a/docs/design/eval-scoring-metrics.md
+++ b/docs/design/eval-scoring-metrics.md
@@ -171,7 +171,7 @@ Scoring has stricter structural requirements than training, so it gets its own `
 
 - **retrieval** (`RETRIEVAL_SCORE_SCHEMA`) requires, per row:
   - `record_uuid` - group chunks into queries (the per-query unit).
-  - `rank` (1...K) - required by NDCG@K and MRR@K; without it those metrics cannot be computed.
+  - `chunk_rank` (1...K) - required by NDCG@K and MRR@K; without it those metrics cannot be computed.
   - `chunk_id` - stable identity within a query (already a dup-key in `transforms.py`).
 - **grounding / generation** (`GROUNDING_SCORE_SCHEMA`, `GENERATION_SCORE_SCHEMA`) require `record_uuid`.
 

--- a/src/pragmata/core/schemas/eval_input.py
+++ b/src/pragmata/core/schemas/eval_input.py
@@ -97,8 +97,8 @@ def _identity_column_schemas(
 
     Every task needs ``record_uuid`` to group rows into the per-query unit that
     metrics average over. Retrieval additionally needs ``chunk_id`` (stable
-    per-chunk identity within a query) and ``chunk_rank`` (the 1-based rank the
-    design doc refers to as ``rank``, required by NDCG@K and MRR@K).
+    per-chunk identity within a query) and ``chunk_rank`` (the 1-based rank
+    within the query, required by NDCG@K and MRR@K).
     """
     columns: dict[str, pa.Column] = {
         "record_uuid": pa.Column(str, nullable=False, required=True, checks=_NON_BLANK_STRING),

--- a/src/pragmata/core/schemas/eval_input.py
+++ b/src/pragmata/core/schemas/eval_input.py
@@ -50,6 +50,11 @@ _NON_BLANK_STRING = pa.Check(
 _BINARY_LABEL = pa.Check.isin([0, 1])
 
 
+# Ranks are 1-based; K (the cutoff) is inferred from the data at scoring time,
+# so only a positive lower bound is enforced here.
+_POSITIVE_RANK = pa.Check.greater_than_or_equal_to(1)
+
+
 _NON_EMPTY_FRAME = pa.Check(
     lambda df: len(df) > 0,
     error="dataframe must contain at least one row",
@@ -83,6 +88,25 @@ def _label_column_schemas(
         )
         for column in LABEL_COLUMNS_BY_TASK[task]
     }
+
+
+def _identity_column_schemas(
+    task: Task,
+) -> dict[str, pa.Column]:
+    """Structural grouping/identity columns that scoring requires but training does not.
+
+    Every task needs ``record_uuid`` to group rows into the per-query unit that
+    metrics average over. Retrieval additionally needs ``chunk_id`` (stable
+    per-chunk identity within a query) and ``chunk_rank`` (the 1-based rank the
+    design doc refers to as ``rank``, required by NDCG@K and MRR@K).
+    """
+    columns: dict[str, pa.Column] = {
+        "record_uuid": pa.Column(str, nullable=False, required=True, checks=_NON_BLANK_STRING),
+    }
+    if task == Task.RETRIEVAL:
+        columns["chunk_id"] = pa.Column(str, nullable=False, required=True, checks=_NON_BLANK_STRING)
+        columns["chunk_rank"] = pa.Column(int, nullable=False, required=True, coerce=True, checks=_POSITIVE_RANK)
+    return columns
 
 
 RETRIEVAL_TRAIN_SCHEMA = pa.DataFrameSchema(
@@ -154,10 +178,56 @@ GENERATION_PREDICT_SCHEMA = pa.DataFrameSchema(
 )
 
 
+RETRIEVAL_SCORE_SCHEMA = pa.DataFrameSchema(
+    {
+        **_text_column_schemas(Task.RETRIEVAL),
+        **_label_column_schemas(Task.RETRIEVAL),
+        **_identity_column_schemas(Task.RETRIEVAL),
+    },
+    checks=[_NON_EMPTY_FRAME],
+    strict=False,
+    ordered=False,
+    coerce=False,
+)
+
+
+GROUNDING_SCORE_SCHEMA = pa.DataFrameSchema(
+    {
+        **_text_column_schemas(Task.GROUNDING),
+        **_label_column_schemas(Task.GROUNDING),
+        **_identity_column_schemas(Task.GROUNDING),
+    },
+    checks=[_NON_EMPTY_FRAME],
+    strict=False,
+    ordered=False,
+    coerce=False,
+)
+
+
+GENERATION_SCORE_SCHEMA = pa.DataFrameSchema(
+    {
+        **_text_column_schemas(Task.GENERATION),
+        **_label_column_schemas(Task.GENERATION),
+        **_identity_column_schemas(Task.GENERATION),
+    },
+    checks=[_NON_EMPTY_FRAME],
+    strict=False,
+    ordered=False,
+    coerce=False,
+)
+
+
 _TRAIN_SCHEMAS_BY_TASK: dict[Task, pa.DataFrameSchema] = {
     Task.RETRIEVAL: RETRIEVAL_TRAIN_SCHEMA,
     Task.GROUNDING: GROUNDING_TRAIN_SCHEMA,
     Task.GENERATION: GENERATION_TRAIN_SCHEMA,
+}
+
+
+_SCORE_SCHEMAS_BY_TASK: dict[Task, pa.DataFrameSchema] = {
+    Task.RETRIEVAL: RETRIEVAL_SCORE_SCHEMA,
+    Task.GROUNDING: GROUNDING_SCORE_SCHEMA,
+    Task.GENERATION: GENERATION_SCORE_SCHEMA,
 }
 
 
@@ -202,6 +272,12 @@ def validate_eval_score_frame(
 ) -> pd.DataFrame:
     """Validate a labeled eval scoring dataframe.
 
+    Scoring has stricter structural requirements than training: every task must
+    carry ``record_uuid`` (the per-query grouping unit), and retrieval must also
+    carry ``chunk_id`` and ``chunk_rank``. These are enforced by dedicated
+    ``*_SCORE_SCHEMA`` definitions rather than the training schemas, so training
+    inputs are not constrained by scoring-only metadata.
+
     Args:
         df: Input dataframe to validate.
         task: Annotation task that determines the input contract to apply.
@@ -217,7 +293,7 @@ def validate_eval_score_frame(
         raise EvalInputSchemaError(f"Expected a pandas DataFrame, got {type(df).__name__}.")
 
     try:
-        return _TRAIN_SCHEMAS_BY_TASK[task].validate(df, lazy=True)
+        return _SCORE_SCHEMAS_BY_TASK[task].validate(df, lazy=True)
     except (SchemaError, SchemaErrors) as exc:
         raise EvalInputSchemaError("Input dataframe violates the eval scoring data contract.") from exc
 

--- a/tests/unit/core/schemas/test_eval_input.py
+++ b/tests/unit/core/schemas/test_eval_input.py
@@ -119,6 +119,47 @@ def generation_predict_frame() -> FrameFactory:
     return _factory
 
 
+@pytest.fixture
+def retrieval_score_frame() -> FrameFactory:
+    """Return a factory for valid retrieval scoring dataframes (two chunks, one query)."""
+
+    def _factory(**overrides: object) -> pd.DataFrame:
+        data: dict[str, object] = {
+            "query": ["a query", "a query"],
+            "chunk": ["first chunk", "second chunk"],
+            "topically_relevant": [1, 0],
+            "evidence_sufficient": [1, 0],
+            "misleading": [0, 1],
+            "record_uuid": ["rec-1", "rec-1"],
+            "chunk_id": ["chunk-1", "chunk-2"],
+            "chunk_rank": [1, 2],
+        }
+        data.update(overrides)
+        return pd.DataFrame(data)
+
+    return _factory
+
+
+@pytest.fixture
+def grounding_score_frame(grounding_train_frame: FrameFactory) -> FrameFactory:
+    """Valid grounding scoring frame: the training columns plus ``record_uuid``."""
+
+    def _factory(**overrides: object) -> pd.DataFrame:
+        return grounding_train_frame(**{"record_uuid": ["rec-1", "rec-2"], **overrides})
+
+    return _factory
+
+
+@pytest.fixture
+def generation_score_frame(generation_train_frame: FrameFactory) -> FrameFactory:
+    """Valid generation scoring frame: the training columns plus ``record_uuid``."""
+
+    def _factory(**overrides: object) -> pd.DataFrame:
+        return generation_train_frame(**{"record_uuid": ["rec-1", "rec-2"], **overrides})
+
+    return _factory
+
+
 class TestValidateEvalTrainFrame:
     """Tests for validating labeled eval training dataframes."""
 
@@ -275,12 +316,43 @@ class TestValidateEvalTrainFrame:
 class TestValidateEvalScoreFrame:
     """Tests for validating labeled eval scoring dataframes."""
 
-    def test_validates_labeled_score_frame(self, retrieval_train_frame: FrameFactory) -> None:
-        df = retrieval_train_frame(record_uuid=["a", "b"])
+    def test_validates_retrieval_score_frame(self, retrieval_score_frame: FrameFactory) -> None:
+        df = retrieval_score_frame()
 
         validated = validate_eval_score_frame(df, task=Task.RETRIEVAL)
 
         pd.testing.assert_frame_equal(validated, df)
+
+    def test_validates_grounding_score_frame(self, grounding_score_frame: FrameFactory) -> None:
+        df = grounding_score_frame()
+
+        validated = validate_eval_score_frame(df, task=Task.GROUNDING)
+
+        pd.testing.assert_frame_equal(validated, df)
+
+    def test_validates_generation_score_frame(self, generation_score_frame: FrameFactory) -> None:
+        df = generation_score_frame()
+
+        validated = validate_eval_score_frame(df, task=Task.GENERATION)
+
+        pd.testing.assert_frame_equal(validated, df)
+
+    def test_preserves_extra_columns(self, retrieval_score_frame: FrameFactory) -> None:
+        df = retrieval_score_frame(doc_id=["doc-a", "doc-b"])
+
+        validated = validate_eval_score_frame(df, task=Task.RETRIEVAL)
+
+        pd.testing.assert_frame_equal(validated, df)
+
+    def test_coerces_rank_to_integer(self, retrieval_score_frame: FrameFactory) -> None:
+        df = retrieval_score_frame(chunk_rank=[1.0, 2.0])
+
+        validated = validate_eval_score_frame(df, task=Task.RETRIEVAL)
+
+        pd.testing.assert_series_equal(
+            validated["chunk_rank"],
+            pd.Series([1, 2], name="chunk_rank", dtype="int64"),
+        )
 
     def test_rejects_non_dataframe_score_input(self) -> None:
         with pytest.raises(EvalInputSchemaError, match="Expected a pandas DataFrame"):
@@ -288,12 +360,70 @@ class TestValidateEvalScoreFrame:
 
     def test_rejects_invalid_labeled_score_frame_with_score_specific_error(
         self,
-        retrieval_train_frame: FrameFactory,
+        retrieval_score_frame: FrameFactory,
     ) -> None:
-        df = retrieval_train_frame(topically_relevant=[1, 2])
+        df = retrieval_score_frame(topically_relevant=[1, 2])
 
         with pytest.raises(EvalInputSchemaError, match="scoring data contract"):
             validate_eval_score_frame(df, task=Task.RETRIEVAL)
+
+    @pytest.mark.parametrize(
+        ("task", "fixture_name"),
+        [
+            (Task.RETRIEVAL, "retrieval_score_frame"),
+            (Task.GROUNDING, "grounding_score_frame"),
+            (Task.GENERATION, "generation_score_frame"),
+        ],
+    )
+    def test_requires_record_uuid(
+        self,
+        request: pytest.FixtureRequest,
+        task: Task,
+        fixture_name: str,
+    ) -> None:
+        factory: FrameFactory = request.getfixturevalue(fixture_name)
+        df = factory().drop(columns=["record_uuid"])
+
+        with pytest.raises(EvalInputSchemaError, match="scoring data contract"):
+            validate_eval_score_frame(df, task=task)
+
+    @pytest.mark.parametrize("missing", ["chunk_id", "chunk_rank"])
+    def test_retrieval_requires_chunk_identity_columns(
+        self,
+        retrieval_score_frame: FrameFactory,
+        missing: str,
+    ) -> None:
+        df = retrieval_score_frame().drop(columns=[missing])
+
+        with pytest.raises(EvalInputSchemaError, match="scoring data contract"):
+            validate_eval_score_frame(df, task=Task.RETRIEVAL)
+
+    @pytest.mark.parametrize("bad_rank", [[1, 0], [1, -1]])
+    def test_rejects_non_positive_rank(
+        self,
+        retrieval_score_frame: FrameFactory,
+        bad_rank: list[int],
+    ) -> None:
+        df = retrieval_score_frame(chunk_rank=bad_rank)
+
+        with pytest.raises(EvalInputSchemaError, match="scoring data contract"):
+            validate_eval_score_frame(df, task=Task.RETRIEVAL)
+
+    def test_train_and_score_schemas_are_distinct(
+        self,
+        retrieval_train_frame: FrameFactory,
+    ) -> None:
+        """One frame, two verdicts: training accepts it, scoring rejects it.
+
+        This pins the design intent that scoring's structural metadata
+        (``record_uuid`` here) does not leak back into the training contract.
+        """
+        df = retrieval_train_frame()
+        assert "record_uuid" not in df.columns
+
+        validate_eval_train_frame(df, task=Task.RETRIEVAL)  # training accepts
+        with pytest.raises(EvalInputSchemaError, match="scoring data contract"):
+            validate_eval_score_frame(df, task=Task.RETRIEVAL)  # scoring rejects
 
 
 class TestValidateEvalPredictFrame:


### PR DESCRIPTION
## Summary

2nd PR of eval-scoring stack (design: `docs/design/eval-scoring-metrics.md`). Scoring has stricter structural requirements than training, so it gets its own input contract instead of reusing the train schemas:

- Adds `RETRIEVAL_SCORE_SCHEMA` / `GROUNDING_SCORE_SCHEMA` / `GENERATION_SCORE_SCHEMA`. Every task requires `record_uuid` (the per-query grouping unit); retrieval additionally requires `chunk_id` and `chunk_rank`.
- Switches `validate_eval_score_frame` onto using these dedicated schemas (prev reused `_TRAIN_SCHEMAS_BY_TASK`) -> training inputs are no longer constrained by scoring-only metadata.
- `K` is inferred from the ranked rows at scoring time, so only `rank >= 1` is enforced = no upper bound, no hard-coded K.
- 
## Test plan

- [x] `pytest tests/unit/core/schemas/test_eval_input.py` - per-task valid frames; `record_uuid` required for all tasks; `chunk_id`/`chunk_rank` required for retrieval only; non-positive rank rejected; rank coercion; and a distinctness test proving one frame is train-valid but score-invalid.
- [x] `pytest tests/unit/core/schemas/ tests/unit/core/eval/` - 301 green; no downstream regressions.
- [x] CI passes.