### PR TITLE
feat: add tlmtc prediction adapter

### DIFF
--- a/src/pragmata/core/eval/tlmtc_adapters.py
+++ b/src/pragmata/core/eval/tlmtc_adapters.py
@@ -5,8 +5,8 @@ from typing import Any
 
 import pandas as pd
 
-# Keep this in sync with run_tlmtc_train's dedicated arguments.
-_RESERVED_TRAIN_KWARGS = frozenset(
+# Keep this in sync with the TLMTC arguments managed by run_tlmtc_train.
+_PRAGMATA_MANAGED_TLMTC_TRAIN_ARGS = frozenset(
     {
         "labeled_data",
         "work_dir",
@@ -15,6 +15,15 @@ _RESERVED_TRAIN_KWARGS = frozenset(
         "proxy_checkpoint",
         "scale_learning_rate",
         "sequence_length",
+    }
+)
+
+# Keep this in sync with the TLMTC arguments managed by run_tlmtc_predict.
+_PRAGMATA_MANAGED_TLMTC_PREDICT_ARGS = frozenset(
+    {
+        "unlabeled_data",
+        "work_dir",
+        "run_id",
     }
 )
 
@@ -54,7 +63,7 @@ def run_tlmtc_train(
         ValueError: If ``train_kwargs`` attempts to override a dedicated
             Pragmata-owned train argument.
     """
-    overlapping_keys = _RESERVED_TRAIN_KWARGS.intersection(train_kwargs)
+    overlapping_keys = _PRAGMATA_MANAGED_TLMTC_TRAIN_ARGS.intersection(train_kwargs)
     if overlapping_keys:
         overlapping = ", ".join(sorted(overlapping_keys))
         raise ValueError(
@@ -79,3 +88,55 @@ def run_tlmtc_train(
     train_args.update(train_kwargs)
 
     return train_tlmtc(**train_args)
+
+
+def run_tlmtc_predict(
+    *,
+    unlabeled_data: str | Path | pd.DataFrame,
+    work_dir: Path,
+    evaluator_run_id: str,
+    predict_kwargs: dict[str, Any],
+) -> Any:
+    """Predict evaluation labels through tlmtc.
+
+    Args:
+        unlabeled_data: Path to unlabeled prediction data, or an in-memory
+            DataFrame containing tlmtc's text input columns.
+        work_dir: Base eval work directory passed through to tlmtc.
+        evaluator_run_id: Concrete, task-compatible evaluator training run selected by pragmata.
+            This is forwarded to tlmtc as ``run_id``.
+        predict_kwargs: Additional tlmtc-owned prediction arguments, such as batch
+            size, device selection, verbosity, and inference backend. Arguments
+            managed by Pragmata are rejected.
+
+    Returns:
+        The result returned by ``tlmtc.predict_tlmtc``.
+
+    Raises:
+        ImportError: If tlmtc is not installed.
+        ValueError: If ``predict_kwargs`` attempts to override a dedicated
+            Pragmata-owned prediction argument.
+    """
+    overlapping_keys = _PRAGMATA_MANAGED_TLMTC_PREDICT_ARGS.intersection(predict_kwargs)
+    if overlapping_keys:
+        overlapping = ", ".join(sorted(overlapping_keys))
+        raise ValueError(
+            f"predict_kwargs must not override pragmata-managed predict settings: {overlapping}. "
+            "Pass these via dedicated arguments instead."
+        )
+
+    try:
+        from tlmtc import predict_tlmtc
+    except ImportError as exc:
+        raise ImportError(
+            "tlmtc is required for evaluator prediction. Install pragmata with the 'eval' extra."
+        ) from exc
+
+    predict_args: dict[str, Any] = {
+        "unlabeled_data": unlabeled_data,
+        "work_dir": work_dir,
+        "run_id": evaluator_run_id,
+    }
+    predict_args.update(predict_kwargs)
+
+    return predict_tlmtc(**predict_args)

--- a/src/pragmata/core/settings/eval_settings.py
+++ b/src/pragmata/core/settings/eval_settings.py
@@ -80,12 +80,13 @@ class EvalPredictSettings(ResolveSettings):
             predicted evaluation labels. Prediction input is intentionally explicit;
             it is not inferred from prior tool outputs.
         evaluator_run_id: Optional trained evaluator run identifier. This selects
-            the tlmtc training run to load. If omitted, tlmtc's default latest-run
-            lookup is used.
+            the tlmtc training run to load. If omitted, Pragmata selects the latest
+            evaluator compatible with the requested task.
         task: Annotation task to predict labels for. The task determines the
             Pragmata-owned task mapping, serialization, labels, and output contract.
         predict_kwargs: Additional `predict_tlmtc`-specific keyword arguments passed
-            through to the tlmtc API. Use this for tlmtc-owned options.
+            through to the tlmtc API. Use this for tlmtc-owned options such as batch
+            size, device selection, verbosity, and inference backend.
     """
 
     base_dir: Path = Field(default_factory=Path.cwd)

--- a/tests/unit/core/eval/test_tlmtc_adapters.py
+++ b/tests/unit/core/eval/test_tlmtc_adapters.py
@@ -13,7 +13,11 @@ import pytest
 from pragmata.core.eval.tlmtc_adapters import run_tlmtc_predict, run_tlmtc_train
 
 _DEDICATED_RUN_TLMTC_TRAIN_ARGS = [name for name in signature(run_tlmtc_train).parameters if name != "train_kwargs"]
-_RESERVED_RUN_TLMTC_PREDICT_KWARGS = ["unlabeled_data", "work_dir", "run_id"]
+_RESERVED_RUN_TLMTC_PREDICT_KWARGS = [
+    "run_id" if name == "evaluator_run_id" else name
+    for name in signature(run_tlmtc_predict).parameters
+    if name != "predict_kwargs"
+]
 
 
 def _run_tlmtc_train_kwargs(

--- a/tests/unit/core/eval/test_tlmtc_adapters.py
+++ b/tests/unit/core/eval/test_tlmtc_adapters.py
@@ -7,11 +7,13 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any, cast
 
+import pandas as pd
 import pytest
 
-from pragmata.core.eval.tlmtc_adapters import run_tlmtc_train
+from pragmata.core.eval.tlmtc_adapters import run_tlmtc_predict, run_tlmtc_train
 
 _DEDICATED_RUN_TLMTC_TRAIN_ARGS = [name for name in signature(run_tlmtc_train).parameters if name != "train_kwargs"]
+_RESERVED_RUN_TLMTC_PREDICT_KWARGS = ["unlabeled_data", "work_dir", "run_id"]
 
 
 def _run_tlmtc_train_kwargs(
@@ -119,3 +121,115 @@ def test_run_tlmtc_train_imports_tlmtc_lazily_and_reports_missing_extra(
 
     with pytest.raises(ImportError, match="Install pragmata with the 'eval' extra"):
         run_tlmtc_train(**_run_tlmtc_train_kwargs())
+
+
+def test_run_tlmtc_predict_forwards_path_and_predict_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """run_tlmtc_predict maps the evaluator ID and forwards tlmtc-owned options."""
+    captured_kwargs: dict[str, Any] = {}
+    fake_tlmtc = ModuleType("tlmtc")
+    expected_result = object()
+
+    def predict_tlmtc(**kwargs: Any) -> object:
+        captured_kwargs.update(kwargs)
+        return expected_result
+
+    setattr(fake_tlmtc, "predict_tlmtc", predict_tlmtc)
+    monkeypatch.setitem(sys.modules, "tlmtc", fake_tlmtc)
+
+    result = run_tlmtc_predict(
+        unlabeled_data=Path("predict.csv"),
+        work_dir=Path("eval"),
+        evaluator_run_id="evaluator-001",
+        predict_kwargs={
+            "batch_size": 8,
+            "use_cpu": True,
+            "verbosity": "quiet",
+            "inference_backend": "torch",
+        },
+    )
+
+    assert result is expected_result
+    assert captured_kwargs == {
+        "unlabeled_data": Path("predict.csv"),
+        "work_dir": Path("eval"),
+        "run_id": "evaluator-001",
+        "batch_size": 8,
+        "use_cpu": True,
+        "verbosity": "quiet",
+        "inference_backend": "torch",
+    }
+
+
+def test_run_tlmtc_predict_forwards_dataframe_with_empty_predict_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """run_tlmtc_predict accepts in-memory data without passthrough options."""
+    captured_kwargs: dict[str, Any] = {}
+    fake_tlmtc = ModuleType("tlmtc")
+    unlabeled_data = pd.DataFrame({"text": ["example"]})
+
+    def predict_tlmtc(**kwargs: Any) -> object:
+        captured_kwargs.update(kwargs)
+        return object()
+
+    setattr(fake_tlmtc, "predict_tlmtc", predict_tlmtc)
+    monkeypatch.setitem(sys.modules, "tlmtc", fake_tlmtc)
+
+    run_tlmtc_predict(
+        unlabeled_data=unlabeled_data,
+        work_dir=Path("eval"),
+        evaluator_run_id="evaluator-001",
+        predict_kwargs={},
+    )
+
+    assert captured_kwargs["unlabeled_data"] is unlabeled_data
+    assert captured_kwargs["work_dir"] == Path("eval")
+    assert captured_kwargs["run_id"] == "evaluator-001"
+    assert set(captured_kwargs) == {"unlabeled_data", "work_dir", "run_id"}
+
+
+@pytest.mark.parametrize("reserved_key", _RESERVED_RUN_TLMTC_PREDICT_KWARGS)
+def test_run_tlmtc_predict_rejects_reserved_predict_kwargs(
+    reserved_key: str,
+) -> None:
+    """predict_kwargs must not override arguments managed by Pragmata."""
+    with pytest.raises(ValueError, match=reserved_key):
+        run_tlmtc_predict(
+            unlabeled_data=Path("predict.csv"),
+            work_dir=Path("eval"),
+            evaluator_run_id="evaluator-001",
+            predict_kwargs={reserved_key: "override"},
+        )
+
+
+def test_run_tlmtc_predict_reports_all_reserved_collisions() -> None:
+    """Reserved predict collisions are reported together in deterministic order."""
+    with pytest.raises(ValueError, match="run_id, unlabeled_data, work_dir"):
+        run_tlmtc_predict(
+            unlabeled_data=Path("predict.csv"),
+            work_dir=Path("eval"),
+            evaluator_run_id="evaluator-001",
+            predict_kwargs={
+                "work_dir": "override",
+                "unlabeled_data": "override",
+                "run_id": "override",
+            },
+        )
+
+
+def test_run_tlmtc_predict_imports_tlmtc_lazily_and_reports_missing_extra(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing tlmtc raises an install hint only when prediction is invoked."""
+    modules = cast(MutableMapping[str, Any], sys.modules)
+    monkeypatch.setitem(modules, "tlmtc", None)
+
+    with pytest.raises(ImportError, match="Install pragmata with the 'eval' extra"):
+        run_tlmtc_predict(
+            unlabeled_data=Path("predict.csv"),
+            work_dir=Path("eval"),
+            evaluator_run_id="evaluator-001",
+            predict_kwargs={},
+        )


### PR DESCRIPTION
### Summary

Adds a narrow adapter around `tlmtc.predict_tlmtc()` for applying a concrete, task-compatible evaluator to prediction data supplied as either a filesystem path or an in-memory pandas `DataFrame`.

`pragmata` manages the prediction input, eval work directory, and evaluator selection. The adapter maps `evaluator_run_id` to `tlmtc`'s `run_id`, forwards remaining inference options through `predict_kwargs`, and returns `tlmtc`'s prediction result unchanged.

### Changes

- Add `run_tlmtc_predict()` as the lazy `tlmtc` prediction boundary.
- Accept prediction data as `str | Path | pd.DataFrame`.
- Require a concrete Pragmata-selected `evaluator_run_id`.
- Map `evaluator_run_id` to TLMTC's `run_id`.
- Forward `tlmtc`-owned inference options through `predict_kwargs`.
- Reject attempts to override `pragmata`-managed `tlmtc` arguments.
- Report all conflicting passthrough arguments in deterministic order.
- Raise installation guidance when the eval dependency is unavailable.
- Rename managed-argument constants to clarify their purpose.
- Clarify that omitted evaluator selection is task-aware and owned by `pragmata`.

### Testing

- Covered filesystem-path prediction input.
- Covered in-memory DataFrame prediction input.
- Covered evaluator ID mapping to `tlmtc`'s `run_id`.
- Covered forwarding batch size, CPU selection, verbosity, and inference backend.
- Covered empty `predict_kwargs`.
- Covered rejection of each `pragmata`-managed argument collision.
- Covered deterministic reporting of multiple argument collisions.
- Covered lazy `tlmtc` import and missing-extra guidance.
- Covered returning `tlmtc`'s result unchanged.