### PR TITLE
feat(eval): add import_eval_score_frame with majority consolidation

### DIFF
--- a/src/pragmata/core/eval/imports.py
+++ b/src/pragmata/core/eval/imports.py
@@ -5,7 +5,14 @@ from pathlib import Path
 import pandas as pd
 
 from pragmata.core.schemas.annotation_task import Task
-from pragmata.core.schemas.eval_input import validate_eval_predict_frame, validate_eval_train_frame
+from pragmata.core.schemas.eval_input import (
+    TEXT_COLUMNS_BY_TASK,
+    EvalInputSchemaError,
+    validate_eval_predict_frame,
+    validate_eval_score_frame,
+    validate_eval_train_frame,
+)
+from pragmata.core.schemas.eval_output import ScoreInputSource
 
 
 def import_eval_train_frame(
@@ -42,3 +49,69 @@ def import_eval_predict_frame(
     """
     frame = pd.read_csv(path, encoding="utf-8")
     return validate_eval_predict_frame(frame, task=task)
+
+
+def import_eval_score_frame(
+    *,
+    path: Path,
+    task: Task,
+    source: ScoreInputSource,
+) -> pd.DataFrame:
+    """Read, prepare, and validate a labeled eval scoring dataframe.
+
+    Direct paths and annotation exports are already Pragmata-shaped and are read
+    and validated as-is. Prediction-run inputs are tlmtc-shaped - they carry the
+    generic ``text``/``text_pair`` columns - so ``source.kind`` drives an inverse
+    mapping back to the task-specific column names (via ``TEXT_COLUMNS_BY_TASK``)
+    before validation; identity and label columns pass through unchanged.
+
+    Beyond the schema contract, scoring requires each resampling unit to be
+    unique: retrieval rows are keyed by ``(record_uuid, chunk_id)`` and their
+    ``chunk_rank`` must be unique within a query; grounding/generation are one
+    row per ``record_uuid``. Scoring does no consensus consolidation (unlike
+    training), so a duplicated unit would double-count in the metric denominators
+    - hence a hard error rather than a silent skew.
+
+    Args:
+        path: Resolved CSV path to read.
+        task: Annotation task that determines the dataframe contract.
+        source: Provenance of the input; ``source.kind`` decides whether the
+            frame needs tlmtc text-column restoration.
+
+    Returns:
+        Validated dataframe with Pragmata task columns.
+
+    Raises:
+        EvalInputSchemaError: If the frame violates the score contract or contains
+            duplicate scoring units.
+    """
+    frame = pd.read_csv(path, encoding="utf-8")
+    if source.kind == "model_prediction":
+        frame = _restore_pragmata_text_columns(frame, task=task)
+    validated = validate_eval_score_frame(frame, task=task)
+    _guard_unique_scoring_units(validated, task=task)
+    return validated
+
+
+def _restore_pragmata_text_columns(frame: pd.DataFrame, *, task: Task) -> pd.DataFrame:
+    """Invert the tlmtc predict mapping: restore task text columns from ``text``/``text_pair``."""
+    text_column, text_pair_column = TEXT_COLUMNS_BY_TASK[task]
+    return frame.rename(columns={"text": text_column, "text_pair": text_pair_column})
+
+
+def _guard_unique_scoring_units(frame: pd.DataFrame, *, task: Task) -> None:
+    """Reject duplicate scoring units that would double-count in metric means."""
+    if task == Task.RETRIEVAL:
+        _reject_duplicates(frame, ["record_uuid", "chunk_id"], task, "chunk")
+        _reject_duplicates(frame, ["record_uuid", "chunk_rank"], task, "chunk rank")
+    else:
+        _reject_duplicates(frame, ["record_uuid"], task, "query")
+
+
+def _reject_duplicates(frame: pd.DataFrame, keys: list[str], task: Task, unit: str) -> None:
+    duplicated = frame.duplicated(subset=keys, keep=False)
+    if duplicated.any():
+        raise EvalInputSchemaError(
+            f"Scoring input for {task.value} has {int(duplicated.sum())} row(s) with a duplicate "
+            f"{unit} key {tuple(keys)}; each unit must be unique so metric denominators are not double-counted."
+        )

--- a/src/pragmata/core/eval/imports.py
+++ b/src/pragmata/core/eval/imports.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pandas as pd
 
+from pragmata.core.eval.transforms import consolidate_labels_by_majority
 from pragmata.core.schemas.annotation_task import Task
 from pragmata.core.schemas.eval_input import (
     TEXT_COLUMNS_BY_TASK,
@@ -65,12 +66,15 @@ def import_eval_score_frame(
     mapping back to the task-specific column names (via ``TEXT_COLUMNS_BY_TASK``)
     before validation; identity and label columns pass through unchanged.
 
-    Beyond the schema contract, scoring requires each resampling unit to be
-    unique: retrieval rows are keyed by ``(record_uuid, chunk_id)`` and their
-    ``chunk_rank`` must be unique within a query; grounding/generation are one
-    row per ``record_uuid``. Scoring does no consensus consolidation (unlike
-    training), so a duplicated unit would double-count in the metric denominators
-    - hence a hard error rather than a silent skew.
+    Each scoring unit must be unique so it is not double-counted in the metric
+    denominators: retrieval rows are keyed by ``(record_uuid, chunk_id)`` (with
+    ``chunk_rank`` unique within a query); grounding/generation are one row per
+    ``record_uuid``. Multiple annotator rows for the same unit are consolidated to
+    a single row by per-label majority (``consolidate_labels_by_majority``, shared
+    with train ingestion) - a no-op when units are already unique.
+    ``_guard_unique_scoring_units`` then runs as a post-collapse invariant: it still
+    hard-errors on a residual duplicate the majority collapse cannot resolve, e.g.
+    two distinct ``chunk_id``s sharing a ``chunk_rank``.
 
     Args:
         path: Resolved CSV path to read.
@@ -79,18 +83,19 @@ def import_eval_score_frame(
             frame needs tlmtc text-column restoration.
 
     Returns:
-        Validated dataframe with Pragmata task columns.
+        Validated dataframe with Pragmata task columns, one row per scoring unit.
 
     Raises:
-        EvalInputSchemaError: If the frame violates the score contract or contains
-            duplicate scoring units.
+        EvalInputSchemaError: If the frame violates the score contract or retains a
+            duplicate scoring unit after majority consolidation.
     """
     frame = pd.read_csv(path, encoding="utf-8")
     if source.kind == "model_prediction":
         frame = _restore_pragmata_text_columns(frame, task=task)
     validated = validate_eval_score_frame(frame, task=task)
-    _guard_unique_scoring_units(validated, task=task)
-    return validated
+    consolidated = consolidate_labels_by_majority(validated, task=task)
+    _guard_unique_scoring_units(consolidated, task=task)
+    return consolidated
 
 
 def _restore_pragmata_text_columns(frame: pd.DataFrame, *, task: Task) -> pd.DataFrame:

--- a/src/pragmata/core/eval/transforms.py
+++ b/src/pragmata/core/eval/transforms.py
@@ -50,7 +50,7 @@ def build_tlmtc_frame(
 
     if mode == "train":
         frame = frame.astype({column: "int64" for column in LABEL_COLUMNS_BY_TASK[task]})
-        consolidated_frame = _consolidate_training_rows(frame, task=task)
+        consolidated_frame = consolidate_labels_by_majority(frame, task=task)
     else:
         consolidated_frame = frame
 
@@ -74,17 +74,20 @@ def build_tlmtc_frame(
     return consolidated_frame.reset_index(drop=True).rename(columns=rename_map)
 
 
-def _consolidate_training_rows(
+def consolidate_labels_by_majority(
     frame: pd.DataFrame,
     *,
     task: Task,
 ) -> pd.DataFrame:
-    """Deduplicate repeated annotation units with per-label majority consensus.
+    """Collapse repeated annotation units to one row via per-label majority consensus.
 
-    For duplicate rows, labels with a strict majority are consolidated independently.
-    Tied labels fall back to the selected source row. When an observed row matches
-    all strict-majority labels, that row is selected to preserve non-label metadata
-    deterministically.
+    Shared by eval train and score ingestion: multiple annotator rows for the same
+    scoring unit (retrieval ``(record_uuid, chunk_id)``; grounding/generation
+    ``record_uuid``) are reduced to a single row. Each label with a strict majority
+    (> half positive) is set independently; a tied label (exact 50/50 on an even
+    number of annotators) falls back to the selected source row's value. When an
+    observed row matches all strict-majority labels, that row is selected to preserve
+    non-label metadata deterministically. A no-op when no unit is duplicated.
     """
     key_columns = _DUPLICATE_KEY_COLUMNS_BY_TASK[task]
     label_columns = LABEL_COLUMNS_BY_TASK[task]
@@ -154,7 +157,7 @@ def _consolidate_training_rows(
         consolidated.loc[target_position, label_override.index] = label_override
 
     logger.info(
-        "Consolidated duplicate eval training rows for %s: input_rows=%d output_rows=%d "
+        "Consolidated duplicate eval rows by majority for %s: input_rows=%d output_rows=%d "
         "collapsed_rows=%d duplicate_units=%d key_columns=%s",
         task.value,
         len(frame),

--- a/tests/unit/core/eval/test_imports.py
+++ b/tests/unit/core/eval/test_imports.py
@@ -205,20 +205,30 @@ class TestImportEvalScoreFrame:
         with pytest.raises(EvalInputSchemaError):
             import_eval_score_frame(path=path, task=Task.RETRIEVAL, source=self._DIRECT)
 
-    def test_rejects_duplicate_chunk_within_query(self, tmp_path: Path) -> None:
+    def test_consolidates_multi_annotator_chunk_by_majority(self, tmp_path: Path) -> None:
+        # Three annotators labeled the same (record_uuid, chunk_id); collapse to one majority row.
         path = self._write(
             tmp_path,
             [
                 "query,chunk,topically_relevant,evidence_sufficient,misleading,record_uuid,chunk_id,chunk_rank",
                 "q1,c1,1,1,0,r1,ch1,1",
-                "q1,c1,1,1,0,r1,ch1,2",
+                "q1,c1,1,1,1,r1,ch1,1",
+                "q1,c1,0,1,1,r1,ch1,1",
             ],
         )
 
-        with pytest.raises(EvalInputSchemaError, match="duplicate chunk key"):
-            import_eval_score_frame(path=path, task=Task.RETRIEVAL, source=self._DIRECT)
+        frame = import_eval_score_frame(path=path, task=Task.RETRIEVAL, source=self._DIRECT)
 
-    def test_rejects_duplicate_chunk_rank_within_query(self, tmp_path: Path) -> None:
+        assert len(frame) == 1
+        row = frame.iloc[0]
+        assert row["record_uuid"] == "r1" and row["chunk_id"] == "ch1"
+        assert row["topically_relevant"] == 1  # 2/3 positive
+        assert row["evidence_sufficient"] == 1  # 3/3
+        assert row["misleading"] == 1  # 2/3
+
+    def test_rejects_non_collapsible_duplicate_chunk_rank(self, tmp_path: Path) -> None:
+        # Two distinct chunk_ids sharing a chunk_rank cannot be majority-collapsed
+        # (different units), so the post-collapse guard still hard-errors.
         path = self._write(
             tmp_path,
             [
@@ -231,19 +241,27 @@ class TestImportEvalScoreFrame:
         with pytest.raises(EvalInputSchemaError, match="duplicate chunk rank key"):
             import_eval_score_frame(path=path, task=Task.RETRIEVAL, source=self._DIRECT)
 
-    def test_rejects_duplicate_query_for_grounding(self, tmp_path: Path) -> None:
+    def test_consolidates_multi_annotator_query_for_grounding(self, tmp_path: Path) -> None:
+        # Three annotators labeled the same grounding query; collapse to one majority row.
         path = self._write(
             tmp_path,
             [
                 "answer,context_set,support_present,unsupported_claim_present,"
                 "contradicted_claim_present,source_cited,fabricated_source,record_uuid",
                 "a1,ctx1,1,0,0,1,0,r1",
-                "a2,ctx2,1,0,0,1,0,r1",
+                "a1,ctx1,1,0,0,1,0,r1",
+                "a1,ctx1,1,1,0,0,0,r1",
             ],
         )
 
-        with pytest.raises(EvalInputSchemaError, match="duplicate query key"):
-            import_eval_score_frame(path=path, task=Task.GROUNDING, source=self._DIRECT)
+        frame = import_eval_score_frame(path=path, task=Task.GROUNDING, source=self._DIRECT)
+
+        assert len(frame) == 1
+        row = frame.iloc[0]
+        assert row["record_uuid"] == "r1"
+        assert row["support_present"] == 1  # 3/3
+        assert row["unsupported_claim_present"] == 0  # 1/3
+        assert row["source_cited"] == 1  # 2/3
 
     def test_restores_tlmtc_text_columns_for_prediction_input(self, tmp_path: Path) -> None:
         # A prediction artifact is tlmtc-shaped: task text columns arrive as text/text_pair.

--- a/tests/unit/core/eval/test_imports.py
+++ b/tests/unit/core/eval/test_imports.py
@@ -5,9 +5,14 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from pragmata.core.eval.imports import import_eval_predict_frame, import_eval_train_frame
+from pragmata.core.eval.imports import (
+    import_eval_predict_frame,
+    import_eval_score_frame,
+    import_eval_train_frame,
+)
 from pragmata.core.schemas.annotation_task import Task
 from pragmata.core.schemas.eval_input import EvalInputSchemaError
+from pragmata.core.schemas.eval_output import ScoreInputSource
 
 
 class TestImportEvalTrainFrame:
@@ -158,3 +163,101 @@ class TestImportEvalPredictFrame:
 
         with pytest.raises(EvalInputSchemaError, match="eval prediction data contract"):
             import_eval_predict_frame(path=path, task=Task.RETRIEVAL)
+
+
+class TestImportEvalScoreFrame:
+    """Tests for labeled eval scoring dataframe imports."""
+
+    _DIRECT = ScoreInputSource(kind="direct_path", ref="in.csv", resolved_path="in.csv")
+    _PREDICTION = ScoreInputSource(
+        kind="model_prediction", ref="run-1", resolved_path="eval/predictions/run-1/predictions.csv"
+    )
+
+    def _write(self, tmp_path: Path, rows: list[str]) -> Path:
+        path = tmp_path / "score.csv"
+        path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+        return path
+
+    def test_reads_and_validates_pragmata_shaped_csv(self, tmp_path: Path) -> None:
+        path = self._write(
+            tmp_path,
+            [
+                "query,chunk,topically_relevant,evidence_sufficient,misleading,record_uuid,chunk_id,chunk_rank",
+                "q1,c1,1,1,0,r1,ch1,1",
+                "q1,c2,0,0,1,r1,ch2,2",
+            ],
+        )
+
+        frame = import_eval_score_frame(path=path, task=Task.RETRIEVAL, source=self._DIRECT)
+
+        assert list(frame["query"]) == ["q1", "q1"]
+        assert set(["query", "chunk", "record_uuid", "chunk_id", "chunk_rank"]).issubset(frame.columns)
+
+    def test_rejects_invalid_csv(self, tmp_path: Path) -> None:
+        path = self._write(
+            tmp_path,
+            [
+                "query,topically_relevant,evidence_sufficient,misleading,record_uuid,chunk_id,chunk_rank",
+                "q1,1,1,0,r1,ch1,1",
+            ],
+        )
+
+        with pytest.raises(EvalInputSchemaError):
+            import_eval_score_frame(path=path, task=Task.RETRIEVAL, source=self._DIRECT)
+
+    def test_rejects_duplicate_chunk_within_query(self, tmp_path: Path) -> None:
+        path = self._write(
+            tmp_path,
+            [
+                "query,chunk,topically_relevant,evidence_sufficient,misleading,record_uuid,chunk_id,chunk_rank",
+                "q1,c1,1,1,0,r1,ch1,1",
+                "q1,c1,1,1,0,r1,ch1,2",
+            ],
+        )
+
+        with pytest.raises(EvalInputSchemaError, match="duplicate chunk key"):
+            import_eval_score_frame(path=path, task=Task.RETRIEVAL, source=self._DIRECT)
+
+    def test_rejects_duplicate_chunk_rank_within_query(self, tmp_path: Path) -> None:
+        path = self._write(
+            tmp_path,
+            [
+                "query,chunk,topically_relevant,evidence_sufficient,misleading,record_uuid,chunk_id,chunk_rank",
+                "q1,c1,1,1,0,r1,ch1,1",
+                "q1,c2,0,0,1,r1,ch2,1",
+            ],
+        )
+
+        with pytest.raises(EvalInputSchemaError, match="duplicate chunk rank key"):
+            import_eval_score_frame(path=path, task=Task.RETRIEVAL, source=self._DIRECT)
+
+    def test_rejects_duplicate_query_for_grounding(self, tmp_path: Path) -> None:
+        path = self._write(
+            tmp_path,
+            [
+                "answer,context_set,support_present,unsupported_claim_present,"
+                "contradicted_claim_present,source_cited,fabricated_source,record_uuid",
+                "a1,ctx1,1,0,0,1,0,r1",
+                "a2,ctx2,1,0,0,1,0,r1",
+            ],
+        )
+
+        with pytest.raises(EvalInputSchemaError, match="duplicate query key"):
+            import_eval_score_frame(path=path, task=Task.GROUNDING, source=self._DIRECT)
+
+    def test_restores_tlmtc_text_columns_for_prediction_input(self, tmp_path: Path) -> None:
+        # A prediction artifact is tlmtc-shaped: task text columns arrive as text/text_pair.
+        path = self._write(
+            tmp_path,
+            [
+                "text,text_pair,topically_relevant,evidence_sufficient,misleading,record_uuid,chunk_id,chunk_rank",
+                "q1,c1,1,1,0,r1,ch1,1",
+            ],
+        )
+
+        frame = import_eval_score_frame(path=path, task=Task.RETRIEVAL, source=self._PREDICTION)
+
+        assert {"query", "chunk"}.issubset(frame.columns)
+        assert "text" not in frame.columns and "text_pair" not in frame.columns
+        assert frame.loc[0, "query"] == "q1"
+        assert frame.loc[0, "chunk"] == "c1"

--- a/tests/unit/core/eval/test_transforms.py
+++ b/tests/unit/core/eval/test_transforms.py
@@ -346,7 +346,7 @@ def test_build_tlmtc_frame_logs_training_duplicate_consolidation(
         build_tlmtc_frame(frame, task=Task.GENERATION, mode="train")
 
     assert caplog.messages == [
-        "Consolidated duplicate eval training rows for generation: input_rows=4 output_rows=1 "
+        "Consolidated duplicate eval rows by majority for generation: input_rows=4 output_rows=1 "
         "collapsed_rows=3 duplicate_units=1 key_columns=('record_uuid',)"
     ]
 


### PR DESCRIPTION
#278 > #282 > #283 > #284 > #279 > #280

---

## Summary

Adds `import_eval_score_frame` as the eval score ingestion boundary, and consolidates multi-annotator inputs into one row per scoring unit.

- **`import_eval_score_frame`** (`core/eval/imports.py`): `read -> (restore tlmtc text columns for prediction inputs) → validate → consolidate → guard`.
- **Majority consolidation** reuses the train-side row consolidation, generalized into a shared **`consolidate_labels_by_majority`** (`core/eval/transforms.py`): per-label strict majority; exact 50/50 tie falls back to a representative row; a no-op when units are already unique. `build_tlmtc_frame` (train) uses the same helper.
- **`_guard_unique_scoring_units`** remains as the post-collapse invariant - it hard-errors only on a residual duplicate the collapse cannot resolve (e.g. two `chunk_id`s sharing a `chunk_rank`).
