### PR TITLE
chore: prepare package metadata for PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,29 @@ authors =[
   { name = "Luis Fernando Ramírez Ruiz" },
 ]
 readme = "README.md"
-license = { file = "LICENSE.md" }
+license = "MIT"
+license-files = ["LICENSE.md"]
 requires-python = ">=3.12"
+keywords = [
+    "rag",
+    "retrieval-augmented generation",
+    "evaluation",
+    "query generation",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Information Technology",
+    "Intended Audience :: Science/Research",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Scientific/Engineering :: Information Analysis",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
 
 dependencies = [
     "typer>=0.9,<1.0",
@@ -21,6 +42,13 @@ dependencies = [
     "langchain-mistralai>=1.1,<2.0",
     "numpy>=2.3,<3.0",
 ]
+
+[project.urls]
+Homepage = "https://bertelsmannstift.github.io/pragmata/"
+Documentation = "https://bertelsmannstift.github.io/pragmata/docs/introduction"
+Repository = "https://github.com/bertelsmannstift/pragmata"
+Issues = "https://github.com/bertelsmannstift/pragmata/issues"
+"Release Notes" = "https://github.com/bertelsmannstift/pragmata/releases"
 
 [project.optional-dependencies]
 test = [
@@ -48,7 +76,7 @@ dev  = ["pragmata[test,lint,type,annotation,querygen,eval]"]
 pragmata = "pragmata.cli.app:app"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.27"]
 build-backend = "hatchling.build"
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,9 @@ requires-python = ">=3.12"
 keywords = [
     "rag",
     "retrieval-augmented generation",
-    "evaluation",
-    "query generation",
+    "rag evaluation",
+    "synthetic query generation",
+    "rag annotation",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",


### PR DESCRIPTION
### Summary

Prepares the package metadata for an eventual initial PyPI release without changing the current package version.

The project now declares its license using the current SPDX-based metadata format and provides focused discovery metadata, supported-environment classifiers, and links to the project’s documentation and development resources.

### Changes

- Replace the deprecated license table with the SPDX expression `MIT`.
- Explicitly include `LICENSE.md` in package distributions.
- Add focused keywords for RAG evaluation and query generation.
- Classify the project as Alpha-stage, console-accessible, and OS-independent.
- Add intended-audience, supported-Python, artificial-intelligence, information-analysis, and Python-library classifiers.
- Add homepage, documentation, repository, issue-tracker, and release-note URLs.
- Require Hatchling 1.27 or newer for PEP 639 and Core Metadata 2.4 support.