### PR TITLE
feat: add public label prediction workflow

### DIFF
--- a/src/pragmata/api/eval.py
+++ b/src/pragmata/api/eval.py
@@ -4,14 +4,19 @@ from pathlib import Path
 from typing import Any
 
 from pragmata.core.eval.export import export_eval_train_meta
-from pragmata.core.eval.imports import import_eval_train_frame
-from pragmata.core.eval.tlmtc_adapters import run_tlmtc_train
+from pragmata.core.eval.imports import import_eval_predict_frame, import_eval_train_frame
+from pragmata.core.eval.tlmtc_adapters import run_tlmtc_predict, run_tlmtc_train
 from pragmata.core.eval.transforms import build_tlmtc_frame
-from pragmata.core.paths.eval_paths import resolve_eval_train_meta_path, resolve_eval_train_paths
+from pragmata.core.paths.eval_paths import (
+    resolve_eval_predict_paths,
+    resolve_eval_train_meta_path,
+    resolve_eval_train_paths,
+    resolve_eval_train_run_id,
+)
 from pragmata.core.paths.paths import WorkspacePaths
 from pragmata.core.schemas.annotation_task import Task
 from pragmata.core.schemas.eval_output import EvalTrainMeta
-from pragmata.core.settings.eval_settings import EvalTrainSettings
+from pragmata.core.settings.eval_settings import EvalPredictSettings, EvalTrainSettings
 from pragmata.core.settings.settings_base import UNSET, Unset, load_config_file
 
 
@@ -121,3 +126,73 @@ def train_evaluator(
     )
 
     return result
+
+
+def predict_labels(
+    *,
+    unlabeled_data_path: str | Path | Unset = UNSET,
+    evaluator_run_id: str | Unset = UNSET,
+    task: str | Task | Unset = UNSET,
+    base_dir: str | Path | Unset = UNSET,
+    config_path: str | Path | Unset = UNSET,
+    predict_kwargs: dict[str, Any] | Unset = UNSET,
+) -> Any:
+    """Predict evaluation labels for an unlabeled Pragmata eval dataset.
+
+    Args:
+        unlabeled_data_path: Direct path to the task-specific unlabeled CSV.
+        evaluator_run_id: Optional evaluator training run identifier. If absent
+            from both the call and configuration, Pragmata selects the latest
+            evaluator compatible with ``task``.
+        task: Evaluation task to predict labels for. Supported values are
+            ``"retrieval"``, ``"grounding"``, and ``"generation"``.
+        base_dir: Workspace base directory. Defaults to the current working
+            directory.
+        config_path: Path to a YAML configuration file.
+        predict_kwargs: Additional tlmtc-owned keyword arguments passed through
+            to ``tlmtc.predict_tlmtc``.
+
+    Returns:
+        Result metadata for the completed tlmtc prediction run. Its ``paths``
+        attribute contains the resolved prediction filesystem layout, including
+        the generated probabilities and predictions CSV artifacts under
+        ``<base_dir>/eval/prediction_outputs/<evaluator_run_id>/``.
+    """
+    settings = EvalPredictSettings.resolve(
+        config=load_config_file(config_path) if isinstance(config_path, (str, Path)) else None,
+        env=None,  # Environment-derived settings are not wired for predict_labels yet.
+        overrides={
+            "base_dir": base_dir,
+            "unlabeled_data_path": unlabeled_data_path,
+            "evaluator_run_id": evaluator_run_id,
+            "task": task,
+            "predict_kwargs": predict_kwargs,
+        },
+    )
+    workspace = WorkspacePaths.from_base_dir(settings.base_dir)
+    predict_paths = resolve_eval_predict_paths(
+        workspace=workspace,
+        unlabeled_data_path=settings.unlabeled_data_path,
+    ).ensure_dirs()
+    resolved_evaluator_run_id = resolve_eval_train_run_id(
+        workspace=workspace,
+        task=settings.task,
+        evaluator_run_id=settings.evaluator_run_id,
+    )
+
+    eval_frame = import_eval_predict_frame(
+        path=predict_paths.prediction_input_csv,
+        task=settings.task,
+    )
+    tlmtc_frame = build_tlmtc_frame(
+        eval_frame,
+        task=settings.task,
+        mode="predict",
+    )
+
+    return run_tlmtc_predict(
+        unlabeled_data=tlmtc_frame,
+        work_dir=predict_paths.tool_root,
+        evaluator_run_id=resolved_evaluator_run_id,
+        predict_kwargs=settings.predict_kwargs,
+    )

