### PR TITLE
feat(eval): add score-input resolution to eval_paths

### DIFF
--- a/src/pragmata/core/paths/eval_paths.py
+++ b/src/pragmata/core/paths/eval_paths.py
@@ -109,6 +109,21 @@ def find_latest_annotation_export_id(
     return latest_export_id
 
 
+def _require_at_most_one_selector(**selectors: object | None) -> None:
+    """Reject ambiguous input selection: at most one selector may be set.
+
+    Eval input selectors (a direct path, an export id, a prediction id) are
+    mutually exclusive - there is no precedence between them. Passing more than
+    one raises; passing none is allowed (callers fall back to the latest export).
+    """
+    given = [name for name, value in selectors.items() if value is not None]
+    if len(given) > 1:
+        raise ValueError(
+            f"At most one input selector may be given, got {', '.join(given)}. "
+            "Pass a single selector, or none to use the latest annotation export."
+        )
+
+
 def resolve_eval_train_paths(
     *,
     workspace: WorkspacePaths,
@@ -383,21 +398,6 @@ def provenance_path(*, input_csv: Path, base_dir: Path) -> str:
         return str(input_csv.relative_to(resolved_base))
     except ValueError:
         return str(input_csv)
-
-
-def _require_at_most_one_selector(**selectors: object | None) -> None:
-    """Reject ambiguous input selection: at most one selector may be set.
-
-    Eval input selectors (a direct path, an export id, a prediction id) are
-    mutually exclusive - there is no precedence between them. Passing more than
-    one raises; passing none is allowed (callers fall back to the latest export).
-    """
-    given = [name for name, value in selectors.items() if value is not None]
-    if len(given) > 1:
-        raise ValueError(
-            f"At most one input selector may be given, got {', '.join(given)}. "
-            "Pass a single selector, or none to use the latest annotation export."
-        )
 
 
 def resolve_eval_score_input(

--- a/src/pragmata/core/paths/eval_paths.py
+++ b/src/pragmata/core/paths/eval_paths.py
@@ -118,10 +118,10 @@ def resolve_eval_train_paths(
 ) -> EvalTrainPaths:
     """Resolve the labeled input CSV consumed by eval train.
 
-    Direct labeled CSV input takes precedence over annotation export selection.
-    If no direct input path is provided, ``export_id`` selects an annotation
-    export. If neither is provided, the latest valid annotation export containing
-    the requested task CSV is selected.
+    At most one input selector may be given: a direct ``labeled_data_path`` or an
+    ``export_id``. Passing both is an error - there is no precedence between them.
+    If neither is provided, the latest valid annotation export containing the
+    requested task CSV is selected.
 
     Args:
         workspace: Workspace path bundle.
@@ -133,9 +133,12 @@ def resolve_eval_train_paths(
         Resolved train-input paths and annotation export provenance.
 
     Raises:
+        ValueError: If both ``labeled_data_path`` and ``export_id`` are given.
         FileNotFoundError: If the selected input CSV or annotation export cannot
             be found.
     """
+    _require_at_most_one_selector(labeled_data_path=labeled_data_path, export_id=export_id)
+
     if labeled_data_path is not None:
         training_input_csv = labeled_data_path.expanduser().resolve()
         if not training_input_csv.is_file():
@@ -382,6 +385,21 @@ def provenance_path(*, input_csv: Path, base_dir: Path) -> str:
         return str(input_csv)
 
 
+def _require_at_most_one_selector(**selectors: object | None) -> None:
+    """Reject ambiguous input selection: at most one selector may be set.
+
+    Eval input selectors (a direct path, an export id, a prediction id) are
+    mutually exclusive - there is no precedence between them. Passing more than
+    one raises; passing none is allowed (callers fall back to the latest export).
+    """
+    given = [name for name, value in selectors.items() if value is not None]
+    if len(given) > 1:
+        raise ValueError(
+            f"At most one input selector may be given, got {', '.join(given)}. "
+            "Pass a single selector, or none to use the latest annotation export."
+        )
+
+
 def resolve_eval_score_input(
     *,
     workspace: WorkspacePaths,
@@ -423,17 +441,7 @@ def resolve_eval_score_input(
         NotImplementedError: If a prediction run is selected; prediction-output
             scoring lands with ``pragmata eval predict``.
     """
-    selectors = {
-        "path": path is not None,
-        "export_id": export_id is not None,
-        "prediction_id": prediction_id is not None,
-    }
-    if sum(selectors.values()) > 1:
-        chosen = ", ".join(name for name, is_set in selectors.items() if is_set)
-        raise ValueError(
-            f"At most one scoring-input selector may be given, got {chosen}. "
-            "Pass one of path / export_id / prediction_id, or none to use the latest annotation export."
-        )
+    _require_at_most_one_selector(path=path, export_id=export_id, prediction_id=prediction_id)
 
     if path is not None:
         input_csv = path.expanduser().resolve()

--- a/src/pragmata/core/paths/eval_paths.py
+++ b/src/pragmata/core/paths/eval_paths.py
@@ -9,7 +9,7 @@ from pragmata.core.paths.annotation_paths import resolve_export_paths
 from pragmata.core.paths.paths import WorkspacePaths
 from pragmata.core.schemas.annotation_export import AnnotationExportMeta
 from pragmata.core.schemas.annotation_task import Task
-from pragmata.core.schemas.eval_output import EvalTrainMeta
+from pragmata.core.schemas.eval_output import EvalTrainMeta, ScoreInputSource
 
 
 @dataclass(frozen=True, slots=True)
@@ -317,7 +317,6 @@ class EvalScorePaths:
         retrieval_scores_json: Output path for retrieval score metrics.
         grounding_scores_json: Output path for grounding score metrics.
         generation_scores_json: Output path for generation score metrics.
-        scores_meta_json: Output path for score run metadata.
     """
 
     tool_root: Path
@@ -325,7 +324,6 @@ class EvalScorePaths:
     retrieval_scores_json: Path
     grounding_scores_json: Path
     generation_scores_json: Path
-    scores_meta_json: Path
 
     def ensure_dirs(
         self,
@@ -358,5 +356,120 @@ def resolve_eval_score_paths(
         retrieval_scores_json=score_dir / "retrieval_scores.json",
         grounding_scores_json=score_dir / "grounding_scores.json",
         generation_scores_json=score_dir / "generation_scores.json",
-        scores_meta_json=score_dir / "scores.meta.json",
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class EvalScoreInput:
+    """Resolved score input CSV and its provenance.
+
+    Attributes:
+        input_csv: Concrete labeled CSV path to read and score.
+        source: Provenance of the input (selector kind, its value, and the
+            resolved path), recorded on the score report.
+    """
+
+    input_csv: Path
+    source: ScoreInputSource
+
+
+def provenance_path(*, input_csv: Path, base_dir: Path) -> str:
+    """Record a scored input relative to the workspace, or absolute if outside it."""
+    resolved_base = base_dir.expanduser().resolve()
+    try:
+        return str(input_csv.relative_to(resolved_base))
+    except ValueError:
+        return str(input_csv)
+
+
+def resolve_eval_score_input(
+    *,
+    workspace: WorkspacePaths,
+    task: Task,
+    path: Path | None = None,
+    export_id: str | None = None,
+    prediction_id: str | None = None,
+) -> EvalScoreInput:
+    """Resolve the labeled CSV consumed by eval score and its provenance.
+
+    Selection follows a fixed precedence: a direct ``path`` wins,
+    then an ``export_id``, then a ``prediction_id``. With no selector, the
+    latest valid annotation export for the task is used, mirroring
+    ``resolve_eval_train_paths``.
+
+    Direct paths and annotation exports are already Pragmata-shaped and score
+    without further preparation. Scoring a prediction run is not yet supported:
+    the ``pragmata eval predict`` output layout does not exist yet, so both an
+    explicit ``prediction_id`` and the eventual "latest prediction run"
+    no-selector fallback that ``docs/design/eval-scoring-metrics.md`` proposes
+    are deferred until predict lands; the interim no-selector fallback is the
+    latest annotation export.
+
+    Args:
+        workspace: Workspace path bundle.
+        task: Annotation task that determines which exported task CSV is required.
+        path: Direct labeled CSV path.
+        export_id: Annotation export identifier.
+        prediction_id: Pragmata prediction run identifier.
+
+    Returns:
+        The resolved input CSV and its ``ScoreInputSource`` provenance. The
+        provenance's ``kind`` and ``ref`` let the caller (and the report) record
+        how the input was selected without re-running selection.
+
+    Raises:
+        FileNotFoundError: If the selected input CSV or annotation export is missing.
+        NotImplementedError: If a prediction run is the only selector; prediction-output
+            scoring lands with ``pragmata eval predict``.
+    """
+    if path is not None:
+        input_csv = path.expanduser().resolve()
+        if not input_csv.is_file():
+            raise FileNotFoundError(f"Scoring input CSV does not exist: {input_csv}")
+        return EvalScoreInput(
+            input_csv=input_csv,
+            source=ScoreInputSource(
+                kind="direct_path",
+                ref=str(path),
+                resolved_path=provenance_path(input_csv=input_csv, base_dir=workspace.base_dir),
+            ),
+        )
+
+    if export_id is not None:
+        resolved_export_id = export_id
+    elif prediction_id is not None:
+        raise NotImplementedError(
+            "Scoring a prediction run is not yet supported: `pragmata eval predict` and its "
+            "output layout are not implemented. Pass path or export_id instead."
+        )
+    else:
+        resolved_export_id = find_latest_annotation_export_id(workspace=workspace, task=task)
+
+    export_paths = resolve_export_paths(workspace=workspace, export_id=resolved_export_id)
+    if not export_paths.export_meta_json.is_file():
+        raise FileNotFoundError(
+            "Annotation export metadata does not exist. "
+            f"Expected annotation_export.meta.json at {export_paths.export_meta_json}."
+        )
+
+    match task:
+        case Task.RETRIEVAL:
+            input_csv = export_paths.retrieval_annotation_csv
+        case Task.GROUNDING:
+            input_csv = export_paths.grounding_annotation_csv
+        case Task.GENERATION:
+            input_csv = export_paths.generation_annotation_csv
+
+    if not input_csv.is_file():
+        raise FileNotFoundError(
+            f"Annotation export {resolved_export_id!r} does not contain the requested {task.value} CSV. "
+            f"Expected {input_csv}."
+        )
+    return EvalScoreInput(
+        input_csv=input_csv,
+        source=ScoreInputSource(
+            kind="annotation_export",
+            ref=resolved_export_id,
+            resolved_path=provenance_path(input_csv=input_csv, base_dir=workspace.base_dir),
+        ),
     )

--- a/src/pragmata/core/paths/eval_paths.py
+++ b/src/pragmata/core/paths/eval_paths.py
@@ -134,9 +134,8 @@ def resolve_eval_train_paths(
     """Resolve the labeled input CSV consumed by eval train.
 
     At most one input selector may be given: a direct ``labeled_data_path`` or an
-    ``export_id``. Passing both is an error - there is no precedence between them.
-    If neither is provided, the latest valid annotation export containing the
-    requested task CSV is selected.
+    ``export_id``. If neither is provided, the latest valid annotation export
+    containing the requested task CSV is selected.
 
     Args:
         workspace: Workspace path bundle.
@@ -411,8 +410,7 @@ def resolve_eval_score_input(
     """Resolve the labeled CSV consumed by eval score and its provenance.
 
     At most one input selector may be given: a direct ``path``, an ``export_id``,
-    or a ``prediction_id``. Passing more than one is an error - there is no
-    precedence between them. With no selector, the latest valid annotation export
+    or a ``prediction_id``. With no selector, the latest valid annotation export
     for the task is used, mirroring ``resolve_eval_train_paths``.
 
     Direct paths and annotation exports are already Pragmata-shaped and score

--- a/src/pragmata/core/paths/eval_paths.py
+++ b/src/pragmata/core/paths/eval_paths.py
@@ -416,10 +416,13 @@ def resolve_eval_score_input(
 
     Direct paths and annotation exports are already Pragmata-shaped and score
     without further preparation. Scoring a prediction run is not yet supported:
-    ``pragmata eval predict`` has landed, but it has no run-addressable output
-    layout and the prediction-run path resolver (``find_latest_prediction_run``)
-    is not implemented, so ``prediction_id`` is deferred. The no-selector
-    fallback is the latest annotation export.
+    ``pragmata eval predict`` persists ``prediction_outputs/<evaluator_run_id>/
+    predictions.csv``, but there is no prediction-run resolver yet - no
+    ``find_latest_prediction_run`` (cf. ``find_latest_eval_train_run_id``) and no
+    resolver mapping a ``prediction_id`` to that output CSV. Prediction outputs
+    are keyed by evaluator run id rather than a distinct prediction-run id, so the
+    selector's identity is unsettled. ``prediction_id`` is therefore deferred. The
+    no-selector fallback is the latest annotation export.
 
     Args:
         workspace: Workspace path bundle.
@@ -437,7 +440,7 @@ def resolve_eval_score_input(
         ValueError: If more than one of ``path`` / ``export_id`` / ``prediction_id`` is given.
         FileNotFoundError: If the selected input CSV or annotation export is missing.
         NotImplementedError: If a prediction run is selected; prediction-output
-            scoring lands with ``pragmata eval predict``.
+            scoring awaits a prediction-run resolver (see above).
     """
     _require_at_most_one_selector(path=path, export_id=export_id, prediction_id=prediction_id)
 
@@ -458,9 +461,9 @@ def resolve_eval_score_input(
         resolved_export_id = export_id
     elif prediction_id is not None:
         raise NotImplementedError(
-            "Scoring a prediction run is not yet supported: `pragmata eval predict` has landed, "
-            "but it has no run-addressable output layout and the prediction-run path resolver "
-            "is not implemented. Pass path or export_id instead."
+            "Scoring a prediction run is not yet supported: `pragmata eval predict` persists "
+            "prediction_outputs/<evaluator_run_id>/predictions.csv, but there is no prediction-run "
+            "resolver mapping a prediction_id to that output CSV yet. Pass path or export_id instead."
         )
     else:
         resolved_export_id = find_latest_annotation_export_id(workspace=workspace, task=task)

--- a/src/pragmata/core/paths/eval_paths.py
+++ b/src/pragmata/core/paths/eval_paths.py
@@ -417,11 +417,10 @@ def resolve_eval_score_input(
 
     Direct paths and annotation exports are already Pragmata-shaped and score
     without further preparation. Scoring a prediction run is not yet supported:
-    the ``pragmata eval predict`` output layout does not exist yet, so both an
-    explicit ``prediction_id`` and the eventual "latest prediction run"
-    no-selector fallback that ``docs/design/eval-scoring-metrics.md`` proposes
-    are deferred until predict lands; the interim no-selector fallback is the
-    latest annotation export.
+    ``pragmata eval predict`` has landed, but it has no run-addressable output
+    layout and the prediction-run path resolver (``find_latest_prediction_run``)
+    is not implemented, so ``prediction_id`` is deferred. The no-selector
+    fallback is the latest annotation export.
 
     Args:
         workspace: Workspace path bundle.
@@ -460,8 +459,9 @@ def resolve_eval_score_input(
         resolved_export_id = export_id
     elif prediction_id is not None:
         raise NotImplementedError(
-            "Scoring a prediction run is not yet supported: `pragmata eval predict` and its "
-            "output layout are not implemented. Pass path or export_id instead."
+            "Scoring a prediction run is not yet supported: `pragmata eval predict` has landed, "
+            "but it has no run-addressable output layout and the prediction-run path resolver "
+            "is not implemented. Pass path or export_id instead."
         )
     else:
         resolved_export_id = find_latest_annotation_export_id(workspace=workspace, task=task)

--- a/src/pragmata/core/paths/eval_paths.py
+++ b/src/pragmata/core/paths/eval_paths.py
@@ -392,10 +392,10 @@ def resolve_eval_score_input(
 ) -> EvalScoreInput:
     """Resolve the labeled CSV consumed by eval score and its provenance.
 
-    Selection follows a fixed precedence: a direct ``path`` wins,
-    then an ``export_id``, then a ``prediction_id``. With no selector, the
-    latest valid annotation export for the task is used, mirroring
-    ``resolve_eval_train_paths``.
+    At most one input selector may be given: a direct ``path``, an ``export_id``,
+    or a ``prediction_id``. Passing more than one is an error - there is no
+    precedence between them. With no selector, the latest valid annotation export
+    for the task is used, mirroring ``resolve_eval_train_paths``.
 
     Direct paths and annotation exports are already Pragmata-shaped and score
     without further preparation. Scoring a prediction run is not yet supported:
@@ -418,10 +418,23 @@ def resolve_eval_score_input(
         how the input was selected without re-running selection.
 
     Raises:
+        ValueError: If more than one of ``path`` / ``export_id`` / ``prediction_id`` is given.
         FileNotFoundError: If the selected input CSV or annotation export is missing.
-        NotImplementedError: If a prediction run is the only selector; prediction-output
+        NotImplementedError: If a prediction run is selected; prediction-output
             scoring lands with ``pragmata eval predict``.
     """
+    selectors = {
+        "path": path is not None,
+        "export_id": export_id is not None,
+        "prediction_id": prediction_id is not None,
+    }
+    if sum(selectors.values()) > 1:
+        chosen = ", ".join(name for name, is_set in selectors.items() if is_set)
+        raise ValueError(
+            f"At most one scoring-input selector may be given, got {chosen}. "
+            "Pass one of path / export_id / prediction_id, or none to use the latest annotation export."
+        )
+
     if path is not None:
         input_csv = path.expanduser().resolve()
         if not input_csv.is_file():

--- a/src/pragmata/core/paths/eval_paths.py
+++ b/src/pragmata/core/paths/eval_paths.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Self
 
-from pragmata.core.paths.annotation_paths import resolve_export_paths
+from pragmata.core.paths.annotation_paths import AnnotationExportPaths, resolve_export_paths
 from pragmata.core.paths.paths import WorkspacePaths
 from pragmata.core.schemas.annotation_export import AnnotationExportMeta
 from pragmata.core.schemas.annotation_task import Task
@@ -58,6 +58,19 @@ class EvalPredictPaths:
         return self
 
 
+def _task_annotation_csv(export_paths: AnnotationExportPaths, task: Task) -> Path:
+    """Select the per-task annotation CSV from a resolved annotation export."""
+    match task:
+        case Task.RETRIEVAL:
+            return export_paths.retrieval_annotation_csv
+        case Task.GROUNDING:
+            return export_paths.grounding_annotation_csv
+        case Task.GENERATION:
+            return export_paths.generation_annotation_csv
+        case _:
+            raise ValueError(f"Unsupported eval task: {task!r}")
+
+
 def find_latest_annotation_export_id(
     *,
     workspace: WorkspacePaths,
@@ -82,13 +95,7 @@ def find_latest_annotation_export_id(
             export_id=meta.export_id,
         )
 
-        match task:
-            case Task.RETRIEVAL:
-                task_csv = export_paths.retrieval_annotation_csv
-            case Task.GROUNDING:
-                task_csv = export_paths.grounding_annotation_csv
-            case Task.GENERATION:
-                task_csv = export_paths.generation_annotation_csv
+        task_csv = _task_annotation_csv(export_paths, task)
 
         if not task_csv.is_file():
             continue
@@ -179,13 +186,7 @@ def resolve_eval_train_paths(
             f"Expected annotation_export.meta.json at {export_paths.export_meta_json}."
         )
 
-    match task:
-        case Task.RETRIEVAL:
-            training_input_csv = export_paths.retrieval_annotation_csv
-        case Task.GROUNDING:
-            training_input_csv = export_paths.grounding_annotation_csv
-        case Task.GENERATION:
-            training_input_csv = export_paths.generation_annotation_csv
+    training_input_csv = _task_annotation_csv(export_paths, task)
 
     if not training_input_csv.is_file():
         raise FileNotFoundError(
@@ -471,13 +472,7 @@ def resolve_eval_score_input(
             f"Expected annotation_export.meta.json at {export_paths.export_meta_json}."
         )
 
-    match task:
-        case Task.RETRIEVAL:
-            input_csv = export_paths.retrieval_annotation_csv
-        case Task.GROUNDING:
-            input_csv = export_paths.grounding_annotation_csv
-        case Task.GENERATION:
-            input_csv = export_paths.generation_annotation_csv
+    input_csv = _task_annotation_csv(export_paths, task)
 
     if not input_csv.is_file():
         raise FileNotFoundError(

--- a/src/pragmata/core/paths/eval_paths.py
+++ b/src/pragmata/core/paths/eval_paths.py
@@ -415,14 +415,9 @@ def resolve_eval_score_input(
     for the task is used, mirroring ``resolve_eval_train_paths``.
 
     Direct paths and annotation exports are already Pragmata-shaped and score
-    without further preparation. Scoring a prediction run is not yet supported:
-    ``pragmata eval predict`` persists ``prediction_outputs/<evaluator_run_id>/
-    predictions.csv``, but there is no prediction-run resolver yet - no
-    ``find_latest_prediction_run`` (cf. ``find_latest_eval_train_run_id``) and no
-    resolver mapping a ``prediction_id`` to that output CSV. Prediction outputs
-    are keyed by evaluator run id rather than a distinct prediction-run id, so the
-    selector's identity is unsettled. ``prediction_id`` is therefore deferred. The
-    no-selector fallback is the latest annotation export.
+    without further preparation. Scoring a prediction run (``prediction_id``) is
+    not currently supported and raises ``NotImplementedError`` (see #303). With no
+    selector, the latest annotation export is used.
 
     Args:
         workspace: Workspace path bundle.
@@ -439,8 +434,7 @@ def resolve_eval_score_input(
     Raises:
         ValueError: If more than one of ``path`` / ``export_id`` / ``prediction_id`` is given.
         FileNotFoundError: If the selected input CSV or annotation export is missing.
-        NotImplementedError: If a prediction run is selected; prediction-output
-            scoring awaits a prediction-run resolver (see above).
+        NotImplementedError: If a prediction run is selected; not yet supported (see #303).
     """
     _require_at_most_one_selector(path=path, export_id=export_id, prediction_id=prediction_id)
 
@@ -461,9 +455,7 @@ def resolve_eval_score_input(
         resolved_export_id = export_id
     elif prediction_id is not None:
         raise NotImplementedError(
-            "Scoring a prediction run is not yet supported: `pragmata eval predict` persists "
-            "prediction_outputs/<evaluator_run_id>/predictions.csv, but there is no prediction-run "
-            "resolver mapping a prediction_id to that output CSV yet. Pass path or export_id instead."
+            "Scoring a prediction run is not yet supported (see issue #303). Pass path or export_id instead."
         )
     else:
         resolved_export_id = find_latest_annotation_export_id(workspace=workspace, task=task)

--- a/tests/unit/core/paths/test_eval_paths.py
+++ b/tests/unit/core/paths/test_eval_paths.py
@@ -668,43 +668,24 @@ def test_resolve_eval_score_input_prediction_run_not_supported(
         resolve_eval_score_input(workspace=workspace, task=Task.RETRIEVAL, prediction_id="run-1")
 
 
-def test_resolve_eval_score_input_export_takes_precedence_over_prediction(
+def test_resolve_eval_score_input_rejects_export_and_prediction_together(
     workspace: WorkspacePaths,
 ) -> None:
-    """Export id outranks a prediction run, so a supported input is chosen without erroring."""
-    _write_annotation_export(
-        workspace=workspace,
-        export_id="export-a",
-        created_at=datetime(2026, 1, 1, tzinfo=UTC),
-        tasks=[Task.RETRIEVAL],
-    )
-
-    resolved = resolve_eval_score_input(
-        workspace=workspace, task=Task.RETRIEVAL, export_id="export-a", prediction_id="run-1"
-    )
-
-    assert resolved.input_csv == workspace.base_dir / "annotation" / "exports" / "export-a" / "retrieval.csv"
-    assert resolved.source.ref == "export-a"
+    """More than one selector is ambiguous and raises rather than picking one."""
+    with pytest.raises(ValueError, match="At most one scoring-input selector"):
+        resolve_eval_score_input(workspace=workspace, task=Task.RETRIEVAL, export_id="export-a", prediction_id="run-1")
 
 
-def test_resolve_eval_score_input_direct_path_takes_precedence(
+def test_resolve_eval_score_input_rejects_path_and_export_together(
     workspace: WorkspacePaths,
     tmp_path: Path,
 ) -> None:
-    """A direct path outranks an export id."""
+    """A direct path and an export id together is an error - there is no precedence."""
     csv = tmp_path / "labeled.csv"
     csv.write_text("example_id\nexample-1\n", encoding="utf-8")
-    _write_annotation_export(
-        workspace=workspace,
-        export_id="export-a",
-        created_at=datetime(2026, 1, 1, tzinfo=UTC),
-        tasks=[Task.RETRIEVAL],
-    )
 
-    resolved = resolve_eval_score_input(workspace=workspace, task=Task.RETRIEVAL, path=csv, export_id="export-a")
-
-    assert resolved.input_csv == csv.resolve()
-    assert resolved.source.kind == "direct_path"
+    with pytest.raises(ValueError, match="path, export_id"):
+        resolve_eval_score_input(workspace=workspace, task=Task.RETRIEVAL, path=csv, export_id="export-a")
 
 
 def test_resolve_eval_score_input_rejects_missing_export_metadata(

--- a/tests/unit/core/paths/test_eval_paths.py
+++ b/tests/unit/core/paths/test_eval_paths.py
@@ -106,7 +106,6 @@ def test_resolve_eval_train_paths_uses_direct_labeled_data_path(
         workspace=workspace,
         task=Task.RETRIEVAL,
         labeled_data_path=input_csv,
-        export_id="ignored-export",
     )
 
     assert paths == EvalTrainPaths(
@@ -114,6 +113,23 @@ def test_resolve_eval_train_paths_uses_direct_labeled_data_path(
         training_input_csv=input_csv.resolve(),
         annotation_export_id=None,
     )
+
+
+def test_resolve_eval_train_paths_rejects_path_and_export_together(
+    workspace: WorkspacePaths,
+) -> None:
+    """A direct path and an export id together is an error - there is no precedence."""
+    input_csv = workspace.base_dir / "standalone" / "labeled.csv"
+    input_csv.parent.mkdir()
+    input_csv.write_text("example_id\nexample-1\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="At most one input selector"):
+        resolve_eval_train_paths(
+            workspace=workspace,
+            task=Task.RETRIEVAL,
+            labeled_data_path=input_csv,
+            export_id="export-a",
+        )
 
 
 def test_eval_train_paths_ensure_dirs_creates_eval_tool_root(
@@ -666,14 +682,6 @@ def test_resolve_eval_score_input_prediction_run_not_supported(
     """A prediction run as the only selector is deferred until eval predict lands."""
     with pytest.raises(NotImplementedError, match="prediction run is not yet supported"):
         resolve_eval_score_input(workspace=workspace, task=Task.RETRIEVAL, prediction_id="run-1")
-
-
-def test_resolve_eval_score_input_rejects_export_and_prediction_together(
-    workspace: WorkspacePaths,
-) -> None:
-    """More than one selector is ambiguous and raises rather than picking one."""
-    with pytest.raises(ValueError, match="At most one scoring-input selector"):
-        resolve_eval_score_input(workspace=workspace, task=Task.RETRIEVAL, export_id="export-a", prediction_id="run-1")
 
 
 def test_resolve_eval_score_input_rejects_path_and_export_together(

--- a/tests/unit/core/paths/test_eval_paths.py
+++ b/tests/unit/core/paths/test_eval_paths.py
@@ -115,23 +115,6 @@ def test_resolve_eval_train_paths_uses_direct_labeled_data_path(
     )
 
 
-def test_resolve_eval_train_paths_rejects_path_and_export_together(
-    workspace: WorkspacePaths,
-) -> None:
-    """A direct path and an export id together is an error - there is no precedence."""
-    input_csv = workspace.base_dir / "standalone" / "labeled.csv"
-    input_csv.parent.mkdir()
-    input_csv.write_text("example_id\nexample-1\n", encoding="utf-8")
-
-    with pytest.raises(ValueError, match="At most one input selector"):
-        resolve_eval_train_paths(
-            workspace=workspace,
-            task=Task.RETRIEVAL,
-            labeled_data_path=input_csv,
-            export_id="export-a",
-        )
-
-
 def test_eval_train_paths_ensure_dirs_creates_eval_tool_root(
     workspace: WorkspacePaths,
 ) -> None:

--- a/tests/unit/core/paths/test_eval_paths.py
+++ b/tests/unit/core/paths/test_eval_paths.py
@@ -11,7 +11,9 @@ from pragmata.core.paths.eval_paths import (
     EvalTrainPaths,
     find_latest_annotation_export_id,
     find_latest_eval_train_run_id,
+    provenance_path,
     resolve_eval_predict_paths,
+    resolve_eval_score_input,
     resolve_eval_score_paths,
     resolve_eval_train_meta_path,
     resolve_eval_train_paths,
@@ -548,7 +550,6 @@ def test_resolve_eval_score_paths_returns_expected_bundle(
         retrieval_scores_json=expected_score_dir / "retrieval_scores.json",
         grounding_scores_json=expected_score_dir / "grounding_scores.json",
         generation_scores_json=expected_score_dir / "generation_scores.json",
-        scores_meta_json=expected_score_dir / "scores.meta.json",
     )
 
 
@@ -588,6 +589,143 @@ def test_score_artifact_paths_are_score_id_specific(
     assert first.retrieval_scores_json != second.retrieval_scores_json
     assert first.grounding_scores_json != second.grounding_scores_json
     assert first.generation_scores_json != second.generation_scores_json
-    assert first.scores_meta_json != second.scores_meta_json
 
     assert first.score_dir.parent == second.score_dir.parent == first.tool_root / "scores"
+
+
+def test_resolve_eval_score_input_uses_direct_labeled_input_path(
+    workspace: WorkspacePaths,
+    tmp_path: Path,
+) -> None:
+    """A direct labeled input path is used verbatim (resolved)."""
+    csv = tmp_path / "labeled.csv"
+    csv.write_text("example_id\nexample-1\n", encoding="utf-8")
+
+    resolved = resolve_eval_score_input(workspace=workspace, task=Task.RETRIEVAL, path=csv)
+
+    assert resolved.input_csv == csv.resolve()
+    assert resolved.source.kind == "direct_path"
+    assert resolved.source.ref == str(csv)
+
+
+def test_resolve_eval_score_input_rejects_missing_direct_path(
+    workspace: WorkspacePaths,
+    tmp_path: Path,
+) -> None:
+    """A direct labeled input path that does not exist fails fast."""
+    with pytest.raises(FileNotFoundError, match="Scoring input CSV does not exist"):
+        resolve_eval_score_input(workspace=workspace, task=Task.RETRIEVAL, path=tmp_path / "nope.csv")
+
+
+def test_resolve_eval_score_input_uses_explicit_export_id(
+    workspace: WorkspacePaths,
+) -> None:
+    """An explicit export id resolves to the requested task CSV."""
+    _write_annotation_export(
+        workspace=workspace,
+        export_id="export-a",
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        tasks=[Task.GROUNDING],
+    )
+
+    resolved = resolve_eval_score_input(workspace=workspace, task=Task.GROUNDING, export_id="export-a")
+
+    assert resolved.input_csv == workspace.base_dir / "annotation" / "exports" / "export-a" / "grounding.csv"
+    assert resolved.source.kind == "annotation_export"
+    assert resolved.source.ref == "export-a"
+    assert resolved.source.resolved_path == "annotation/exports/export-a/grounding.csv"
+
+
+def test_resolve_eval_score_input_falls_back_to_latest_export(
+    workspace: WorkspacePaths,
+) -> None:
+    """With no selector, the latest valid annotation export is used (interim fallback)."""
+    _write_annotation_export(
+        workspace=workspace,
+        export_id="older",
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        tasks=[Task.RETRIEVAL],
+    )
+    _write_annotation_export(
+        workspace=workspace,
+        export_id="newer",
+        created_at=datetime(2026, 6, 1, tzinfo=UTC),
+        tasks=[Task.RETRIEVAL],
+    )
+
+    resolved = resolve_eval_score_input(workspace=workspace, task=Task.RETRIEVAL)
+
+    assert resolved.input_csv == workspace.base_dir / "annotation" / "exports" / "newer" / "retrieval.csv"
+    assert resolved.source.kind == "annotation_export"
+    assert resolved.source.ref == "newer"
+
+
+def test_resolve_eval_score_input_prediction_run_not_supported(
+    workspace: WorkspacePaths,
+) -> None:
+    """A prediction run as the only selector is deferred until eval predict lands."""
+    with pytest.raises(NotImplementedError, match="prediction run is not yet supported"):
+        resolve_eval_score_input(workspace=workspace, task=Task.RETRIEVAL, prediction_id="run-1")
+
+
+def test_resolve_eval_score_input_export_takes_precedence_over_prediction(
+    workspace: WorkspacePaths,
+) -> None:
+    """Export id outranks a prediction run, so a supported input is chosen without erroring."""
+    _write_annotation_export(
+        workspace=workspace,
+        export_id="export-a",
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        tasks=[Task.RETRIEVAL],
+    )
+
+    resolved = resolve_eval_score_input(
+        workspace=workspace, task=Task.RETRIEVAL, export_id="export-a", prediction_id="run-1"
+    )
+
+    assert resolved.input_csv == workspace.base_dir / "annotation" / "exports" / "export-a" / "retrieval.csv"
+    assert resolved.source.ref == "export-a"
+
+
+def test_resolve_eval_score_input_direct_path_takes_precedence(
+    workspace: WorkspacePaths,
+    tmp_path: Path,
+) -> None:
+    """A direct path outranks an export id."""
+    csv = tmp_path / "labeled.csv"
+    csv.write_text("example_id\nexample-1\n", encoding="utf-8")
+    _write_annotation_export(
+        workspace=workspace,
+        export_id="export-a",
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        tasks=[Task.RETRIEVAL],
+    )
+
+    resolved = resolve_eval_score_input(workspace=workspace, task=Task.RETRIEVAL, path=csv, export_id="export-a")
+
+    assert resolved.input_csv == csv.resolve()
+    assert resolved.source.kind == "direct_path"
+
+
+def test_resolve_eval_score_input_rejects_missing_export_metadata(
+    workspace: WorkspacePaths,
+) -> None:
+    """Export selection requires export metadata."""
+    export_dir = workspace.base_dir / "annotation" / "exports" / "broken"
+    export_dir.mkdir(parents=True)
+    (export_dir / "retrieval.csv").write_text("example_id\nexample-1\n", encoding="utf-8")
+
+    with pytest.raises(FileNotFoundError, match="Annotation export metadata does not exist"):
+        resolve_eval_score_input(workspace=workspace, task=Task.RETRIEVAL, export_id="broken")
+
+
+def test_provenance_path_relativizes_inside_workspace(tmp_path: Path) -> None:
+    """An input under the workspace is recorded relative to it."""
+    csv = tmp_path / "eval" / "scores" / "in.csv"
+    assert provenance_path(input_csv=csv, base_dir=tmp_path) == "eval/scores/in.csv"
+
+
+def test_provenance_path_keeps_absolute_outside_workspace(tmp_path: Path) -> None:
+    """An input outside the workspace is recorded as its absolute path."""
+    outside = Path("/data/external/labeled.csv")
+    assert provenance_path(input_csv=outside, base_dir=tmp_path) == str(outside)


### PR DESCRIPTION
#278 > #282 > #283 > #284 > #279 > #280

---

## Summary

Adds score-input selection + path resolution to `core/paths/eval_paths.py`, and makes eval input selection mutually exclusive across both train and score.

- **`resolve_eval_score_input(...)`** → `EvalScoreInput` bundle: the concrete labeled CSV to read plus its `ScoreInputSource` provenance (`kind` / `ref` / `resolved_path`), so the caller and report record how the input was selected without re-resolving.
- **Mutually exclusive selectors.** `path`, `export_id`, and `prediction_id` are alternatives: at most one may be given, more than one raises, and no selector resolves to the latest annotation export for the task. Enforced by a shared `_require_at_most_one_selector` helper.
- **`resolve_eval_train_paths`** uses the same helper, so `labeled_data_path` vs `export_id` follows identical rules.
- **`EvalScoreInput`** dataclass (input CSV + provenance) and **`provenance_path(...)`** (records the input relative to the workspace, or absolute when outside it).
