### PR TITLE
feat: add predict-labels CLI command

### DIFF
--- a/src/pragmata/cli/commands/eval.py
+++ b/src/pragmata/cli/commands/eval.py
@@ -86,3 +86,53 @@ def train_evaluator_command(
     typer.echo(f"run_id: {result.paths.run_id}")
     typer.echo(f"run_directory: {result.paths.run_dir}")
     typer.echo(f"model_directory: {result.paths.model_dir}")
+
+
+@eval_app.command("predict-labels")
+def predict_command(
+    unlabeled_data_path: str | None = typer.Option(
+        None,
+        "--unlabeled-data-path",
+        help="Path to the task-specific unlabeled eval prediction CSV.",
+    ),
+    evaluator_run_id: str | None = typer.Option(
+        None,
+        "--evaluator-run-id",
+        help="Evaluator training run identifier. If omitted, the latest task-compatible evaluator is used.",
+    ),
+    task: str | None = typer.Option(
+        None,
+        "--task",
+        help="Eval task to predict for: retrieval, grounding, or generation.",
+    ),
+    base_dir: str | None = typer.Option(
+        None,
+        "--base-dir",
+        help="Workspace base directory. Defaults to current working directory.",
+    ),
+    config_path: str | None = typer.Option(
+        None,
+        "--config",
+        help="Path to the config file.",
+    ),
+    predict_kwargs: str | None = typer.Option(
+        None,
+        "--predict-kwargs",
+        help="Additional tlmtc predict_tlmtc keyword arguments. Accepts a JSON object.",
+    ),
+) -> None:
+    """Predict evaluation labels with a trained evaluator."""
+    result = eval.predict_labels(
+        unlabeled_data_path=UNSET if unlabeled_data_path is None else unlabeled_data_path,
+        evaluator_run_id=UNSET if evaluator_run_id is None else evaluator_run_id,
+        task=UNSET if task is None else task,
+        base_dir=UNSET if base_dir is None else base_dir,
+        config_path=UNSET if config_path is None else config_path,
+        predict_kwargs=parse_cli_value(predict_kwargs),
+    )
+
+    typer.echo("Evaluator prediction run complete.")
+    typer.echo(f"evaluator_run_id: {result.paths.run_id}")
+    typer.echo(f"prediction_directory: {result.paths.prediction_run_dir}")
+    typer.echo(f"probabilities: {result.paths.probabilities_path}")
+    typer.echo(f"predictions: {result.paths.predictions_path}")

--- a/tests/unit/cli/test_cli_eval.py
+++ b/tests/unit/cli/test_cli_eval.py
@@ -23,11 +23,29 @@ class _TrainResult:
     paths = _Paths()
 
 
+class _PredictResult:
+    class _Paths:
+        run_id = "train-run-123"
+        prediction_run_dir = Path("workspace/eval/prediction_outputs/train-run-123")
+        probabilities_path = prediction_run_dir / "probabilities.csv"
+        predictions_path = prediction_run_dir / "predictions.csv"
+
+    paths = _Paths()
+
+
 def test_eval_command_registered() -> None:
     result = runner.invoke(app, ["--help"])
 
     assert result.exit_code == 0
     assert "eval" in result.output
+
+
+def test_eval_help_lists_commands() -> None:
+    result = runner.invoke(app, ["eval", "--help"])
+
+    assert result.exit_code == 0
+    assert "train-evaluator" in result.output
+    assert "predict-labels" in result.output
 
 
 class TestTrainEvaluatorCommand:
@@ -50,7 +68,7 @@ class TestTrainEvaluatorCommand:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.setenv("COLUMNS", "200")
-        result = runner.invoke(eval_app, ["--help"], color=False)
+        result = runner.invoke(eval_app, ["train-evaluator", "--help"], color=False)
         output = strip_ansi(result.output)
 
         assert result.exit_code == 0
@@ -79,7 +97,7 @@ class TestTrainEvaluatorCommand:
 
         monkeypatch.setattr("pragmata.eval.train_evaluator", fake_train_evaluator)
 
-        result = runner.invoke(eval_app, [])
+        result = runner.invoke(eval_app, ["train-evaluator"])
 
         expected_keys = {
             "labeled_data_path",
@@ -116,6 +134,7 @@ class TestTrainEvaluatorCommand:
         result = runner.invoke(
             eval_app,
             [
+                "train-evaluator",
                 "--labeled-data-path",
                 "exports/retrieval.csv",
                 "--export-id",
@@ -169,6 +188,7 @@ class TestTrainEvaluatorCommand:
         result = runner.invoke(
             eval_app,
             [
+                "train-evaluator",
                 "--no-scale-learning-rate",
             ],
         )
@@ -188,7 +208,7 @@ class TestTrainEvaluatorCommand:
 
         monkeypatch.setattr("pragmata.eval.train_evaluator", fake_train_evaluator)
 
-        result = runner.invoke(eval_app, ["--scale-learning-rate"])
+        result = runner.invoke(eval_app, ["train-evaluator", "--scale-learning-rate"])
 
         assert result.exit_code == 0
         assert captured["scale_learning_rate"] is True
@@ -202,7 +222,7 @@ class TestTrainEvaluatorCommand:
 
         monkeypatch.setattr("pragmata.eval.train_evaluator", fake_train_evaluator)
 
-        result = runner.invoke(eval_app, [])
+        result = runner.invoke(eval_app, ["train-evaluator"])
 
         assert result.exit_code == 0
         assert "Evaluator training run complete." in result.output
@@ -211,3 +231,95 @@ class TestTrainEvaluatorCommand:
         assert "workspace/eval/train_outputs/train-run-123" in result.output
         assert "model_directory:" in result.output
         assert "workspace/eval/train_outputs/train-run-123/model" in result.output
+
+
+class TestPredictLabelsCommand:
+    """Tests for the eval predict-labels CLI command."""
+
+    def test_help_available(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("COLUMNS", "200")
+        result = runner.invoke(eval_app, ["predict-labels", "--help"], color=False)
+        output = strip_ansi(result.output)
+
+        assert result.exit_code == 0
+        assert "Predict evaluation labels with a trained evaluator." in output
+        assert "--unlabeled-data-path" in output
+        assert "--evaluator-run-id" in output
+        assert "--task" in output
+        assert "--base-dir" in output
+        assert "--config" in output
+        assert "--predict-kwargs" in output
+
+    def test_maps_omitted_options_to_unset(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_predict_labels(**kwargs: Any) -> _PredictResult:
+            captured.update(kwargs)
+            return _PredictResult()
+
+        monkeypatch.setattr("pragmata.eval.predict_labels", fake_predict_labels)
+
+        result = runner.invoke(eval_app, ["predict-labels"])
+
+        assert result.exit_code == 0
+        assert set(captured) == {
+            "unlabeled_data_path",
+            "evaluator_run_id",
+            "task",
+            "base_dir",
+            "config_path",
+            "predict_kwargs",
+        }
+        assert all(value is UNSET for value in captured.values())
+
+    def test_delegates_to_public_api_and_prints_summary(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_predict_labels(**kwargs: Any) -> _PredictResult:
+            captured.update(kwargs)
+            return _PredictResult()
+
+        monkeypatch.setattr("pragmata.eval.predict_labels", fake_predict_labels)
+
+        result = runner.invoke(
+            eval_app,
+            [
+                "predict-labels",
+                "--unlabeled-data-path",
+                "inputs/retrieval.csv",
+                "--evaluator-run-id",
+                "train-run-123",
+                "--task",
+                "retrieval",
+                "--base-dir",
+                "workspace",
+                "--config",
+                "eval.yml",
+                "--predict-kwargs",
+                '{"batch_size": 16, "use_cpu": true, "verbosity": "quiet"}',
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert captured == {
+            "unlabeled_data_path": "inputs/retrieval.csv",
+            "evaluator_run_id": "train-run-123",
+            "task": "retrieval",
+            "base_dir": "workspace",
+            "config_path": "eval.yml",
+            "predict_kwargs": {"batch_size": 16, "use_cpu": True, "verbosity": "quiet"},
+        }
+        assert "Evaluator prediction run complete." in result.output
+        assert "evaluator_run_id: train-run-123" in result.output
+        assert "prediction_directory: workspace/eval/prediction_outputs/train-run-123" in result.output
+        assert "probabilities: workspace/eval/prediction_outputs/train-run-123/probabilities.csv" in result.output
+        assert "predictions: workspace/eval/prediction_outputs/train-run-123/predictions.csv" in result.output

--- a/tests/unit/cli/test_cli_eval.py
+++ b/tests/unit/cli/test_cli_eval.py
@@ -254,6 +254,15 @@ class TestTrainEvaluatorCommand:
 class TestPredictLabelsCommand:
     """Tests for the eval predict-labels CLI command."""
 
+    def test_root_app_help_available(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("COLUMNS", "200")
+        result = runner.invoke(app, ["eval", "predict-labels", "--help"], color=False)
+        output = strip_ansi(result.output)
+
+        assert result.exit_code == 0
+        assert "Predict evaluation labels with a trained evaluator." in output
+        assert "--predict-kwargs" in output
+
     def test_help_available(
         self,
         monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
### Summary

Adds the `pragmata eval predict-labels` command for predicting task-specific evaluation labels with a trained evaluator.

The command is a thin wrapper around the public `pragmata.eval.predict_labels()` API. It preserves configuration fallback for omitted options, parses `tlmtc`-owned prediction arguments from JSON, and prints the artifact paths returned by `tlmtc`.

### Changes

- Register `predict-labels` on the existing eval Typer application.
- Expose unlabeled input path, evaluator run ID, task, workspace, configuration, and prediction keyword options.
- Map omitted CLI options to Pragmata's `UNSET` sentinel.
- Parse `--predict-kwargs` through the existing CLI value parser.
- Delegate exclusively to `pragmata.eval.predict_labels()`.
- Print the selected evaluator ID, prediction directory, probabilities path, and predictions path.

### Testing

- Covered eval help output listing both `train-evaluator` and `predict-labels`.
- Covered the complete `predict-labels` help surface.
- Covered omitted options mapping to `UNSET`.
- Covered explicit option forwarding and JSON prediction-kwargs parsing.
- Covered completion output using the returned prediction artifact paths.