### PR TITLE
feat(eval): add pragmata eval score CLI subcommand

### DIFF
--- a/src/pragmata/cli/commands/annotation.py
+++ b/src/pragmata/cli/commands/annotation.py
@@ -13,7 +13,7 @@ from pragmata.cli.parsing import (
     parse_user_specs,
 )
 
-annotation_app = typer.Typer(help="Annotation pipeline commands.")
+annotation_app = typer.Typer(help="Annotation pipeline commands.", no_args_is_help=True)
 
 _api_url_opt = typer.Option(None, "--api-url", help="Argilla server URL. Falls back to ARGILLA_API_URL env var.")
 _api_key_opt = typer.Option(None, "--api-key", help="Argilla API key. Falls back to ARGILLA_API_KEY env var.")

--- a/src/pragmata/cli/commands/eval.py
+++ b/src/pragmata/cli/commands/eval.py
@@ -163,7 +163,7 @@ def score_command(
     typer.echo(f"\n{report.task.value} scores (n={report.n_examples}, {report.ci_level:.0%} CI):")
     for name, metric in report.metric_scores():
         if metric is None:
-            typer.echo(f"  {name}: n/a (no cited examples)")
+            typer.echo(f"  {name}: n/a (not computed)")
         else:
             typer.echo(
                 f"  {name}: {metric.point:.3f} "

--- a/src/pragmata/cli/commands/eval.py
+++ b/src/pragmata/cli/commands/eval.py
@@ -6,7 +6,7 @@ from pragmata import eval
 from pragmata.api import UNSET
 from pragmata.cli.parsing import parse_cli_value
 
-eval_app = typer.Typer(help="Evaluation commands.")
+eval_app = typer.Typer(help="Evaluation commands.", no_args_is_help=True)
 
 
 @eval_app.command("train-evaluator")

--- a/src/pragmata/cli/commands/eval.py
+++ b/src/pragmata/cli/commands/eval.py
@@ -86,3 +86,86 @@ def train_evaluator_command(
     typer.echo(f"run_id: {result.paths.run_id}")
     typer.echo(f"run_directory: {result.paths.run_dir}")
     typer.echo(f"model_directory: {result.paths.model_dir}")
+
+
+@eval_app.command("score")
+def score_command(
+    task: str | None = typer.Option(
+        None,
+        "--task",
+        help="Eval task to score: retrieval, grounding, or generation.",
+    ),
+    path: str | None = typer.Option(
+        None,
+        "--path",
+        help="Direct path to the labeled CSV to score.",
+    ),
+    export_id: str | None = typer.Option(
+        None,
+        "--export-id",
+        help="Annotation export identifier; resolves to the task-specific exported CSV.",
+    ),
+    prediction_id: str | None = typer.Option(
+        None,
+        "--prediction-id",
+        help="Prediction run identifier. Not yet supported (lands with eval predict).",
+    ),
+    score_id: str | None = typer.Option(
+        None,
+        "--score-id",
+        help="Output identifier naming eval/scores/<score-id>/. Defaults to a generated value.",
+    ),
+    base_dir: str | None = typer.Option(
+        None,
+        "--base-dir",
+        help="Workspace base directory. Defaults to current working directory.",
+    ),
+    n_resamples: int | None = typer.Option(
+        None,
+        "--n-resamples",
+        help="Bootstrap iterations for the continuous metrics' confidence intervals.",
+    ),
+    ci: float | None = typer.Option(
+        None,
+        "--ci",
+        help="Confidence level for every reported interval (e.g. 0.95).",
+    ),
+    seed: int | None = typer.Option(
+        None,
+        "--seed",
+        help="RNG seed for reproducible bootstrap intervals.",
+    ),
+    config_path: str | None = typer.Option(
+        None,
+        "--config",
+        help="Path to the config file.",
+    ),
+) -> None:
+    """Score labeled eval data into corpus metrics with confidence intervals.
+
+    The input is selected by one of ``--path`` / ``--export-id`` /
+    ``--prediction-id`` (precedence in that order); with none, the latest
+    annotation export is used.
+    """
+    report = eval.score(
+        task=UNSET if task is None else task,
+        path=UNSET if path is None else path,
+        export_id=UNSET if export_id is None else export_id,
+        prediction_id=UNSET if prediction_id is None else prediction_id,
+        score_id=UNSET if score_id is None else score_id,
+        base_dir=UNSET if base_dir is None else base_dir,
+        n_resamples=UNSET if n_resamples is None else n_resamples,
+        ci=UNSET if ci is None else ci,
+        seed=UNSET if seed is None else seed,
+        config_path=UNSET if config_path is None else config_path,
+    )
+
+    typer.echo(f"\n{report.task.value} scores (n={report.n_examples}, {report.ci_level:.0%} CI):")
+    for name, metric in report.metric_scores():
+        if metric is None:
+            typer.echo(f"  {name}: n/a (no cited examples)")
+        else:
+            typer.echo(
+                f"  {name}: {metric.point:.3f} "
+                f"[{metric.ci_lower:.3f}, {metric.ci_upper:.3f}] ({metric.method}, n={metric.n})"
+            )

--- a/src/pragmata/cli/commands/querygen.py
+++ b/src/pragmata/cli/commands/querygen.py
@@ -6,7 +6,7 @@ from pragmata import querygen
 from pragmata.api import UNSET
 from pragmata.cli.parsing import parse_cli_value
 
-querygen_app = typer.Typer(help="Synthetic query generation commands.")
+querygen_app = typer.Typer(help="Synthetic query generation commands.", no_args_is_help=True)
 
 
 @querygen_app.command("gen-queries")

--- a/src/pragmata/core/schemas/eval_output.py
+++ b/src/pragmata/core/schemas/eval_output.py
@@ -89,6 +89,17 @@ class RetrievalScoreReport(BaseModel):
     mean_reciprocal_rank_at_k: MetricScore
     ndcg_at_k: MetricScore
 
+    def metric_scores(self) -> list[tuple[str, MetricScore | None]]:
+        """The report's metrics in display order, each paired with its field name."""
+        return [
+            ("topical_precision_at_k", self.topical_precision_at_k),
+            ("sufficiency_hit_at_k", self.sufficiency_hit_at_k),
+            ("sufficiency_rate_at_k", self.sufficiency_rate_at_k),
+            ("misleading_context_rate_at_k", self.misleading_context_rate_at_k),
+            ("mean_reciprocal_rank_at_k", self.mean_reciprocal_rank_at_k),
+            ("ndcg_at_k", self.ndcg_at_k),
+        ]
+
 
 class GroundingScoreReport(BaseModel):
     """Schema for grounding_scores.json."""
@@ -107,6 +118,16 @@ class GroundingScoreReport(BaseModel):
     citation_presence_rate: MetricScore
     conditional_fabrication_rate: MetricScore | None = None
 
+    def metric_scores(self) -> list[tuple[str, MetricScore | None]]:
+        """The report's metrics in display order, each paired with its field name."""
+        return [
+            ("grounding_presence_rate", self.grounding_presence_rate),
+            ("unsupported_claim_rate", self.unsupported_claim_rate),
+            ("contradiction_rate", self.contradiction_rate),
+            ("citation_presence_rate", self.citation_presence_rate),
+            ("conditional_fabrication_rate", self.conditional_fabrication_rate),
+        ]
+
 
 class GenerationScoreReport(BaseModel):
     """Schema for generation_scores.json."""
@@ -124,3 +145,13 @@ class GenerationScoreReport(BaseModel):
     helpfulness_rate: MetricScore
     incompleteness_rate: MetricScore
     unsafe_content_rate: MetricScore
+
+    def metric_scores(self) -> list[tuple[str, MetricScore | None]]:
+        """The report's metrics in display order, each paired with its field name."""
+        return [
+            ("proper_action_rate", self.proper_action_rate),
+            ("on_topic_rate", self.on_topic_rate),
+            ("helpfulness_rate", self.helpfulness_rate),
+            ("incompleteness_rate", self.incompleteness_rate),
+            ("unsafe_content_rate", self.unsafe_content_rate),
+        ]

--- a/tests/unit/cli/test_cli_eval.py
+++ b/tests/unit/cli/test_cli_eval.py
@@ -48,6 +48,19 @@ class TestTrainEvaluatorCommand:
         assert "Train a supervised evaluator model." in output
         assert "--train-kwargs" in output
 
+    def test_bare_invocation_shows_help(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("COLUMNS", "200")
+        result = runner.invoke(eval_app, [], color=False)
+        output = strip_ansi(result.output)
+
+        assert result.exit_code != 0
+        assert "Usage" in output
+        assert "train-evaluator" in output
+        assert "score" in output
+
     def test_help_available(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/cli/test_cli_eval.py
+++ b/tests/unit/cli/test_cli_eval.py
@@ -1,14 +1,17 @@
 """Tests CLI commands for evaluation workflows."""
 
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+import pandas as pd
 import pytest
 from typer.testing import CliRunner
 
 from pragmata.api import UNSET
 from pragmata.cli.app import app
 from pragmata.cli.commands.eval import eval_app
+from pragmata.core.schemas.eval_output import MetricScore, RetrievalScoreReport, ScoreInputSource
 from tests.unit.cli.conftest import strip_ansi
 
 runner = CliRunner()
@@ -50,7 +53,7 @@ class TestTrainEvaluatorCommand:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.setenv("COLUMNS", "200")
-        result = runner.invoke(eval_app, ["--help"], color=False)
+        result = runner.invoke(eval_app, ["train-evaluator", "--help"], color=False)
         output = strip_ansi(result.output)
 
         assert result.exit_code == 0
@@ -79,7 +82,7 @@ class TestTrainEvaluatorCommand:
 
         monkeypatch.setattr("pragmata.eval.train_evaluator", fake_train_evaluator)
 
-        result = runner.invoke(eval_app, [])
+        result = runner.invoke(eval_app, ["train-evaluator"])
 
         expected_keys = {
             "labeled_data_path",
@@ -116,6 +119,7 @@ class TestTrainEvaluatorCommand:
         result = runner.invoke(
             eval_app,
             [
+                "train-evaluator",
                 "--labeled-data-path",
                 "exports/retrieval.csv",
                 "--export-id",
@@ -169,6 +173,7 @@ class TestTrainEvaluatorCommand:
         result = runner.invoke(
             eval_app,
             [
+                "train-evaluator",
                 "--no-scale-learning-rate",
             ],
         )
@@ -188,7 +193,7 @@ class TestTrainEvaluatorCommand:
 
         monkeypatch.setattr("pragmata.eval.train_evaluator", fake_train_evaluator)
 
-        result = runner.invoke(eval_app, ["--scale-learning-rate"])
+        result = runner.invoke(eval_app, ["train-evaluator", "--scale-learning-rate"])
 
         assert result.exit_code == 0
         assert captured["scale_learning_rate"] is True
@@ -202,7 +207,7 @@ class TestTrainEvaluatorCommand:
 
         monkeypatch.setattr("pragmata.eval.train_evaluator", fake_train_evaluator)
 
-        result = runner.invoke(eval_app, [])
+        result = runner.invoke(eval_app, ["train-evaluator"])
 
         assert result.exit_code == 0
         assert "Evaluator training run complete." in result.output
@@ -211,3 +216,191 @@ class TestTrainEvaluatorCommand:
         assert "workspace/eval/train_outputs/train-run-123" in result.output
         assert "model_directory:" in result.output
         assert "workspace/eval/train_outputs/train-run-123/model" in result.output
+
+
+def _fake_retrieval_report() -> RetrievalScoreReport:
+    def metric(method: str) -> MetricScore:
+        return MetricScore(point=0.5, ci_lower=0.4, ci_upper=0.6, method=method, n=2)
+
+    return RetrievalScoreReport(
+        source=ScoreInputSource(kind="direct_path", ref="d.csv", resolved_path="d.csv"),
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        n_examples=2,
+        top_k=3,
+        ci_level=0.95,
+        topical_precision_at_k=metric("bootstrap"),
+        sufficiency_hit_at_k=metric("wilson"),
+        sufficiency_rate_at_k=metric("bootstrap"),
+        misleading_context_rate_at_k=metric("bootstrap"),
+        mean_reciprocal_rank_at_k=metric("bootstrap"),
+        ndcg_at_k=metric("bootstrap"),
+    )
+
+
+def _retrieval_rows() -> list[dict]:
+    return [
+        {
+            "record_uuid": "r1",
+            "chunk_id": "c1",
+            "chunk_rank": 1,
+            "query": "q1",
+            "chunk": "a",
+            "topically_relevant": 1,
+            "evidence_sufficient": 1,
+            "misleading": 0,
+        },
+        {
+            "record_uuid": "r1",
+            "chunk_id": "c2",
+            "chunk_rank": 2,
+            "query": "q1",
+            "chunk": "b",
+            "topically_relevant": 1,
+            "evidence_sufficient": 0,
+            "misleading": 0,
+        },
+        {
+            "record_uuid": "r2",
+            "chunk_id": "c3",
+            "chunk_rank": 1,
+            "query": "q2",
+            "chunk": "c",
+            "topically_relevant": 0,
+            "evidence_sufficient": 0,
+            "misleading": 1,
+        },
+    ]
+
+
+class TestScoreCommand:
+    """Tests for the eval score CLI command."""
+
+    def test_help_lists_score_options(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("COLUMNS", "200")
+        result = runner.invoke(eval_app, ["score", "--help"], color=False)
+        output = strip_ansi(result.output)
+
+        assert result.exit_code == 0
+        assert "Score labeled eval data" in output
+        for option in (
+            "--task",
+            "--path",
+            "--export-id",
+            "--prediction-id",
+            "--score-id",
+            "--base-dir",
+            "--n-resamples",
+            "--ci",
+            "--seed",
+            "--config",
+        ):
+            assert option in output
+        assert "--top-k" not in output  # K is inferred, never a parameter
+
+    def test_maps_omitted_options_to_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_score(**kwargs: Any) -> RetrievalScoreReport:
+            captured.update(kwargs)
+            return _fake_retrieval_report()
+
+        monkeypatch.setattr("pragmata.eval.score", fake_score)
+
+        result = runner.invoke(eval_app, ["score"])
+
+        assert result.exit_code == 0
+        assert set(captured) == {
+            "task",
+            "path",
+            "export_id",
+            "prediction_id",
+            "score_id",
+            "base_dir",
+            "n_resamples",
+            "ci",
+            "seed",
+            "config_path",
+        }
+        assert all(value is UNSET for value in captured.values())
+
+    def test_delegates_to_public_api(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_score(**kwargs: Any) -> RetrievalScoreReport:
+            captured.update(kwargs)
+            return _fake_retrieval_report()
+
+        monkeypatch.setattr("pragmata.eval.score", fake_score)
+
+        result = runner.invoke(
+            eval_app,
+            [
+                "score",
+                "--task",
+                "retrieval",
+                "--path",
+                "data/labeled.csv",
+                "--export-id",
+                "e1",
+                "--prediction-id",
+                "p1",
+                "--score-id",
+                "score-1",
+                "--base-dir",
+                "workspace",
+                "--n-resamples",
+                "500",
+                "--ci",
+                "0.9",
+                "--seed",
+                "7",
+                "--config",
+                "eval.yml",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert captured == {
+            "task": "retrieval",
+            "path": "data/labeled.csv",
+            "export_id": "e1",
+            "prediction_id": "p1",
+            "score_id": "score-1",
+            "base_dir": "workspace",
+            "n_resamples": 500,
+            "ci": 0.9,
+            "seed": 7,
+            "config_path": "eval.yml",
+        }
+
+    def test_prints_score_summary(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("pragmata.eval.score", lambda **_: _fake_retrieval_report())
+
+        result = runner.invoke(eval_app, ["score", "--task", "retrieval", "--path", "d.csv"])
+        output = strip_ansi(result.output)
+
+        assert result.exit_code == 0
+        assert "retrieval scores (n=2, 95% CI)" in output
+        assert "ndcg_at_k: 0.500 [0.400, 0.600] (bootstrap, n=2)" in output
+        assert "sufficiency_hit_at_k: 0.500 [0.400, 0.600] (wilson, n=2)" in output
+
+    def test_end_to_end_writes_report(self, tmp_path: Path) -> None:
+        csv = tmp_path / "ret.csv"
+        pd.DataFrame(_retrieval_rows()).to_csv(csv, index=False)
+
+        result = runner.invoke(
+            eval_app,
+            ["score", "--task", "retrieval", "--path", str(csv), "--base-dir", str(tmp_path), "--seed", "1"],
+        )
+
+        assert result.exit_code == 0
+        assert "retrieval scores" in strip_ansi(result.output)
+        assert next((tmp_path / "eval" / "scores").glob("*/retrieval_scores.json")).is_file()
+
+    def test_prediction_id_exits_nonzero(self, tmp_path: Path) -> None:
+        # Prediction-run scoring is not yet supported; it must fail rather than silently no-op.
+        result = runner.invoke(
+            eval_app, ["score", "--task", "retrieval", "--prediction-id", "p1", "--base-dir", str(tmp_path)]
+        )
+
+        assert result.exit_code != 0


### PR DESCRIPTION
#278 > #282 > #283 > #284 > #279 > #280

---

## Summary

`pragmata eval score` CLI subcommand - the top of the eval-score stack, a thin Typer wrapper 1:1 over `pragmata.eval.score`.

- `eval score --task ... [--path P | --export-id ID | --prediction-id ID] [--score-id] [--base-dir] [--n-resamples] [--ci] [--seed] [--config]` maps each flag to the API (UNSET when omitted), then renders each metric as `point [lo, hi] (method, n)` (`n/a` for an absent conditional metric).
- Adds `ScoreReport.metric_scores()` on the three report schemas (display-ordered `(name, metric)` pairs) - the CLI's render helper, folded here (its only consumer) rather than restacking the schema slice.

## Finalised naming (this stack)

Selector and provenance-kind are consistent per concept:

| selector / CLI flag | provenance `kind` |
|---|---|
| `--path` | `direct_path` |
| `--export-id` | `annotation_export` |
| `--prediction-id` | `model_prediction` |
