### PR TITLE
feat(eval): add per-query metrics and query grouping

### DIFF
--- a/src/pragmata/core/eval/grouping.py
+++ b/src/pragmata/core/eval/grouping.py
@@ -1,0 +1,89 @@
+"""Group validated eval score frames into the per-query values metrics consume.
+
+The scoring resampling unit is the query (``record_uuid``). Retrieval rows are
+grouped into queries and each query's chunks ordered by ``chunk_rank`` before the
+per-query retrieval formulas run; grounding and generation carry one row per
+query, so their per-query values are the row-level labels directly.
+
+Each function returns ``{report_field_name: [per-query value, ...]}`` in a stable
+query order (first appearance), which the scoring layer turns into point
+estimates and confidence intervals. Input frames are assumed already validated
+(``validate_eval_score_frame``) and complete; dataset-level policy for incomplete
+or degenerate data is the scoring layer's responsibility, not this module's.
+"""
+
+import numpy as np
+import pandas as pd
+from numpy.typing import NDArray
+
+from pragmata.core.eval import metrics
+
+# Report field name -> source binary label column. Grounding and generation have
+# one row per query, so the per-query value is the label itself (the conditional
+# fabrication rate is handled separately, as it is not a plain column mean). This
+# column wiring lives in the preparation layer; metrics.py stays column-agnostic.
+GROUNDING_METRIC_LABELS: dict[str, str] = {
+    "grounding_presence_rate": "support_present",
+    "unsupported_claim_rate": "unsupported_claim_present",
+    "contradiction_rate": "contradicted_claim_present",
+    "citation_presence_rate": "source_cited",
+}
+
+GENERATION_METRIC_LABELS: dict[str, str] = {
+    "proper_action_rate": "proper_action",
+    "on_topic_rate": "response_on_topic",
+    "helpfulness_rate": "helpful",
+    "incompleteness_rate": "incomplete",
+    "unsafe_content_rate": "unsafe_content",
+}
+
+
+def retrieval_per_query_values(frame: pd.DataFrame) -> dict[str, list[float]]:
+    """Per-query retrieval metric values, one entry per query in the frame."""
+    values: dict[str, list[float]] = {
+        "topical_precision_at_k": [],
+        "sufficiency_hit_at_k": [],
+        "sufficiency_rate_at_k": [],
+        "misleading_context_rate_at_k": [],
+        "mean_reciprocal_rank_at_k": [],
+        "ndcg_at_k": [],
+    }
+    for _, query in frame.groupby("record_uuid", sort=False):
+        ordered = query.sort_values("chunk_rank")
+        topically_relevant = ordered["topically_relevant"].to_numpy()
+        evidence_sufficient = ordered["evidence_sufficient"].to_numpy()
+        misleading = ordered["misleading"].to_numpy()
+        values["topical_precision_at_k"].append(metrics.topical_precision(topically_relevant))
+        values["sufficiency_hit_at_k"].append(metrics.sufficiency_hit(evidence_sufficient))
+        values["sufficiency_rate_at_k"].append(metrics.sufficiency_rate(evidence_sufficient))
+        values["misleading_context_rate_at_k"].append(metrics.misleading_context_rate(misleading))
+        values["mean_reciprocal_rank_at_k"].append(metrics.reciprocal_rank(topically_relevant))
+        values["ndcg_at_k"].append(metrics.ndcg(topically_relevant, evidence_sufficient))
+    return values
+
+
+def _row_level_values(frame: pd.DataFrame, label_map: dict[str, str]) -> dict[str, list[float]]:
+    """Extract each report field's binary label column as a per-query value list."""
+    return {field: frame[column].astype(float).tolist() for field, column in label_map.items()}
+
+
+def grounding_per_query_values(frame: pd.DataFrame) -> dict[str, list[float]]:
+    """Per-query values for the four unconditional grounding metrics.
+
+    The conditional fabrication rate is not a plain column mean; use
+    :func:`conditional_fabrication_units`.
+    """
+    return _row_level_values(frame, GROUNDING_METRIC_LABELS)
+
+
+def generation_per_query_values(frame: pd.DataFrame) -> dict[str, list[float]]:
+    """Per-query values for the five generation metrics."""
+    return _row_level_values(frame, GENERATION_METRIC_LABELS)
+
+
+def conditional_fabrication_units(frame: pd.DataFrame) -> NDArray[np.int_]:
+    """Fabrication flags over the cited subset, for the conditional fabrication rate."""
+    return metrics.fabricated_among_cited(
+        frame["source_cited"].to_numpy(),
+        frame["fabricated_source"].to_numpy(),
+    )

