### PR TITLE
ci: add package build validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v7
 
     - name: Set up uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.2.0
       with:
         version: ${{ env.UV_VERSION }}
         enable-cache: true
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
@@ -98,3 +98,27 @@ jobs:
 
       - name: Run packaging tests
         run: uv run pytest -m packaging -q
+
+  build:
+    name: Build package
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Set up Python
+        run: uv python install ${{ env.PYTHON_VERSION }}
+
+      - name: Check lockfile is current
+        run: uv lock --check
+
+      - name: Build package
+        run: uv build


### PR DESCRIPTION
### Summary

Adds package build validation to the regular CI workflow so packaging failures are detected before release tags are created.

### Changes

- Add an independent CI job that builds the wheel and source distribution with `uv build`.
- Verify that the lockfile is current before building.
- Update all CI jobs to use `astral-sh/setup-uv@v8.2.0`.