### PR TITLE
feat: add prediction paths and task-aware evaluator selection

### DIFF
--- a/src/pragmata/core/paths/eval_paths.py
+++ b/src/pragmata/core/paths/eval_paths.py
@@ -9,6 +9,7 @@ from pragmata.core.paths.annotation_paths import resolve_export_paths
 from pragmata.core.paths.paths import WorkspacePaths
 from pragmata.core.schemas.annotation_export import AnnotationExportMeta
 from pragmata.core.schemas.annotation_task import Task
+from pragmata.core.schemas.eval_output import EvalTrainMeta
 
 
 @dataclass(frozen=True, slots=True)
@@ -31,6 +32,28 @@ class EvalTrainPaths:
         self,
     ) -> Self:
         """Create the eval tool directory scaffold."""
+        self.tool_root.mkdir(parents=True, exist_ok=True)
+        return self
+
+
+@dataclass(frozen=True, slots=True)
+class EvalPredictPaths:
+    """Resolved input paths for eval prediction.
+
+    Attributes:
+        tool_root: Root directory for eval artifacts. Passed to tlmtc as
+            ``work_dir`` for prediction.
+        prediction_input_csv: Concrete unlabeled CSV path consumed by eval
+            prediction.
+    """
+
+    tool_root: Path
+    prediction_input_csv: Path
+
+    def ensure_dirs(
+        self,
+    ) -> Self:
+        """Create the eval tool root."""
         self.tool_root.mkdir(parents=True, exist_ok=True)
         return self
 
