### PR TITLE
feat(eval): add pragmata.eval.score scoring API

### DIFF
--- a/docs/design/eval-scoring-metrics.md
+++ b/docs/design/eval-scoring-metrics.md
@@ -124,9 +124,9 @@ Lives in `api/eval.py` alongside `train_evaluator` (no separate `api/eval_score.
 def score(
     *, base_dir: str | Path | Unset = UNSET,
     score_id: str | None = None,               # OUTPUT identifier (see below)
-    labeled_input_path: str | Path | None = None,
-    export_id: str | None = None,
-    prediction_run_id: str | None = None,
+    path: str | Path | Unset = UNSET,
+    export_id: str | Unset = UNSET,
+    prediction_id: str | Unset = UNSET,
     task: Task,
     n_resamples: int = 1000, ci: float = 0.95, seed: int | None = None,
     config_path: str | Path | Unset = UNSET,
@@ -143,13 +143,13 @@ The input is selected by exactly one of three mutually-exclusive selectors:
 
 | Selector | Mode | Notes |
 |---|---|---|
-| `labeled_input_path` | direct labeled data | human-annotated or externally-prepared labeled records that score without going through prediction |
+| `path` | direct labeled data | human-annotated or externally-prepared labeled records that score without going through prediction |
 | `export_id` | annotation export | convenience selector; resolves to the task-specific CSV (mirrors `find_latest_annotation_export_id`) |
-| `prediction_run_id` | prediction output | labels produced by `pragmata eval predict`; a **pragmata** prediction run, even though the underlying output is tlmtc-managed |
+| `prediction_id` | prediction output | labels produced by `pragmata eval predict`; a **pragmata** prediction run, even though the underlying output is tlmtc-managed |
 
 `score_id` is an **output** identifier, not an input selector: it names where score artifacts are written (`eval/scores/<score_id>/`) and defaults to the generated value from `EvalScoreSettings`. `export_id` is never reused for output naming.
 
-`EvalScoreSettings` already carries `labeled_input_path`, `prediction_run_id`, and `score_id`; `export_id` needs adding. Precedence and fallback are an open decision (below); a `find_latest_prediction_run` resolver still needs writing in `eval_paths.py`.
+`EvalScoreSettings` carries `path`, `export_id`, `prediction_id`, and `score_id`. The selectors are mutually exclusive, with the latest annotation export as the no-selector fallback (resolved; see below). `prediction_id` is not yet wired - a `find_latest_prediction_run` resolver still needs writing in `eval_paths.py` (deferred, tracked in #303).
 
 ### CLI - `pragmata eval score`
 
@@ -157,7 +157,7 @@ Extend the existing `eval_app` Typer group with a `score` subcommand. The CLI is
 
 ```
 pragmata eval score --task retrieval \
-  [--labeled-input-path PATH | --export-id ID | --prediction-run-id ID] \
+  [--path PATH | --export-id ID | --prediction-id ID] \
   [--score-id ID] [--base-dir DIR] \
   [--n-resamples 1000] [--ci 0.95] [--seed N] [--config FILE]
 ```
@@ -189,6 +189,6 @@ Input-source selection and path resolution belong in `core/paths/eval_paths.py`,
 
 ### Open decisions
 
-1. **Input selection semantics.** Define which of `labeled_input_path` / `export_id` / `prediction_run_id` are mutually exclusive, which (if any) is required, and the precedence/fallback when more than one - or none - is supplied. Proposed: precedence `labeled_input_path` > `export_id` > `prediction_run_id`, with "latest prediction run" as the no-selector fallback (per the `EvalScoreSettings` docstring). Confirm.
+1. ~~**Input selection semantics.**~~ **Resolved.** `path` / `export_id` / `prediction_id` are mutually exclusive with no precedence - passing more than one raises `ValueError` (`_require_at_most_one_selector` in `eval_paths.py`). None is required; with no selector the latest annotation export is used. (The earlier proposal of a precedence order was dropped in favour of mutual exclusivity.)
 2. **Incomplete and degenerate scoring data.** Retrieval metrics assume complete ranked chunk labels per query. If some chunks are unlabeled we need a deliberate policy: fail with an informative message, skip affected queries, or compute a caveated fallback. Similarly, all-0/all-1 or otherwise degenerate labels can make some estimates uninformative and should be handled explicitly. Ideally the validation/guard logic is reusable between `eval train` and `eval score` where the constraints overlap.
-3. **`find_latest_prediction_run` resolver** to be added in `eval_paths.py`, mirroring `find_latest_annotation_export_id`.
+3. **`find_latest_prediction_run` resolver** to be added in `eval_paths.py`, mirroring `find_latest_annotation_export_id`. Deferred alongside `prediction_id` scoring - tracked in #303.

--- a/src/pragmata/api/eval.py
+++ b/src/pragmata/api/eval.py
@@ -1,14 +1,23 @@
 """API orchestration for evaluation workflows."""
 
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from pragmata.api._error_log import error_log
 from pragmata.core.eval.export import export_eval_train_meta
-from pragmata.core.eval.imports import import_eval_predict_frame, import_eval_train_frame
+from pragmata.core.eval.imports import (
+    import_eval_predict_frame,
+    import_eval_score_frame,
+    import_eval_train_frame,
+)
+from pragmata.core.eval.scoring import ScoreReport, build_score_report
 from pragmata.core.eval.tlmtc_adapters import run_tlmtc_predict, run_tlmtc_train
 from pragmata.core.eval.transforms import build_tlmtc_frame
 from pragmata.core.paths.eval_paths import (
     resolve_eval_predict_paths,
+    resolve_eval_score_input,
+    resolve_eval_score_paths,
     resolve_eval_train_meta_path,
     resolve_eval_train_paths,
     resolve_eval_train_run_id,
@@ -16,7 +25,11 @@ from pragmata.core.paths.eval_paths import (
 from pragmata.core.paths.paths import WorkspacePaths
 from pragmata.core.schemas.annotation_task import Task
 from pragmata.core.schemas.eval_output import EvalTrainMeta
-from pragmata.core.settings.eval_settings import EvalPredictSettings, EvalTrainSettings
+from pragmata.core.settings.eval_settings import (
+    EvalPredictSettings,
+    EvalScoreSettings,
+    EvalTrainSettings,
+)
 from pragmata.core.settings.settings_base import UNSET, Unset, load_config_file
 
 
@@ -194,3 +207,98 @@ def predict_labels(
         evaluator_run_id=resolved_evaluator_run_id,
         predict_kwargs=settings.predict_kwargs,
     )
+
+
+def score(
+    *,
+    base_dir: str | Path | Unset = UNSET,
+    score_id: str | Unset = UNSET,
+    path: str | Path | Unset = UNSET,
+    export_id: str | Unset = UNSET,
+    prediction_id: str | Unset = UNSET,
+    task: str | Task | Unset = UNSET,
+    n_resamples: int | Unset = UNSET,
+    ci: float | Unset = UNSET,
+    seed: int | Unset = UNSET,
+    config_path: str | Path | Unset = UNSET,
+) -> ScoreReport:
+    """Score labeled eval data into corpus metrics with confidence intervals.
+
+    Reads one labeled CSV, computes the task's taxonomy metrics as corpus point
+    estimates with a confidence interval on each (Wilson for proportion metrics,
+    percentile bootstrap for the continuous retrieval metrics), and writes the
+    task's ``*_scores.json`` report. The input is selected by precedence
+    ``path`` > ``export_id`` > ``prediction_id``; with no
+    selector the latest annotation export is used. The resolved input and how it
+    was selected are recorded on the report's ``source``.
+
+    Args:
+        base_dir: Workspace base directory. Defaults to the current directory.
+        score_id: Output identifier; names ``<base_dir>/eval/scores/<score_id>/``.
+            Defaults to a generated value.
+        path: Direct path to the labeled CSV to score.
+        export_id: Annotation export identifier; resolves to the task-specific
+            exported CSV.
+        prediction_id: Pragmata prediction run identifier. Not yet supported -
+            prediction-output scoring lands with ``pragmata eval predict``.
+        task: Annotation task to score (``"retrieval"``, ``"grounding"``, or
+            ``"generation"``).
+        n_resamples: Bootstrap iterations for the continuous metrics. Defaults to 1000.
+        ci: Confidence level for every interval. Defaults to 0.95.
+        seed: Optional RNG seed for reproducible bootstrap intervals.
+        config_path: Path to a YAML configuration file.
+
+    Returns:
+        The task-specific score report, also written to ``*_scores.json``.
+
+    Raises:
+        EvalInputSchemaError: If the input violates the score contract.
+        FileNotFoundError: If the selected input CSV or annotation export is missing.
+        NotImplementedError: If ``prediction_id`` is used before predict lands.
+    """
+    settings = EvalScoreSettings.resolve(
+        config=load_config_file(config_path) if isinstance(config_path, (str, Path)) else None,
+        env=None,
+        overrides={
+            "base_dir": base_dir,
+            "score_id": score_id,
+            "path": path,
+            "export_id": export_id,
+            "prediction_id": prediction_id,
+            "task": task,
+            "n_resamples": n_resamples,
+            "ci": ci,
+            "seed": seed,
+        },
+    )
+    workspace = WorkspacePaths.from_base_dir(settings.base_dir)
+    score_paths = resolve_eval_score_paths(workspace=workspace, score_id=settings.score_id).ensure_dirs()
+
+    with error_log(score_paths.tool_root):
+        resolved = resolve_eval_score_input(
+            workspace=workspace,
+            task=settings.task,
+            path=settings.path,
+            export_id=settings.export_id,
+            prediction_id=settings.prediction_id,
+        )
+        frame = import_eval_score_frame(path=resolved.input_csv, task=settings.task, source=resolved.source)
+        report = build_score_report(
+            frame,
+            task=settings.task,
+            ci=settings.ci,
+            n_resamples=settings.n_resamples,
+            seed=settings.seed,
+            source=resolved.source,
+            created_at=datetime.now(UTC),
+        )
+        match settings.task:
+            case Task.RETRIEVAL:
+                output_json = score_paths.retrieval_scores_json
+            case Task.GROUNDING:
+                output_json = score_paths.grounding_scores_json
+            case Task.GENERATION:
+                output_json = score_paths.generation_scores_json
+        output_json.write_text(report.model_dump_json(indent=2), encoding="utf-8")
+
+    return report

--- a/src/pragmata/api/eval.py
+++ b/src/pragmata/api/eval.py
@@ -227,8 +227,8 @@ def score(
     Reads one labeled CSV, computes the task's taxonomy metrics as corpus point
     estimates with a confidence interval on each (Wilson for proportion metrics,
     percentile bootstrap for the continuous retrieval metrics), and writes the
-    task's ``*_scores.json`` report. The input is selected by precedence
-    ``path`` > ``export_id`` > ``prediction_id``; with no
+    task's ``*_scores.json`` report. The input is selected by a single mutually
+    exclusive selector (``path``, ``export_id``, or ``prediction_id``); with no
     selector the latest annotation export is used. The resolved input and how it
     was selected are recorded on the report's ``source``.
 

--- a/src/pragmata/api/eval.py
+++ b/src/pragmata/api/eval.py
@@ -252,6 +252,8 @@ def score(
         The task-specific score report, also written to ``*_scores.json``.
 
     Raises:
+        ValueError: If more than one input selector (``path`` / ``export_id`` /
+            ``prediction_id``) is given.
         EvalInputSchemaError: If the input violates the score contract.
         FileNotFoundError: If the selected input CSV or annotation export is missing.
         NotImplementedError: If ``prediction_id`` is used before predict lands.
@@ -274,7 +276,7 @@ def score(
     workspace = WorkspacePaths.from_base_dir(settings.base_dir)
     score_paths = resolve_eval_score_paths(workspace=workspace, score_id=settings.score_id).ensure_dirs()
 
-    with error_log(score_paths.tool_root):
+    with error_log(score_paths.score_dir):
         resolved = resolve_eval_score_input(
             workspace=workspace,
             task=settings.task,
@@ -299,6 +301,8 @@ def score(
                 output_json = score_paths.grounding_scores_json
             case Task.GENERATION:
                 output_json = score_paths.generation_scores_json
+            case _:
+                raise ValueError(f"Unsupported eval task: {settings.task!r}")
         output_json.write_text(report.model_dump_json(indent=2), encoding="utf-8")
 
     return report

--- a/src/pragmata/core/settings/eval_settings.py
+++ b/src/pragmata/core/settings/eval_settings.py
@@ -109,7 +109,7 @@ class EvalScoreSettings(ResolveSettings):
         base_dir: Workspace base directory. Pragmata resolves score artifacts under
             `<base_dir>/eval/scores/<score_id>/`.
         score_id: Unique identifier for the score run. Names the Pragmata-owned
-            score artifact directory. An output identifier, never an input selector.
+            score artifact directory.
         path: Optional direct path to labeled data to score. Use this
             for standalone scoring, including human-labeled datasets or externally
             prepared labeled records.

--- a/src/pragmata/core/settings/eval_settings.py
+++ b/src/pragmata/core/settings/eval_settings.py
@@ -99,25 +99,36 @@ class EvalPredictSettings(ResolveSettings):
 class EvalScoreSettings(ResolveSettings):
     """Evaluation scoring settings.
 
+    Input selection follows a fixed precedence applied by
+    ``resolve_eval_score_input``: ``path`` > ``export_id`` >
+    ``prediction_id``. With no selector, the latest annotation export for the
+    task is used (interim, until ``eval predict`` and its output layout land).
+
     Attributes:
         base_dir: Workspace base directory. Pragmata resolves score artifacts under
             `<base_dir>/eval/scores/<score_id>/`.
-        score_id: Unique identifier for the score run. Used to name the
-            Pragmata-owned score artifact directory.
-        labeled_input_path: Optional direct path to labeled data to score. Use this
+        score_id: Unique identifier for the score run. Names the Pragmata-owned
+            score artifact directory. An output identifier, never an input selector.
+        path: Optional direct path to labeled data to score. Use this
             for standalone scoring, including human-labeled datasets or externally
-            prepared labeled records. If provided, it takes precedence over
-            `prediction_run_id`.
-        prediction_run_id: Optional Pragmata prediction run identifier. Use this to
-            score labels produced by `pragmata eval predict`. If omitted together
-            with `labeled_input_path`, the scoring workflow selects the latest
-            available prediction run.
+            prepared labeled records.
+        export_id: Optional annotation export identifier; resolves to the
+            task-specific exported CSV.
+        prediction_id: Optional Pragmata prediction run identifier for labels
+            produced by `pragmata eval predict`. Not yet supported.
         task: Annotation task to score. The task determines which task-specific
             label contract and score metrics are applied.
+        n_resamples: Bootstrap iterations for the continuous metrics' CIs.
+        ci: Confidence level for every reported interval (e.g. 0.95 for 95%).
+        seed: Optional RNG seed for reproducible bootstrap intervals.
     """
 
     base_dir: Path = Field(default_factory=Path.cwd)
     score_id: str = Field(default_factory=lambda: uuid4().hex)
-    labeled_input_path: Path | None = None
-    prediction_run_id: str | None = None
+    path: Path | None = None
+    export_id: str | None = None
+    prediction_id: str | None = None
     task: Task
+    n_resamples: PositiveInt = 1000
+    ci: float = Field(default=0.95, gt=0.0, lt=1.0)
+    seed: int | None = None

--- a/src/pragmata/core/settings/eval_settings.py
+++ b/src/pragmata/core/settings/eval_settings.py
@@ -99,10 +99,11 @@ class EvalPredictSettings(ResolveSettings):
 class EvalScoreSettings(ResolveSettings):
     """Evaluation scoring settings.
 
-    Input selection follows a fixed precedence applied by
-    ``resolve_eval_score_input``: ``path`` > ``export_id`` >
-    ``prediction_id``. With no selector, the latest annotation export for the
-    task is used (interim, until ``eval predict`` and its output layout land).
+    Input selectors are mutually exclusive (enforced by
+    ``resolve_eval_score_input``): at most one of ``path`` / ``export_id`` /
+    ``prediction_id`` may be given, and more than one raises. With no selector,
+    the latest annotation export for the task is used (interim, until
+    ``eval predict`` and its output layout land).
 
     Attributes:
         base_dir: Workspace base directory. Pragmata resolves score artifacts under

--- a/src/pragmata/eval/__init__.py
+++ b/src/pragmata/eval/__init__.py
@@ -1,6 +1,7 @@
 """Public evaluation namespace."""
 
 from pragmata.api.eval import predict_labels as predict_labels
+from pragmata.api.eval import score as score
 from pragmata.api.eval import train_evaluator as train_evaluator
 
-__all__ = ["predict_labels", "train_evaluator"]
+__all__ = ["predict_labels", "score", "train_evaluator"]

--- a/tests/unit/api/test_eval_score.py
+++ b/tests/unit/api/test_eval_score.py
@@ -1,0 +1,314 @@
+"""End-to-end tests for the eval scoring API (``pragmata.eval.score``)."""
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from pragmata.api.eval import score
+from pragmata.core.schemas.annotation_export import AnnotationExportMeta
+from pragmata.core.schemas.annotation_task import Task
+from pragmata.core.schemas.eval_input import EvalInputSchemaError
+from pragmata.core.schemas.eval_output import (
+    GenerationScoreReport,
+    GroundingScoreReport,
+    MetricScore,
+    RetrievalScoreReport,
+)
+
+
+def _write(path: Path, rows: list[dict]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(rows).to_csv(path, index=False)
+    return path
+
+
+def _retrieval_rows() -> list[dict]:
+    # rec-1: two chunks (one relevant+sufficient, one relevant); rec-2: one irrelevant chunk.
+    return [
+        {
+            "record_uuid": "r1",
+            "chunk_id": "c1",
+            "chunk_rank": 1,
+            "query": "q1",
+            "chunk": "a",
+            "topically_relevant": 1,
+            "evidence_sufficient": 1,
+            "misleading": 0,
+        },
+        {
+            "record_uuid": "r1",
+            "chunk_id": "c2",
+            "chunk_rank": 2,
+            "query": "q1",
+            "chunk": "b",
+            "topically_relevant": 1,
+            "evidence_sufficient": 0,
+            "misleading": 0,
+        },
+        {
+            "record_uuid": "r2",
+            "chunk_id": "c3",
+            "chunk_rank": 1,
+            "query": "q2",
+            "chunk": "c",
+            "topically_relevant": 0,
+            "evidence_sufficient": 0,
+            "misleading": 1,
+        },
+    ]
+
+
+def _grounding_rows() -> list[dict]:
+    return [
+        {
+            "record_uuid": "r1",
+            "answer": "a",
+            "context_set": "c",
+            "support_present": 1,
+            "unsupported_claim_present": 0,
+            "contradicted_claim_present": 0,
+            "source_cited": 1,
+            "fabricated_source": 1,
+        },
+        {
+            "record_uuid": "r2",
+            "answer": "a",
+            "context_set": "c",
+            "support_present": 0,
+            "unsupported_claim_present": 1,
+            "contradicted_claim_present": 0,
+            "source_cited": 0,
+            "fabricated_source": 0,
+        },
+    ]
+
+
+def _generation_rows() -> list[dict]:
+    return [
+        {
+            "record_uuid": "r1",
+            "query": "q",
+            "answer": "a",
+            "proper_action": 1,
+            "response_on_topic": 1,
+            "helpful": 1,
+            "incomplete": 0,
+            "unsafe_content": 0,
+        },
+        {
+            "record_uuid": "r2",
+            "query": "q",
+            "answer": "a",
+            "proper_action": 0,
+            "response_on_topic": 1,
+            "helpful": 0,
+            "incomplete": 1,
+            "unsafe_content": 0,
+        },
+    ]
+
+
+def _write_retrieval_export(base_dir: Path, export_id: str) -> None:
+    """Write a retrieval annotation export under ``base_dir`` for fallback/export tests."""
+    export_dir = base_dir / "annotation" / "exports" / export_id
+    _write(export_dir / "retrieval.csv", _retrieval_rows())
+    meta = AnnotationExportMeta(
+        export_id=export_id,
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        dataset_id=None,
+        tasks=[Task.RETRIEVAL],
+        include_discarded=False,
+        row_counts={Task.RETRIEVAL: 3},
+        n_annotators={Task.RETRIEVAL: 1},
+        calibration_enabled={},
+        constraint_summary={},
+    )
+    (export_dir / "annotation_export.meta.json").write_text(meta.model_dump_json(), encoding="utf-8")
+
+
+class TestScoreRetrieval:
+    def test_returns_and_writes_report(self, tmp_path: Path):
+        csv = _write(tmp_path / "ret.csv", _retrieval_rows())
+
+        report = score(base_dir=tmp_path, path=csv, task="retrieval", seed=42, n_resamples=200)
+
+        assert isinstance(report, RetrievalScoreReport)
+        assert report.task == Task.RETRIEVAL
+        assert report.n_examples == 2  # two queries
+        assert report.top_k == 2  # inferred max chunk_rank
+        assert report.ci_level == 0.95
+        # topical precision: mean over queries of (per-query mean) = mean(1.0, 0.0) = 0.5
+        assert report.topical_precision_at_k.point == pytest.approx(0.5)
+
+        # the written JSON round-trips back to an equal report
+        out = next((tmp_path / "eval" / "scores").glob("*/retrieval_scores.json"))
+        assert RetrievalScoreReport.model_validate_json(out.read_text()) == report
+
+    def test_method_per_metric(self, tmp_path: Path):
+        csv = _write(tmp_path / "ret.csv", _retrieval_rows())
+        report = score(base_dir=tmp_path, path=csv, task="retrieval", seed=1)
+
+        assert report.sufficiency_hit_at_k.method == "wilson"
+        for field in (
+            report.topical_precision_at_k,
+            report.sufficiency_rate_at_k,
+            report.misleading_context_rate_at_k,
+            report.mean_reciprocal_rank_at_k,
+            report.ndcg_at_k,
+        ):
+            assert field.method == "bootstrap"
+
+    def test_wilson_point_within_interval_bootstrap_only_ordered(self, tmp_path: Path):
+        csv = _write(tmp_path / "ret.csv", _retrieval_rows())
+        report = score(base_dir=tmp_path, path=csv, task="retrieval", seed=7)
+
+        # Wilson: point lies within the interval by construction.
+        hit = report.sufficiency_hit_at_k
+        assert hit.ci_lower <= hit.point <= hit.ci_upper
+        # Bootstrap at tiny n: only require ordered, bounded CI (point may sit outside).
+        for m in (report.topical_precision_at_k, report.ndcg_at_k):
+            assert 0.0 <= m.ci_lower <= m.ci_upper <= 1.0
+
+    def test_seed_reproducible(self, tmp_path: Path):
+        csv = _write(tmp_path / "ret.csv", _retrieval_rows())
+        a = score(base_dir=tmp_path, path=csv, task="retrieval", seed=99, n_resamples=300)
+        b = score(base_dir=tmp_path, path=csv, task="retrieval", seed=99, n_resamples=300)
+        assert a.ndcg_at_k == b.ndcg_at_k
+        assert a.topical_precision_at_k == b.topical_precision_at_k
+
+
+class TestScoreGrounding:
+    def test_returns_report_with_conditional(self, tmp_path: Path):
+        csv = _write(tmp_path / "g.csv", _grounding_rows())
+        report = score(base_dir=tmp_path, path=csv, task="grounding", seed=1)
+
+        assert isinstance(report, GroundingScoreReport)
+        assert report.grounding_presence_rate.method == "wilson"
+        assert report.grounding_presence_rate.point == pytest.approx(0.5)
+        # one cited query (r1) whose source is fabricated -> rate 1.0 over n=1
+        assert report.conditional_fabrication_rate is not None
+        assert report.conditional_fabrication_rate.point == pytest.approx(1.0)
+        assert report.conditional_fabrication_rate.n == 1
+        assert report.conditional_fabrication_rate.method == "wilson"
+
+    def test_conditional_none_when_no_citations(self, tmp_path: Path):
+        rows = _grounding_rows()
+        for row in rows:
+            row["source_cited"] = 0
+        csv = _write(tmp_path / "g.csv", rows)
+
+        report = score(base_dir=tmp_path, path=csv, task="grounding")
+
+        assert report.conditional_fabrication_rate is None
+        # the Optional None field survives the JSON round-trip
+        out = next((tmp_path / "eval" / "scores").glob("*/grounding_scores.json"))
+        assert GroundingScoreReport.model_validate_json(out.read_text()) == report
+
+
+class TestScoreGeneration:
+    def test_returns_report_all_wilson(self, tmp_path: Path):
+        csv = _write(tmp_path / "gen.csv", _generation_rows())
+        report = score(base_dir=tmp_path, path=csv, task="generation", seed=1)
+
+        assert isinstance(report, GenerationScoreReport)
+        for m in (
+            report.proper_action_rate,
+            report.on_topic_rate,
+            report.helpfulness_rate,
+            report.incompleteness_rate,
+            report.unsafe_content_rate,
+        ):
+            assert isinstance(m, MetricScore)
+            assert m.method == "wilson"
+        assert report.on_topic_rate.point == pytest.approx(1.0)  # both on-topic
+
+
+class TestScoreInput:
+    def test_records_source_relative_to_workspace(self, tmp_path: Path):
+        csv = _write(tmp_path / "ret.csv", _retrieval_rows())
+
+        report = score(base_dir=tmp_path, path=csv, task="retrieval", seed=1)
+
+        # Inside the workspace -> recorded relative to base_dir.
+        assert report.source.kind == "direct_path"
+        assert report.source.ref == str(csv)
+        assert report.source.resolved_path == "ret.csv"
+
+    def test_records_absolute_path_when_outside_workspace(self, tmp_path: Path):
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        csv = _write(tmp_path / "external" / "ret.csv", _retrieval_rows())  # outside the workspace
+
+        report = score(base_dir=workspace, path=csv, task="retrieval", seed=1)
+
+        # Outside the workspace -> can't be made relative, so recorded absolute.
+        assert report.source.resolved_path == str(csv.resolve())
+
+    def test_missing_path_errors(self, tmp_path: Path):
+        with pytest.raises(FileNotFoundError, match="Scoring input CSV does not exist"):
+            score(base_dir=tmp_path, path=tmp_path / "nope.csv", task="retrieval")
+
+    def test_scores_via_export_id(self, tmp_path: Path):
+        _write_retrieval_export(tmp_path, "export-a")
+
+        report = score(base_dir=tmp_path, export_id="export-a", task="retrieval", seed=1)
+
+        assert isinstance(report, RetrievalScoreReport)
+        assert report.n_examples == 2
+        assert report.source.kind == "annotation_export"
+        assert report.source.ref == "export-a"
+        assert report.source.resolved_path == str(Path("annotation") / "exports" / "export-a" / "retrieval.csv")
+
+    def test_no_selector_falls_back_to_latest_export(self, tmp_path: Path):
+        _write_retrieval_export(tmp_path, "export-a")
+
+        report = score(base_dir=tmp_path, task="retrieval", seed=1)  # no selector
+
+        assert report.source.kind == "annotation_export"
+        assert report.source.ref == "export-a"
+
+    def test_no_selector_without_exports_errors(self, tmp_path: Path):
+        with pytest.raises(FileNotFoundError):
+            score(base_dir=tmp_path, task="retrieval")  # nothing to fall back to
+
+    def test_rejects_multiple_selectors(self, tmp_path: Path):
+        csv = _write(tmp_path / "ret.csv", _retrieval_rows())
+
+        # path and export_id together is ambiguous - selectors are mutually exclusive, no precedence.
+        with pytest.raises(ValueError, match="At most one input selector"):
+            score(base_dir=tmp_path, path=csv, export_id="ignored", task="retrieval", seed=1)
+
+    def test_prediction_id_not_supported(self, tmp_path: Path):
+        with pytest.raises(NotImplementedError, match="not yet supported"):
+            score(base_dir=tmp_path, prediction_id="predict-001", task="retrieval")
+
+
+class TestScoreConsolidationAndGuard:
+    def test_consolidates_duplicate_chunk(self, tmp_path: Path):
+        rows = _retrieval_rows()
+        rows.append({**rows[0]})  # a second annotator row for (r1, c1) - collapsed by majority
+        csv = _write(tmp_path / "ret.csv", rows)
+
+        report = score(base_dir=tmp_path, path=csv, task="retrieval", seed=1)
+
+        assert report.n_examples == 2  # two queries; the duplicate chunk was consolidated
+
+    def test_rejects_non_collapsible_duplicate_chunk_rank(self, tmp_path: Path):
+        rows = _retrieval_rows()
+        # distinct chunk_id sharing (record_uuid, chunk_rank) -> not collapsible, guard still errors
+        rows.append({**rows[0], "chunk_id": "c1b"})
+        csv = _write(tmp_path / "ret.csv", rows)
+
+        with pytest.raises(EvalInputSchemaError, match="chunk rank"):
+            score(base_dir=tmp_path, path=csv, task="retrieval")
+
+    def test_consolidates_duplicate_record_uuid_grounding(self, tmp_path: Path):
+        rows = _grounding_rows()
+        rows.append({**rows[0]})  # a second annotator row for r1 - collapsed by majority
+        csv = _write(tmp_path / "g.csv", rows)
+
+        report = score(base_dir=tmp_path, path=csv, task="grounding")
+
+        assert report.n_examples == 2  # two records; the duplicate was consolidated

--- a/tests/unit/core/settings/test_eval_settings.py
+++ b/tests/unit/core/settings/test_eval_settings.py
@@ -179,35 +179,35 @@ def test_eval_predict_settings_accepts_evaluator_run_id_and_predict_kwargs() -> 
     }
 
 
-def test_eval_score_settings_construction_with_labeled_input_path() -> None:
+def test_eval_score_settings_construction_with_path() -> None:
     """EvalScoreSettings accepts a direct labeled input path."""
     settings = EvalScoreSettings.model_validate(
         {
-            "labeled_input_path": "data/labeled.csv",
+            "path": "data/labeled.csv",
             "task": "retrieval",
         }
     )
 
     assert settings.base_dir == Path.cwd()
     assert settings.score_id
-    assert settings.labeled_input_path == Path("data/labeled.csv")
-    assert settings.prediction_run_id is None
+    assert settings.path == Path("data/labeled.csv")
+    assert settings.prediction_id is None
     assert settings.task == Task.RETRIEVAL
 
 
-def test_eval_score_settings_construction_with_prediction_run_id() -> None:
+def test_eval_score_settings_construction_with_prediction_id() -> None:
     """EvalScoreSettings accepts a prediction run selector."""
     settings = EvalScoreSettings.model_validate(
         {
-            "prediction_run_id": "prediction-run-001",
+            "prediction_id": "prediction-run-001",
             "task": "grounding",
         }
     )
 
     assert settings.base_dir == Path.cwd()
     assert settings.score_id
-    assert settings.labeled_input_path is None
-    assert settings.prediction_run_id == "prediction-run-001"
+    assert settings.path is None
+    assert settings.prediction_id == "prediction-run-001"
     assert settings.task == Task.GROUNDING
 
 


### PR DESCRIPTION
#278 > #282 > #283 > #284 > #279 > #280

---

## Summary

thin `pragmata.eval.score` API orchestration:

- **`api/eval.py: score(...)`** - pure orchestration, no implementation logic: resolve settings → resolve input (`resolve_eval_score_input`) → ingest (`import_eval_score_frame`) → assemble (`build_score_report`) → write `*_scores.json`, wrapped in `error_log`. All maths lives in `core/`.
- **`EvalScoreSettings`** - extends main's stub: renames `labeled_input_path`→`path`, adds `export_id`, `prediction_id`, and the uncertainty params (`n_resamples`, `ci`, `seed`). Selectors are mutually exclusive (enforced in `resolve_eval_score_input`), with a latest-export fallback when none is given.
- All optional API params use the `UNSET` sentinel (matching `train_evaluator`) so config/env/default resolution works.
- **`pragmata.eval.score`** exported alongside `train_evaluator`.

## NB
- `prediction_id` raises `NotImplementedError` (lands with `eval predict`); interim no-selector fallback is the latest annotation export.