--- a/src/pragmata/core/eval/metrics.py
+++ b/src/pragmata/core/eval/metrics.py
@@ -1,0 +1,105 @@
+"""Pure, deterministic metric formulas from the taxonomy.
+
+Implements the per-query formulas in ``docs/methodology/metrics-taxonomy.md``.
+Every function is I/O-free and operates on NumPy label arrays: retrieval
+functions take one query's chunk labels (pre-sorted by ``chunk_rank`` ascending,
+so array position ``i`` is rank ``i + 1``); grounding/generation values are the
+row-level binary labels themselves.
+
+Corpus aggregation (the mean over queries) and confidence intervals live in the
+scoring layer - this module only computes the deterministic per-query numbers.
+Dataset-level policy for incomplete or degenerate data is likewise out of scope
+here; these functions assume each query they receive is complete.
+"""
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+def _require_nonempty(values: NDArray) -> None:
+    if values.shape[0] == 0:
+        raise ValueError("retrieval metrics require at least one chunk per query")
+
+
+def _mean(values: NDArray) -> float:
+    _require_nonempty(values)
+    return float(np.mean(values))
+
+
+def corpus_mean(per_query_values: NDArray | list[float]) -> float:
+    """Corpus-level point estimate: the taxonomy's ``1/I`` mean over per-query values.
+
+    Applies to every metric's point estimate - a 0/1 array for the proportion
+    metrics (where the mean is the proportion), continuous otherwise. The
+    confidence interval is computed separately by the scoring layer.
+    """
+    return _mean(np.asarray(per_query_values, dtype=float))
+
+
+# ---- retrieval per-query metrics (chunks pre-sorted by chunk_rank ascending) ----
+
+
+def topical_precision(topically_relevant: NDArray) -> float:
+    """Fraction of the query's chunks that are topically relevant."""
+    return _mean(topically_relevant)
+
+
+def sufficiency_hit(evidence_sufficient: NDArray) -> float:
+    """1.0 if any chunk is sufficient evidence, else 0.0 (binary per query)."""
+    _require_nonempty(evidence_sufficient)
+    return float(np.any(evidence_sufficient == 1))
+
+
+def sufficiency_rate(evidence_sufficient: NDArray) -> float:
+    """Fraction of the query's chunks that are individually sufficient."""
+    return _mean(evidence_sufficient)
+
+
+def misleading_context_rate(misleading: NDArray) -> float:
+    """Fraction of the query's chunks that are misleading."""
+    return _mean(misleading)
+
+
+def reciprocal_rank(topically_relevant: NDArray) -> float:
+    """Reciprocal of the rank of the first topically-relevant chunk, else 0.0."""
+    _require_nonempty(topically_relevant)
+    hits = np.flatnonzero(topically_relevant == 1)
+    if hits.size == 0:
+        return 0.0
+    return 1.0 / (int(hits[0]) + 1)
+
+
+def _relevance_grades(topically_relevant: NDArray, evidence_sufficient: NDArray) -> NDArray:
+    """Graded relevance: sufficient -> 2, relevant-only -> 1, else 0."""
+    return np.where(evidence_sufficient == 1, 2, np.where(topically_relevant == 1, 1, 0))
+
+
+def _dcg(grades: NDArray) -> float:
+    """Discounted cumulative gain with gain ``2^grade - 1`` at 1-based positions."""
+    positions = np.arange(1, grades.shape[0] + 1)
+    gains = np.power(2.0, grades) - 1.0
+    return float(np.sum(gains / np.log2(positions + 1)))
+
+
+def ndcg(topically_relevant: NDArray, evidence_sufficient: NDArray) -> float:
+    """Normalised DCG@K over the query's ranked chunks; 0.0 when no chunk is graded."""
+    _require_nonempty(topically_relevant)
+    grades = _relevance_grades(topically_relevant, evidence_sufficient)
+    ideal = _dcg(np.sort(grades)[::-1])
+    if ideal == 0.0:
+        return 0.0
+    return _dcg(grades) / ideal
+
+
+# ---- conditional grounding metric ----
+
+
+def fabricated_among_cited(source_cited: NDArray, fabricated_source: NDArray) -> NDArray:
+    """Binary ``fabricated_source`` values over the cited subset only.
+
+    The conditional fabrication rate is defined only where ``source_cited == 1``.
+    Returns the per-cited-query fabrication flags; the scoring layer forms the
+    rate and its Wilson interval from these (and reports ``None`` when empty).
+    """
+    cited = source_cited == 1
+    return fabricated_source[cited].astype(int)