@@ -176,6 +199,112 @@ def resolve_eval_train_meta_path(
         directory.
     """
     return workspace.tool_root("eval") / "train_outputs" / run_id / "pragmata_train.meta.json"
+
+
+def resolve_eval_predict_paths(
+    *,
+    workspace: WorkspacePaths,
+    unlabeled_data_path: Path,
+) -> EvalPredictPaths:
+    """Resolve the explicit unlabeled input CSV consumed by eval predict.
+
+    Args:
+        workspace: Workspace path bundle.
+        unlabeled_data_path: Direct unlabeled CSV path.
+
+    Returns:
+        Resolved prediction-input paths.
+
+    Raises:
+        FileNotFoundError: If the input path is not an existing file.
+    """
+    prediction_input_csv = unlabeled_data_path.expanduser().resolve()
+    if not prediction_input_csv.is_file():
+        raise FileNotFoundError(f"Unlabeled eval prediction input CSV does not exist: {prediction_input_csv}")
+
+    return EvalPredictPaths(
+        tool_root=workspace.tool_root("eval"),
+        prediction_input_csv=prediction_input_csv,
+    )
+
+
+def find_latest_eval_train_run_id(
+    *,
+    workspace: WorkspacePaths,
+    task: Task,
+) -> str:
+    """Find the latest completed evaluator training run for a task.
+
+    Args:
+        workspace: Workspace path bundle.
+        task: Pragmata task the evaluator must have been trained for.
+
+    Returns:
+        Run ID selected by creation time with run ID as a deterministic
+        tie-breaker.
+
+    Raises:
+        FileNotFoundError: If no evaluator metadata matches the requested task.
+        pydantic.ValidationError: If persisted evaluator metadata is invalid.
+    """
+    train_outputs_dir = workspace.tool_root("eval") / "train_outputs"
+    compatible_runs: list[tuple[datetime, str]] = []
+
+    for meta_path in train_outputs_dir.glob("*/pragmata_train.meta.json"):
+        meta = EvalTrainMeta.model_validate_json(meta_path.read_text(encoding="utf-8"))
+        if meta.task == task:
+            compatible_runs.append((meta.created_at, meta.run_id))
+
+    if not compatible_runs:
+        raise FileNotFoundError(
+            f"No completed eval training runs found for task={task.value!r}. "
+            f"Expected matching pragmata_train.meta.json under {train_outputs_dir}."
+        )
+
+    return max(compatible_runs, key=lambda item: (item[0], item[1]))[1]
+
+
+def resolve_eval_train_run_id(
+    *,
+    workspace: WorkspacePaths,
+    task: Task,
+    evaluator_run_id: str | None = None,
+) -> str:
+    """Resolve a concrete evaluator training run ID compatible with a task.
+
+    Args:
+        workspace: Workspace path bundle.
+        task: Pragmata task the evaluator must have been trained for.
+        evaluator_run_id: Optional explicit evaluator run ID. When omitted, the
+            latest task-compatible evaluator is selected.
+
+    Returns:
+        Concrete task-compatible evaluator run ID.
+
+    Raises:
+        FileNotFoundError: If explicit evaluator metadata is missing or no
+            compatible evaluator exists.
+        ValueError: If explicit metadata identifies a different task.
+        pydantic.ValidationError: If persisted evaluator metadata is invalid.
+    """
+    if evaluator_run_id is None:
+        return find_latest_eval_train_run_id(workspace=workspace, task=task)
+
+    meta_path = resolve_eval_train_meta_path(
+        workspace=workspace,
+        run_id=evaluator_run_id,
+    )
+    if not meta_path.is_file():
+        raise FileNotFoundError(f"Eval train metadata does not exist: {meta_path}")
+
+    meta = EvalTrainMeta.model_validate_json(meta_path.read_text(encoding="utf-8"))
+    if meta.task != task:
+        raise ValueError(
+            f"Evaluator {evaluator_run_id!r} was trained for task={meta.task.value!r}, "
+            f"not requested task={task.value!r}."
+        )
+
+    return evaluator_run_id
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/unit/core/paths/test_eval_paths.py
+++ b/tests/unit/core/paths/test_eval_paths.py
@@ -485,6 +485,32 @@ def test_find_latest_eval_train_run_id_selects_latest_matching_task(
     assert run_id == "newer-retrieval"
 
 
+def test_find_latest_eval_train_run_id_tie_breaks_by_run_id(
+    workspace: WorkspacePaths,
+) -> None:
+    """Latest evaluator selection uses run ID as deterministic timestamp tie-breaker."""
+    created_at = datetime(2026, 1, 1, tzinfo=UTC)
+    _write_eval_train_meta(
+        workspace=workspace,
+        run_id="run-a",
+        created_at=created_at,
+        task=Task.RETRIEVAL,
+    )
+    _write_eval_train_meta(
+        workspace=workspace,
+        run_id="run-b",
+        created_at=created_at,
+        task=Task.RETRIEVAL,
+    )
+
+    run_id = find_latest_eval_train_run_id(
+        workspace=workspace,
+        task=Task.RETRIEVAL,
+    )
+
+    assert run_id == "run-b"
+
+
 def test_find_latest_eval_train_run_id_rejects_no_matching_evaluator(
     workspace: WorkspacePaths,
 ) -> None:

--- a/tests/unit/core/paths/test_eval_paths.py
+++ b/tests/unit/core/paths/test_eval_paths.py
@@ -1,4 +1,4 @@
-"""Tests for eval score run path bundle."""
+"""Tests for eval workflow path bundles."""
 
 from datetime import UTC, datetime
 from pathlib import Path
@@ -6,16 +6,21 @@ from pathlib import Path
 import pytest
 
 from pragmata.core.paths.eval_paths import (
+    EvalPredictPaths,
     EvalScorePaths,
     EvalTrainPaths,
     find_latest_annotation_export_id,
+    find_latest_eval_train_run_id,
+    resolve_eval_predict_paths,
     resolve_eval_score_paths,
     resolve_eval_train_meta_path,
     resolve_eval_train_paths,
+    resolve_eval_train_run_id,
 )
 from pragmata.core.paths.paths import WorkspacePaths
 from pragmata.core.schemas.annotation_export import AnnotationExportMeta
 from pragmata.core.schemas.annotation_task import Task
+from pragmata.core.schemas.eval_output import EvalTrainMeta
 
 
 @pytest.fixture()
@@ -64,6 +69,27 @@ def _write_annotation_export(
     )
 
     return export_dir
+
+
+def _write_eval_train_meta(
+    *,
+    workspace: WorkspacePaths,
+    run_id: str,
+    created_at: datetime,
+    task: Task,
+) -> None:
+    """Write a minimal eval train metadata sidecar for path tests."""
+    meta_path = resolve_eval_train_meta_path(
+        workspace=workspace,
+        run_id=run_id,
+    )
+    meta_path.parent.mkdir(parents=True)
+    meta = EvalTrainMeta(
+        run_id=run_id,
+        created_at=created_at,
+        task=task,
+    )
+    meta_path.write_text(meta.model_dump_json(), encoding="utf-8")
 
 
 def test_resolve_eval_train_paths_uses_direct_labeled_data_path(
@@ -330,6 +356,151 @@ def test_resolve_eval_train_meta_path_returns_train_run_sidecar_path(
     )
 
     assert path == workspace.base_dir / "eval" / "train_outputs" / "train-run-26" / "pragmata_train.meta.json"
+
+
+def test_resolve_eval_predict_paths_uses_direct_unlabeled_data_path(
+    workspace: WorkspacePaths,
+) -> None:
+    """Direct unlabeled CSV input resolves to an eval prediction path bundle."""
+    input_csv = workspace.base_dir / "standalone" / "unlabeled.csv"
+    input_csv.parent.mkdir()
+    input_csv.write_text("example_id\nexample-1\n", encoding="utf-8")
+
+    paths = resolve_eval_predict_paths(
+        workspace=workspace,
+        unlabeled_data_path=input_csv,
+    )
+
+    assert paths == EvalPredictPaths(
+        tool_root=workspace.base_dir / "eval",
+        prediction_input_csv=input_csv.resolve(),
+    )
+
+
+def test_resolve_eval_predict_paths_rejects_missing_input(
+    workspace: WorkspacePaths,
+) -> None:
+    """Prediction input must point to an existing file."""
+    with pytest.raises(FileNotFoundError, match="Unlabeled eval prediction input CSV does not exist"):
+        resolve_eval_predict_paths(
+            workspace=workspace,
+            unlabeled_data_path=workspace.base_dir / "missing.csv",
+        )
+
+
+def test_eval_predict_paths_ensure_dirs_creates_eval_tool_root(
+    workspace: WorkspacePaths,
+) -> None:
+    """EvalPredictPaths.ensure_dirs creates the eval tool root and returns self."""
+    paths = EvalPredictPaths(
+        tool_root=workspace.base_dir / "eval",
+        prediction_input_csv=workspace.base_dir / "unlabeled.csv",
+    )
+
+    returned = paths.ensure_dirs()
+
+    assert returned is paths
+    assert paths.tool_root.is_dir()
+
+
+def test_resolve_eval_train_run_id_uses_explicit_task_compatible_evaluator(
+    workspace: WorkspacePaths,
+) -> None:
+    """Explicit evaluator selection accepts metadata for the requested task."""
+    _write_eval_train_meta(
+        workspace=workspace,
+        run_id="retrieval-run",
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        task=Task.RETRIEVAL,
+    )
+
+    run_id = resolve_eval_train_run_id(
+        workspace=workspace,
+        task=Task.RETRIEVAL,
+        evaluator_run_id="retrieval-run",
+    )
+
+    assert run_id == "retrieval-run"
+
+
+def test_resolve_eval_train_run_id_rejects_missing_metadata(
+    workspace: WorkspacePaths,
+) -> None:
+    """Explicit evaluator selection requires its Pragmata metadata sidecar."""
+    with pytest.raises(FileNotFoundError, match="pragmata_train.meta.json"):
+        resolve_eval_train_run_id(
+            workspace=workspace,
+            task=Task.RETRIEVAL,
+            evaluator_run_id="missing-run",
+        )
+
+
+def test_resolve_eval_train_run_id_rejects_task_mismatch(
+    workspace: WorkspacePaths,
+) -> None:
+    """An explicit evaluator cannot be selected for a different task."""
+    _write_eval_train_meta(
+        workspace=workspace,
+        run_id="generation-run",
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        task=Task.GENERATION,
+    )
+
+    with pytest.raises(ValueError, match="generation.*retrieval"):
+        resolve_eval_train_run_id(
+            workspace=workspace,
+            task=Task.RETRIEVAL,
+            evaluator_run_id="generation-run",
+        )
+
+
+def test_find_latest_eval_train_run_id_selects_latest_matching_task(
+    workspace: WorkspacePaths,
+) -> None:
+    """Latest evaluator selection filters by task and creation time."""
+    _write_eval_train_meta(
+        workspace=workspace,
+        run_id="older-retrieval",
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        task=Task.RETRIEVAL,
+    )
+    _write_eval_train_meta(
+        workspace=workspace,
+        run_id="newer-retrieval",
+        created_at=datetime(2026, 1, 2, tzinfo=UTC),
+        task=Task.RETRIEVAL,
+    )
+    _write_eval_train_meta(
+        workspace=workspace,
+        run_id="newest-generation",
+        created_at=datetime(2026, 1, 3, tzinfo=UTC),
+        task=Task.GENERATION,
+    )
+
+    run_id = find_latest_eval_train_run_id(
+        workspace=workspace,
+        task=Task.RETRIEVAL,
+    )
+
+    assert run_id == "newer-retrieval"
+
+
+def test_find_latest_eval_train_run_id_rejects_no_matching_evaluator(
+    workspace: WorkspacePaths,
+) -> None:
+    """Latest evaluator selection fails when no metadata matches the task."""
+    _write_eval_train_meta(
+        workspace=workspace,
+        run_id="generation-run",
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        task=Task.GENERATION,
+    )
+
+    with pytest.raises(FileNotFoundError, match="task='retrieval'"):
+        find_latest_eval_train_run_id(
+            workspace=workspace,
+            task=Task.RETRIEVAL,
+        )
 
 
 def test_resolve_eval_score_paths_returns_expected_bundle(


### PR DESCRIPTION
### Summary

Adds the path-resolution and evaluator-selection foundation for the eval prediction workflow.

Prediction inputs now resolve through a dedicated path bundle. Evaluators can be selected explicitly or resolved automatically to the latest training run compatible with the requested `pragmata` task.

### Changes

- Add `EvalPredictPaths` for the eval tool root and unlabeled prediction input.
- Add explicit prediction input path resolution and validation.
- Add task-aware latest evaluator selection using persisted `EvalTrainMeta`.
- Validate explicitly selected evaluators against the requested task.
- Keep evaluator selection independent from TLMTC model validation and prediction execution.

### Testing

- Covered direct prediction input resolution and missing inputs.
- Covered creation of the eval tool root.
- Covered explicit compatible evaluator selection.
- Covered missing evaluator metadata and task mismatches.
- Covered latest evaluator selection by task and creation time.
- Covered failure when no task-compatible evaluator exists.