--- a/src/pragmata/api/eval.py
+++ b/src/pragmata/api/eval.py
@@ -65,8 +65,7 @@ def train_evaluator(
     Returns:
         Result metadata containing resolved filesystem paths for a single tlmtc
         training run, including the run ID, run directory, model directory,
-        prepared split artifacts, metadata sidecar, and evaluation artifacts
-        under ``<base_dir>/eval/train_outputs/<run_id>/``.
+        prepared split artifacts, metadata sidecar, and evaluation artifacts.
     """
     settings = EvalTrainSettings.resolve(
         config=load_config_file(config_path) if isinstance(config_path, (str, Path)) else None,
@@ -155,8 +154,7 @@ def predict_labels(
     Returns:
         Result metadata for the completed tlmtc prediction run. Its ``paths``
         attribute contains the resolved prediction filesystem layout, including
-        the generated probabilities and predictions CSV artifacts under
-        ``<base_dir>/eval/prediction_outputs/<evaluator_run_id>/``.
+        the generated probabilities and predictions CSV artifacts.
     """
     settings = EvalPredictSettings.resolve(
         config=load_config_file(config_path) if isinstance(config_path, (str, Path)) else None,

--- a/src/pragmata/eval/__init__.py
+++ b/src/pragmata/eval/__init__.py
@@ -1,5 +1,6 @@
 """Public evaluation namespace."""
 
+from pragmata.api.eval import predict_labels as predict_labels
 from pragmata.api.eval import train_evaluator as train_evaluator
 
-__all__ = ["train_evaluator"]
+__all__ = ["predict_labels", "train_evaluator"]

--- a/tests/unit/api/test_eval.py
+++ b/tests/unit/api/test_eval.py
@@ -219,3 +219,153 @@ def test_train_evaluator_resolves_annotation_export_for_selected_task(
         "task": Task.GENERATION,
         "annotation_export_id": "export-1",
     }
+
+
+def test_predict_labels_orchestrates_direct_unlabeled_input(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """predict_labels selects an evaluator, transforms input, and predicts."""
+    input_csv = tmp_path / "unlabeled.csv"
+    input_csv.write_text("placeholder\nvalue\n", encoding="utf-8")
+    eval_frame = pd.DataFrame({"source": ["eval"]})
+    tlmtc_frame = pd.DataFrame({"text": ["query"], "text_pair": ["chunk"]})
+    expected_result = object()
+    calls: dict[str, Any] = {}
+
+    def resolve_eval_train_run_id(
+        *,
+        workspace: WorkspacePaths,
+        task: Task,
+        evaluator_run_id: str | None = None,
+    ) -> str:
+        calls["select"] = {
+            "workspace_base_dir": workspace.base_dir,
+            "task": task,
+            "evaluator_run_id": evaluator_run_id,
+        }
+        return "evaluator-1"
+
+    def import_eval_predict_frame(
+        *,
+        path: Path,
+        task: Task,
+    ) -> pd.DataFrame:
+        calls["import"] = {"path": path, "task": task}
+        return eval_frame
+
+    def build_tlmtc_frame(
+        frame: pd.DataFrame,
+        *,
+        task: Task,
+        mode: str,
+    ) -> pd.DataFrame:
+        calls["transform"] = {"frame": frame, "task": task, "mode": mode}
+        return tlmtc_frame
+
+    def run_tlmtc_predict(
+        **kwargs: Any,
+    ) -> object:
+        calls["predict"] = kwargs
+        return expected_result
+
+    monkeypatch.setattr(eval_api, "resolve_eval_train_run_id", resolve_eval_train_run_id)
+    monkeypatch.setattr(eval_api, "import_eval_predict_frame", import_eval_predict_frame)
+    monkeypatch.setattr(eval_api, "build_tlmtc_frame", build_tlmtc_frame)
+    monkeypatch.setattr(eval_api, "run_tlmtc_predict", run_tlmtc_predict)
+
+    result = eval_api.predict_labels(
+        unlabeled_data_path=input_csv,
+        evaluator_run_id="evaluator-1",
+        task="retrieval",
+        base_dir=tmp_path,
+        predict_kwargs={"batch_size": 8, "use_cpu": True},
+    )
+
+    assert result is expected_result
+    assert calls["select"] == {
+        "workspace_base_dir": tmp_path.resolve(),
+        "task": Task.RETRIEVAL,
+        "evaluator_run_id": "evaluator-1",
+    }
+    assert calls["import"] == {"path": input_csv.resolve(), "task": Task.RETRIEVAL}
+    assert calls["transform"] == {"frame": eval_frame, "task": Task.RETRIEVAL, "mode": "predict"}
+    assert calls["predict"]["unlabeled_data"] is tlmtc_frame
+    assert {key: value for key, value in calls["predict"].items() if key != "unlabeled_data"} == {
+        "work_dir": tmp_path.resolve() / "eval",
+        "evaluator_run_id": "evaluator-1",
+        "predict_kwargs": {"batch_size": 8, "use_cpu": True},
+    }
+    assert (tmp_path / "eval").is_dir()
+
+
+def test_predict_labels_combines_config_and_explicit_overrides(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit predict args override config before automatic evaluator selection."""
+    config_input_csv = tmp_path / "config-unlabeled.csv"
+    override_input_csv = tmp_path / "override-unlabeled.csv"
+    override_input_csv.write_text("placeholder\nvalue\n", encoding="utf-8")
+    config_path = tmp_path / "eval.yml"
+    config_path.write_text(
+        dedent(
+            f"""\
+            base_dir: {tmp_path / "config-workspace"}
+            unlabeled_data_path: {config_input_csv}
+            task: grounding
+            predict_kwargs:
+              batch_size: 8
+              use_cpu: false
+            """
+        ),
+        encoding="utf-8",
+    )
+    tlmtc_frame = pd.DataFrame({"text": ["query"], "text_pair": ["answer"]})
+    expected_result = object()
+    calls: dict[str, Any] = {}
+
+    def resolve_eval_train_run_id(
+        *,
+        workspace: WorkspacePaths,
+        task: Task,
+        evaluator_run_id: str | None = None,
+    ) -> str:
+        calls["select"] = {
+            "workspace_base_dir": workspace.base_dir,
+            "task": task,
+            "evaluator_run_id": evaluator_run_id,
+        }
+        return "latest-generation-evaluator"
+
+    def run_tlmtc_predict(
+        **kwargs: Any,
+    ) -> object:
+        calls["predict"] = kwargs
+        return expected_result
+
+    monkeypatch.setattr(eval_api, "resolve_eval_train_run_id", resolve_eval_train_run_id)
+    monkeypatch.setattr(eval_api, "import_eval_predict_frame", lambda *, path, task: pd.DataFrame({"path": [path]}))
+    monkeypatch.setattr(eval_api, "build_tlmtc_frame", lambda frame, *, task, mode: tlmtc_frame)
+    monkeypatch.setattr(eval_api, "run_tlmtc_predict", run_tlmtc_predict)
+
+    result = eval_api.predict_labels(
+        unlabeled_data_path=override_input_csv,
+        task="generation",
+        base_dir=tmp_path,
+        config_path=config_path,
+        predict_kwargs={"batch_size": 16},
+    )
+
+    assert result is expected_result
+    assert calls["select"] == {
+        "workspace_base_dir": tmp_path.resolve(),
+        "task": Task.GENERATION,
+        "evaluator_run_id": None,
+    }
+    assert calls["predict"]["unlabeled_data"] is tlmtc_frame
+    assert {key: value for key, value in calls["predict"].items() if key != "unlabeled_data"} == {
+        "work_dir": tmp_path.resolve() / "eval",
+        "evaluator_run_id": "latest-generation-evaluator",
+        "predict_kwargs": {"batch_size": 16, "use_cpu": False},
+    }


### PR DESCRIPTION
### Summary

Adds the public `pragmata.eval.predict_labels()` Python workflow for predicting task-specific evaluation labels from unlabeled CSV inputs.

`pragmata` resolves and validates the prediction input, selects a task-compatible evaluator, maps `pragmata` task columns to `tlmtc`'s input contract, and delegates inference to the existing `tlmtc` prediction adapter. The raw `tlmtc` `PredictResult` is returned unchanged.

Only the unlabeled data path and evaluation task are required. If no evaluator run ID is supplied through the call or configuration, `pragmata` selects the latest evaluator compatible with the requested task.

### Changes

- Add the public `predict_labels()` API to `pragmata.api.eval`.
- Resolve prediction settings from an optional YAML configuration and explicit API overrides.
- Preserve `UNSET` semantics so omitted API arguments can fall back to configuration values.
- Resolve the eval workspace and explicit unlabeled prediction input path.
- Select a concrete evaluator run ID through `pragmata`'s task-aware evaluator selector.
- Import and validate the task-specific unlabeled CSV.
- Transform `pragmata` text columns to `tlmtc`'s `text` and `text_pair` contract.
- Pass the transformed in-memory DataFrame, eval work directory, concrete evaluator ID, and `tlmtc`-owned prediction options to the prediction adapter.
- Return `tlmtc`'s `PredictResult` without rewriting its paths or generated artifacts.
- Re-export `predict_labels` through the public `pragmata.eval` namespace.

### Testing

- Covered direct prediction from an explicit unlabeled CSV and evaluator run ID.
- Covered task propagation through evaluator selection, input import, and dataframe transformation.
- Covered forwarding of the transformed DataFrame, concrete evaluator ID, eval work directory, and prediction options.
- Covered automatic task-compatible evaluator selection when no evaluator ID is configured.
- Covered configuration merging and explicit API override precedence.
- Covered returning the raw adapter result unchanged.