--- a/tests/unit/core/eval/test_grouping.py
+++ b/tests/unit/core/eval/test_grouping.py
@@ -1,0 +1,213 @@
+"""Unit tests for grouping validated score frames into per-query values."""
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from pragmata.core.eval import grouping
+from pragmata.core.eval.grouping import GENERATION_METRIC_LABELS, GROUNDING_METRIC_LABELS
+from pragmata.core.schemas.annotation_task import Task
+from pragmata.core.schemas.eval_input import LABEL_COLUMNS_BY_TASK
+
+
+def _retrieval_frame(rows: list[dict]) -> pd.DataFrame:
+    return pd.DataFrame(rows)
+
+
+class TestRetrievalPerQueryValues:
+    def test_two_queries(self):
+        # rec-1: three chunks; rec-2: two chunks. Label patterns are chosen so
+        # each retrieval metric yields a UNIQUE per-query array - a metric sourced
+        # from the wrong label column (e.g. sufficiency_rate <-> misleading) would
+        # produce a different array and fail.
+        frame = _retrieval_frame(
+            [
+                {
+                    "record_uuid": "rec-1",
+                    "chunk_rank": 1,
+                    "topically_relevant": 1,
+                    "evidence_sufficient": 1,
+                    "misleading": 0,
+                },
+                {
+                    "record_uuid": "rec-1",
+                    "chunk_rank": 2,
+                    "topically_relevant": 1,
+                    "evidence_sufficient": 0,
+                    "misleading": 0,
+                },
+                {
+                    "record_uuid": "rec-1",
+                    "chunk_rank": 3,
+                    "topically_relevant": 0,
+                    "evidence_sufficient": 0,
+                    "misleading": 0,
+                },
+                {
+                    "record_uuid": "rec-2",
+                    "chunk_rank": 1,
+                    "topically_relevant": 0,
+                    "evidence_sufficient": 0,
+                    "misleading": 1,
+                },
+                {
+                    "record_uuid": "rec-2",
+                    "chunk_rank": 2,
+                    "topically_relevant": 1,
+                    "evidence_sufficient": 0,
+                    "misleading": 1,
+                },
+            ]
+        )
+
+        values = grouping.retrieval_per_query_values(frame)
+
+        assert values["topical_precision_at_k"] == pytest.approx([2 / 3, 0.5])
+        assert values["sufficiency_hit_at_k"] == [1.0, 0.0]
+        assert values["sufficiency_rate_at_k"] == pytest.approx([1 / 3, 0.0])
+        assert values["misleading_context_rate_at_k"] == pytest.approx([0.0, 1.0])
+        assert values["mean_reciprocal_rank_at_k"] == pytest.approx([1.0, 0.5])
+        # rec-2's only relevant chunk sits at rank 2, so NDCG is penalised to
+        # DCG/IDCG = (1/log2(3)) / (1/log2(2)) = 1/log2(3).
+        assert values["ndcg_at_k"] == pytest.approx([1.0, 1 / math.log2(3)])
+
+    def test_chunks_are_ordered_by_rank(self):
+        # Rows supplied out of rank order; rank-1 chunk is the relevant one.
+        # Correct ordering -> first relevant at rank 1 -> RR 1.0. Ignoring rank -> 0.5.
+        frame = _retrieval_frame(
+            [
+                {
+                    "record_uuid": "rec-1",
+                    "chunk_rank": 2,
+                    "topically_relevant": 0,
+                    "evidence_sufficient": 0,
+                    "misleading": 0,
+                },
+                {
+                    "record_uuid": "rec-1",
+                    "chunk_rank": 1,
+                    "topically_relevant": 1,
+                    "evidence_sufficient": 0,
+                    "misleading": 0,
+                },
+            ]
+        )
+
+        values = grouping.retrieval_per_query_values(frame)
+
+        assert values["mean_reciprocal_rank_at_k"] == pytest.approx([1.0])
+
+    def test_query_order_is_first_appearance(self):
+        frame = _retrieval_frame(
+            [
+                {
+                    "record_uuid": "z",
+                    "chunk_rank": 1,
+                    "topically_relevant": 1,
+                    "evidence_sufficient": 0,
+                    "misleading": 0,
+                },
+                {
+                    "record_uuid": "a",
+                    "chunk_rank": 1,
+                    "topically_relevant": 0,
+                    "evidence_sufficient": 0,
+                    "misleading": 0,
+                },
+            ]
+        )
+
+        values = grouping.retrieval_per_query_values(frame)
+
+        # 'z' appears first, so its topical precision (1.0) leads.
+        assert values["topical_precision_at_k"] == pytest.approx([1.0, 0.0])
+
+
+class TestGroundingPerQueryValues:
+    def test_wiring_each_field_to_its_label(self):
+        # Three rows so every mapped column has a distinct pattern: a swap
+        # between any two fields would change the routed values and fail.
+        frame = pd.DataFrame(
+            {
+                "record_uuid": ["r1", "r2", "r3"],
+                "support_present": [1, 1, 1],
+                "unsupported_claim_present": [1, 1, 0],
+                "contradicted_claim_present": [1, 0, 0],
+                "source_cited": [0, 1, 1],
+                "fabricated_source": [0, 0, 0],
+            }
+        )
+
+        values = grouping.grounding_per_query_values(frame)
+
+        assert values["grounding_presence_rate"] == [1.0, 1.0, 1.0]
+        assert values["unsupported_claim_rate"] == [1.0, 1.0, 0.0]
+        assert values["contradiction_rate"] == [1.0, 0.0, 0.0]
+        assert values["citation_presence_rate"] == [0.0, 1.0, 1.0]
+        assert "conditional_fabrication_rate" not in values
+
+
+class TestGenerationPerQueryValues:
+    def test_wiring_each_field_to_its_label(self):
+        # Three rows: five distinct column patterns so no two fields collide
+        # (only four patterns exist with two rows), catching any rename/swap.
+        frame = pd.DataFrame(
+            {
+                "record_uuid": ["r1", "r2", "r3"],
+                "proper_action": [1, 1, 1],
+                "response_on_topic": [1, 1, 0],
+                "helpful": [1, 0, 0],
+                "incomplete": [0, 1, 1],
+                "unsafe_content": [0, 0, 1],
+            }
+        )
+
+        values = grouping.generation_per_query_values(frame)
+
+        assert values["proper_action_rate"] == [1.0, 1.0, 1.0]
+        assert values["on_topic_rate"] == [1.0, 1.0, 0.0]
+        assert values["helpfulness_rate"] == [1.0, 0.0, 0.0]
+        assert values["incompleteness_rate"] == [0.0, 1.0, 1.0]
+        assert values["unsafe_content_rate"] == [0.0, 0.0, 1.0]
+
+
+class TestConditionalFabricationUnits:
+    def test_cited_subset(self):
+        frame = pd.DataFrame(
+            {
+                "record_uuid": ["r1", "r2", "r3"],
+                "source_cited": [1, 0, 1],
+                "fabricated_source": [1, 1, 0],
+            }
+        )
+
+        units = grouping.conditional_fabrication_units(frame)
+
+        assert np.array_equal(units, np.array([1, 0]))
+
+    def test_no_cited_is_empty(self):
+        frame = pd.DataFrame(
+            {
+                "record_uuid": ["r1"],
+                "source_cited": [0],
+                "fabricated_source": [1],
+            }
+        )
+
+        assert grouping.conditional_fabrication_units(frame).shape[0] == 0
+
+
+class TestMetricLabelMapsStayAligned:
+    """Guard against silent drift if a label column is renamed in eval_input."""
+
+    def test_grounding_map_targets_real_labels(self):
+        # Four unconditional metrics; fabricated_source is used only via the
+        # conditional fabrication rate, so it is the one grounding label absent here.
+        assert set(GROUNDING_METRIC_LABELS.values()) | {"fabricated_source"} == set(
+            LABEL_COLUMNS_BY_TASK[Task.GROUNDING]
+        )
+
+    def test_generation_map_targets_real_labels(self):
+        assert set(GENERATION_METRIC_LABELS.values()) == set(LABEL_COLUMNS_BY_TASK[Task.GENERATION])

--- a/tests/unit/core/eval/test_metrics.py
+++ b/tests/unit/core/eval/test_metrics.py
@@ -1,0 +1,135 @@
+"""Unit tests for the pure per-query metric formulas."""
+
+import math
+
+import numpy as np
+import pytest
+
+from pragmata.core.eval import metrics
+
+
+def arr(*values: int) -> np.ndarray:
+    return np.array(values, dtype=int)
+
+
+class TestTopicalPrecision:
+    def test_fraction_relevant(self):
+        assert metrics.topical_precision(arr(1, 1, 0)) == pytest.approx(2 / 3)
+
+    def test_all_relevant(self):
+        assert metrics.topical_precision(arr(1, 1)) == 1.0
+
+    def test_none_relevant(self):
+        assert metrics.topical_precision(arr(0, 0)) == 0.0
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError, match="at least one chunk"):
+            metrics.topical_precision(arr())
+
+
+class TestSufficiency:
+    def test_hit_true_when_any_sufficient(self):
+        assert metrics.sufficiency_hit(arr(0, 1, 0)) == 1.0
+
+    def test_hit_false_when_none_sufficient(self):
+        assert metrics.sufficiency_hit(arr(0, 0, 0)) == 0.0
+
+    def test_rate_is_fraction(self):
+        assert metrics.sufficiency_rate(arr(1, 0, 0)) == pytest.approx(1 / 3)
+
+
+class TestMisleadingContextRate:
+    def test_fraction_misleading(self):
+        assert metrics.misleading_context_rate(arr(1, 1, 0, 0)) == 0.5
+
+
+class TestReciprocalRank:
+    def test_first_relevant_at_rank_two(self):
+        # arrays are pre-sorted by chunk_rank, so index 1 is rank 2.
+        assert metrics.reciprocal_rank(arr(0, 1, 0)) == pytest.approx(0.5)
+
+    def test_first_relevant_at_rank_one(self):
+        assert metrics.reciprocal_rank(arr(1, 0)) == 1.0
+
+    def test_no_relevant_is_zero(self):
+        assert metrics.reciprocal_rank(arr(0, 0, 0)) == 0.0
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError, match="at least one chunk"):
+            metrics.reciprocal_rank(arr())
+
+
+class TestNdcg:
+    def test_ideal_ordering_is_one(self):
+        # grades [2, 1, 0] already descending -> DCG == IDCG.
+        topically_relevant = arr(1, 1, 0)
+        evidence_sufficient = arr(1, 0, 0)
+        assert metrics.ndcg(topically_relevant, evidence_sufficient) == pytest.approx(1.0)
+
+    def test_worked_example(self):
+        # rank1: t=1,s=0 -> grade 1 (gain 1); rank2: t=1,s=1 -> grade 2 (gain 3); rank3: 0.
+        # DCG  = 1/log2(2) + 3/log2(3)          = 2.892789
+        # IDCG = 3/log2(2) + 1/log2(3)          = 3.630930  (grades sorted [2,1,0])
+        # NDCG = 0.796708
+        topically_relevant = arr(1, 1, 0)
+        evidence_sufficient = arr(0, 1, 0)
+        result = metrics.ndcg(topically_relevant, evidence_sufficient)
+        assert result == pytest.approx(0.796708, abs=1e-5)
+        assert 0.0 <= result <= 1.0
+
+    def test_no_relevant_is_zero(self):
+        assert metrics.ndcg(arr(0, 0), arr(0, 0)) == 0.0
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError, match="at least one chunk"):
+            metrics.ndcg(arr(), arr())
+
+    def test_never_exceeds_one(self):
+        rng = np.random.default_rng(0)
+        for _ in range(50):
+            n = int(rng.integers(1, 6))
+            t = rng.integers(0, 2, size=n)
+            s = rng.integers(0, 2, size=n)
+            assert metrics.ndcg(t, s) <= 1.0 + 1e-9
+
+
+class TestFabricatedAmongCited:
+    def test_filters_to_cited_subset(self):
+        source_cited = arr(1, 0, 1, 1)
+        fabricated_source = arr(1, 1, 0, 1)  # index 1 is fabricated but NOT cited -> excluded
+        result = metrics.fabricated_among_cited(source_cited, fabricated_source)
+        assert np.array_equal(result, np.array([1, 0, 1]))
+
+    def test_no_cited_returns_empty(self):
+        result = metrics.fabricated_among_cited(arr(0, 0), arr(1, 1))
+        assert result.shape[0] == 0
+
+
+class TestCorpusMean:
+    def test_mean_of_continuous_values(self):
+        assert metrics.corpus_mean([0.5, 1.0, 0.0]) == pytest.approx(0.5)
+
+    def test_mean_of_binary_is_proportion(self):
+        assert metrics.corpus_mean([1, 0, 1, 1]) == pytest.approx(0.75)
+
+    def test_accepts_ndarray(self):
+        assert metrics.corpus_mean(np.array([0.2, 0.4])) == pytest.approx(0.3)
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError, match="at least one"):
+            metrics.corpus_mean([])
+
+
+def test_all_retrieval_values_are_finite_rates():
+    """Sanity: every per-query retrieval value lands in [0, 1]."""
+    t, s, m = arr(1, 0, 1), arr(1, 0, 0), arr(0, 1, 0)
+    for value in (
+        metrics.topical_precision(t),
+        metrics.sufficiency_hit(s),
+        metrics.sufficiency_rate(s),
+        metrics.misleading_context_rate(m),
+        metrics.reciprocal_rank(t),
+        metrics.ndcg(t, s),
+    ):
+        assert not math.isnan(value)
+        assert 0.0 <= value <= 1.0


### PR DESCRIPTION
#278 > #282 > #283 > #284 > #279 > #280

---

## Summary

4th in eval-scoring stack (design: `docs/design/eval-scoring-metrics.md`). Adds the pure computation layer that turns row-level labels into the per-query values each corpus metric averages over:

- `core/eval/grouping.py` — groups a validated score frame into per-query values for all three tasks. Retrieval is the special case: chunk rows are grouped by `record_uuid` and ordered by `chunk_rank` into per-query ranked lists; grounding/generation are one row per query.
- `core/eval/metrics.py` — the metric primitives (precision@K, sufficiency hit/rate@K, misleading-context rate@K, MRR@K, NDCG@K, and the proportion helpers) plus `corpus_mean`, computed on the per-query values.
- No API/CLI wiring here — both modules are dormant at merge and consumed by the scoring API (next PR in the stack). No dependency on the uncertainty work in #275; this is an independent sibling.

## Test plan

- [x] `pytest tests/unit/core/eval/test_grouping.py tests/unit/core/eval/test_metrics.py` — 33 passed (per-query grouping across tasks, retrieval rank ordering, each metric primitive incl. edge cases, corpus mean).
- [x] CI passes.