### PR TITLE
fix(annotation): isolate integration tests on ephemeral Argilla stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,16 @@
 COMPOSE_FILE := deploy/annotation/docker-compose.dev.yml
 ENV_FILE     := deploy/annotation/.env
 ENV_EXAMPLE  := deploy/annotation/.env.dev.example
-TEST_PROJECT := pragmata-test
 
-.PHONY: docker-up docker-up-external-pg docker-up-external-es docker-up-external docker-down docker-down-clean docker-stop docker-logs docker-status ensure-env lint type-check test-stack test test-integration test-all ci
+# One throwaway stack for all test targets — an isolated Compose project on a
+# non-default host port so its destructive setup/teardown can never touch the
+# live stack (Compose project 'annotation') on :6900. The -p project scope
+# always wins over the shared compose file, so containers/volumes stay disjoint.
+# test-stack and test-integration/test-all share it (they never run at once).
+TEST_STACK_PROJECT := pragmata-test
+TEST_STACK_PORT    := 6901
+
+.PHONY: docker-up docker-up-external-pg docker-up-external-es docker-up-external docker-down docker-down-clean docker-stop docker-logs docker-status ensure-env lint type-check test-stack test-unit test-integration test-all ci
 
 # Profiles: all-bundled (default), external-pg (ext Postgres), external-es (ext ES), no profile (all external)
 ALL_PROFILES := --profile all-bundled --profile external-pg --profile external-es
@@ -62,22 +69,42 @@ type-check: ## Run mypy type checker
 	uv run mypy src/pragmata
 
 # ── Test suites ──────────────────────────────────────────────────────
+#
+#   test-unit         unit tests only — no stack, fast (default dev loop)
+#   test-integration  integration tests on a throwaway isolated stack
+#   test-all          every test (unit + integration + packaging) on that stack
+#   test-stack        stack health smoke test (isolated project + port)
+#
+# test-integration / test-all stand up an ephemeral Argilla on :$(TEST_STACK_PORT)
+# under an isolated Compose project, point the tests at it via
+# PRAGMATA_TEST_ARGILLA_URL, and always tear it down (volumes included). The live
+# stack on :6900 is never touched. Integration tests also
+# refuse to run unless PRAGMATA_TEST_ARGILLA_URL is set (tests/conftest.py), so a
+# bare `pytest -m integration` can't fall back to :6900 either.
 
-test: ## Run unit tests (default — excludes integration)
+test-unit: ## Run unit tests only — no stack (fast default loop)
 	python -m pytest
 
-test-stack: ensure-env ## Smoke-test the stack in an isolated Compose project
+test-integration: PYTEST_SELECT := -m integration
+test-all:         PYTEST_SELECT :=
+test-integration test-all: ensure-env
 	@set -e; \
-	trap 'docker compose -p $(TEST_PROJECT) -f $(COMPOSE_FILE) --env-file $(ENV_FILE) $(ALL_PROFILES) down -v >/dev/null' EXIT; \
-	docker compose -p $(TEST_PROJECT) -f $(COMPOSE_FILE) --env-file $(ENV_FILE) --profile all-bundled up -d --pull always --wait --remove-orphans; \
-	python3 -c "import urllib.request; r = urllib.request.urlopen(urllib.request.Request('http://localhost:6900/api/v1/me', headers={'X-Argilla-Api-Key': 'argilla.apikey'}), timeout=10); assert r.status == 200" \
-		|| { echo "Stack health check failed"; exit 1; }; \
-	echo "Stack smoke test passed (isolated project '$(TEST_PROJECT)' torn down, volumes cleaned up)"
+	export ARGILLA_PORT=$(TEST_STACK_PORT); \
+	trap 'docker compose -p $(TEST_STACK_PROJECT) -f $(COMPOSE_FILE) --env-file $(ENV_FILE) $(ALL_PROFILES) down -v >/dev/null 2>&1' EXIT; \
+	docker compose -p $(TEST_STACK_PROJECT) -f $(COMPOSE_FILE) --env-file $(ENV_FILE) --profile all-bundled up -d --pull always --wait --remove-orphans; \
+	API_KEY=$$(. $(ENV_FILE); echo $${ARGILLA_API_KEY:-argilla.apikey}); \
+	PRAGMATA_TEST_ARGILLA_URL=http://localhost:$(TEST_STACK_PORT) \
+	PRAGMATA_TEST_ARGILLA_API_KEY=$$API_KEY \
+		python -m pytest -o "addopts=" $(PYTEST_SELECT)
 
-test-integration: ## Run integration tests (requires running Argilla stack)
-	python -m pytest -o "addopts=" -m integration
+test-stack: ensure-env ## Smoke-test the stack in an isolated Compose project + port (never touches :6900)
+	@set -e; \
+	export ARGILLA_PORT=$(TEST_STACK_PORT); \
+	trap 'docker compose -p $(TEST_STACK_PROJECT) -f $(COMPOSE_FILE) --env-file $(ENV_FILE) $(ALL_PROFILES) down -v >/dev/null 2>&1' EXIT; \
+	docker compose -p $(TEST_STACK_PROJECT) -f $(COMPOSE_FILE) --env-file $(ENV_FILE) --profile all-bundled up -d --pull always --wait --remove-orphans; \
+	API_KEY=$$(. $(ENV_FILE); echo $${ARGILLA_API_KEY:-argilla.apikey}); \
+	python3 -c "import urllib.request; r = urllib.request.urlopen(urllib.request.Request('http://localhost:$(TEST_STACK_PORT)/api/v1/me', headers={'X-Argilla-Api-Key': '$$API_KEY'}), timeout=10); assert r.status == 200" \
+		|| { echo 'Stack health check failed'; exit 1; }; \
+	echo "Stack smoke test passed (isolated project '$(TEST_STACK_PROJECT)' on :$(TEST_STACK_PORT), torn down + volumes cleaned)"
 
-test-all: ## Run all tests
-	python -m pytest -o "addopts="
-
-ci: lint type-check test ## Run full CI locally (lint + type-check + unit tests)
+ci: lint type-check test-unit ## Run full CI locally (lint + type-check + unit tests)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,14 @@
 """Shared pytest configuration and fixtures."""
 
+import os
 import shutil
 import socket
 import subprocess
 import urllib.error
 import urllib.request
+import warnings
 from dataclasses import dataclass
+from urllib.parse import urlsplit
 
 import pytest
 
@@ -14,6 +17,27 @@ ARGILLA_DEFAULT_PORT = 6900
 ARGILLA_DEFAULT_API_KEY = "argilla.apikey"
 _CONNECT_TIMEOUT_S = 2
 _HTTP_TIMEOUT_S = 3
+
+
+def argilla_api_url() -> str:
+    """Base URL of the Argilla stack under test.
+
+    Defaults to the live dev stack on ``localhost:6900``; override via
+    ``PRAGMATA_TEST_ARGILLA_URL`` to point integration tests at an ephemeral
+    isolated stack (see ``make test-integration``) so destructive
+    setup/teardown never touches a shared or live deployment.
+    """
+    return os.environ.get("PRAGMATA_TEST_ARGILLA_URL", f"http://{ARGILLA_DEFAULT_HOST}:{ARGILLA_DEFAULT_PORT}")
+
+
+def argilla_api_key() -> str:
+    """API key for the Argilla stack under test (override via ``PRAGMATA_TEST_ARGILLA_API_KEY``)."""
+    return os.environ.get("PRAGMATA_TEST_ARGILLA_API_KEY", ARGILLA_DEFAULT_API_KEY)
+
+
+def _argilla_host_port() -> tuple[str, int]:
+    parts = urlsplit(argilla_api_url())
+    return parts.hostname or ARGILLA_DEFAULT_HOST, parts.port or ARGILLA_DEFAULT_PORT
 
 
 @dataclass(frozen=True)
@@ -36,9 +60,10 @@ class AnnotationStackStatus:
         if not self.docker_daemon:
             return "Docker daemon not running (start Docker, then retry)"
         if not self.argilla_tcp:
-            return f"Argilla not reachable at {ARGILLA_DEFAULT_HOST}:{ARGILLA_DEFAULT_PORT} (try: make docker-up)"
+            host, port = _argilla_host_port()
+            return f"Argilla not reachable at {host}:{port} (try: make docker-up)"
         if not self.argilla_api:
-            return f"Argilla API not responding at http://{ARGILLA_DEFAULT_HOST}:{ARGILLA_DEFAULT_PORT}"
+            return f"Argilla API not responding at {argilla_api_url()}"
         return None
 
 
@@ -62,8 +87,9 @@ def _docker_daemon_running() -> bool:
 
 
 def _argilla_tcp_open() -> bool:
+    host, port = _argilla_host_port()
     try:
-        with socket.create_connection((ARGILLA_DEFAULT_HOST, ARGILLA_DEFAULT_PORT), timeout=_CONNECT_TIMEOUT_S):
+        with socket.create_connection((host, port), timeout=_CONNECT_TIMEOUT_S):
             return True
     except OSError:
         return False
@@ -72,8 +98,8 @@ def _argilla_tcp_open() -> bool:
 def _argilla_api_healthy() -> bool:
     try:
         req = urllib.request.Request(
-            f"http://{ARGILLA_DEFAULT_HOST}:{ARGILLA_DEFAULT_PORT}/api/v1/me",
-            headers={"X-Argilla-Api-Key": ARGILLA_DEFAULT_API_KEY},
+            f"{argilla_api_url()}/api/v1/me",
+            headers={"X-Argilla-Api-Key": argilla_api_key()},
         )
         with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_S) as resp:
             return resp.status == 200
@@ -97,6 +123,44 @@ def _check_annotation_stack() -> AnnotationStackStatus:
 def pytest_configure(config: pytest.Config) -> None:
     """Run annotation stack preflight once at session start, cache on config."""
     config.stash[_STACK_STATUS_KEY] = _check_annotation_stack()
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Fail-closed guard for destructive annotation integration tests.
+
+    Runs ``trylast`` so pytest's own ``-m`` marker filtering happens first: on a
+    unit run the annotation items are already gone and this is a silent no-op;
+    only a run that actually selects them (e.g. ``-m integration``) triggers the
+    deselection + warning below.
+
+    The annotation integration suite runs destructive setup/teardown (workspace
+    and user deletion) against whatever ``argilla_api_url()`` resolves to, which
+    defaults to the shared dev stack on :6900. To make it impossible to wipe a
+    live or shared stack by accident, these tests are *deselected at collection
+    time* unless ``PRAGMATA_TEST_ARGILLA_URL`` is explicitly set.
+
+    ``make test-integration`` sets it to a throwaway isolated stack; a bare
+    ``pytest`` run without it collects zero annotation tests, so no fixture at
+    any scope is instantiated and no teardown ever fires. Deselection — rather
+    than a skip marker — is what guarantees the module-scoped ``clean_environment``
+    fixtures never run.
+    """
+    if os.environ.get("PRAGMATA_TEST_ARGILLA_URL"):
+        return
+    selected, deselected = [], []
+    for item in items:
+        (deselected if item.get_closest_marker("annotation") else selected).append(item)
+    if deselected:
+        config.hook.pytest_deselected(items=deselected)
+        items[:] = selected
+        warnings.warn(
+            f"Deselected {len(deselected)} annotation integration test(s): PRAGMATA_TEST_ARGILLA_URL "
+            "is unset, so they will not run against the default Argilla stack on :6900. Use "
+            "`make test-integration` (ephemeral isolated stack) or set PRAGMATA_TEST_ARGILLA_URL "
+            "to a disposable target.",
+            stacklevel=2,
+        )
 
 
 def _stack_layer_lines(status: AnnotationStackStatus) -> list[tuple[str, bool]]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,6 @@ import socket
 import subprocess
 import urllib.error
 import urllib.request
-import warnings
 from dataclasses import dataclass
 from urllib.parse import urlsplit
 
@@ -129,37 +128,33 @@ def pytest_configure(config: pytest.Config) -> None:
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
     """Fail-closed guard for destructive annotation integration tests.
 
-    Runs ``trylast`` so pytest's own ``-m`` marker filtering happens first: on a
-    unit run the annotation items are already gone and this is a silent no-op;
-    only a run that actually selects them (e.g. ``-m integration``) triggers the
-    deselection + warning below.
-
     The annotation integration suite runs destructive setup/teardown (workspace
     and user deletion) against whatever ``argilla_api_url()`` resolves to, which
-    defaults to the shared dev stack on :6900. To make it impossible to wipe a
-    live or shared stack by accident, these tests are *deselected at collection
-    time* unless ``PRAGMATA_TEST_ARGILLA_URL`` is explicitly set.
+    defaults to the shared dev stack on :6900. Running it must be a deliberate
+    act pointed at a disposable stack, never an accident against a live one.
 
-    ``make test-integration`` sets it to a throwaway isolated stack; a bare
-    ``pytest`` run without it collects zero annotation tests, so no fixture at
-    any scope is instantiated and no teardown ever fires. Deselection — rather
-    than a skip marker — is what guarantees the module-scoped ``clean_environment``
-    fixtures never run.
+    Runs ``trylast`` so pytest's own ``-m`` filtering happens first. If any
+    ``annotation`` item survives to here, the run *explicitly selected* it — so
+    when ``PRAGMATA_TEST_ARGILLA_URL`` is unset we abort the whole session with
+    a clear error rather than silently dropping those tests (a green-but-vacuous
+    run is worse than a loud failure — a CI gate would pass having tested
+    nothing). On an ordinary unit run the ``-m 'not integration'`` default has
+    already removed every annotation item, so this hook is a no-op.
+
+    ``UsageError`` raised at collection time aborts before any fixture is
+    instantiated, so the module-scoped ``clean_environment`` teardown never
+    fires — this is what makes the guard safe as well as loud. ``make
+    test-integration`` sets the env var to a throwaway isolated stack.
     """
     if os.environ.get("PRAGMATA_TEST_ARGILLA_URL"):
         return
-    selected, deselected = [], []
-    for item in items:
-        (deselected if item.get_closest_marker("annotation") else selected).append(item)
-    if deselected:
-        config.hook.pytest_deselected(items=deselected)
-        items[:] = selected
-        warnings.warn(
-            f"Deselected {len(deselected)} annotation integration test(s): PRAGMATA_TEST_ARGILLA_URL "
-            "is unset, so they will not run against the default Argilla stack on :6900. Use "
-            "`make test-integration` (ephemeral isolated stack) or set PRAGMATA_TEST_ARGILLA_URL "
-            "to a disposable target.",
-            stacklevel=2,
+    annotation_items = [item for item in items if item.get_closest_marker("annotation")]
+    if annotation_items:
+        raise pytest.UsageError(
+            f"{len(annotation_items)} annotation integration test(s) selected but "
+            "PRAGMATA_TEST_ARGILLA_URL is unset. These run destructive setup/teardown and "
+            "default to the Argilla stack on :6900. Run `make test-integration` (ephemeral "
+            "isolated stack), or set PRAGMATA_TEST_ARGILLA_URL to a disposable target."
         )
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,32 @@
+"""Shared fixtures for annotation integration tests.
+
+Every annotation integration module talks to the same Argilla stack under test
+and isolates its filesystem state per test, so ``client`` and ``base_dir`` live
+here rather than being re-derived (and drifting) in each module.
+"""
+
+from pathlib import Path
+
+import argilla as rg
+import pytest
+
+from tests.conftest import argilla_api_key, argilla_api_url
+
+
+@pytest.fixture(scope="module")
+def client(annotation_stack_status) -> rg.Argilla:
+    """Argilla client for the stack under test; skips the module if it isn't ready."""
+    if not annotation_stack_status.ready:
+        pytest.skip(annotation_stack_status.skip_reason or "annotation stack not ready")
+    return rg.Argilla(api_url=argilla_api_url(), api_key=argilla_api_key())
+
+
+@pytest.fixture()
+def base_dir(tmp_path: Path) -> Path:
+    """Per-test workspace so each test owns its partition manifest.
+
+    Without this, tests sharing ``base_dir=cwd`` also share one persistent
+    manifest; an earlier default-fraction import would lock records into
+    calibration and skew later ``calibration_fraction=0.0`` assertions.
+    """
+    return tmp_path

--- a/tests/integration/test_annotation_calibration.py
+++ b/tests/integration/test_annotation_calibration.py
@@ -1,13 +1,15 @@
 """Integration tests for the calibration / production split against a live Argilla.
 
 Run with: pytest tests/integration/test_annotation_calibration.py -m "integration and annotation" -v
-Requires: make setup (Argilla stack running on localhost:6900)
+Requires: an Argilla stack. `make test-integration` stands up an ephemeral one and
+targets it via PRAGMATA_TEST_ARGILLA_URL / PRAGMATA_TEST_ARGILLA_API_KEY.
 """
 
 from pathlib import Path
 
 import argilla as rg
 import pytest
+import yaml
 
 from pragmata.api.annotation_import import import_records
 from pragmata.core.annotation.argilla_task_definitions import dataset_name
@@ -16,12 +18,13 @@ from pragmata.core.paths.annotation_paths import resolve_import_paths
 from pragmata.core.paths.paths import WorkspacePaths
 from pragmata.core.schemas.annotation_import import PartitionManifest
 from pragmata.core.schemas.annotation_task import Task
-from pragmata.core.settings.annotation_settings import AnnotationSettings, TaskSettings, WorkspaceSettings
+from pragmata.core.settings.annotation_settings import AnnotationSettings
+from tests.conftest import argilla_api_key, argilla_api_url
 
 pytestmark = [pytest.mark.integration, pytest.mark.annotation]
 
-_API_URL = "http://localhost:6900"
-_API_KEY = "argilla.apikey"
+_API_URL = argilla_api_url()
+_API_KEY = argilla_api_key()
 _DATASET_ID = "testcalibration"
 _CREDS: dict[str, str] = {"api_url": _API_URL, "api_key": _API_KEY}
 
@@ -47,23 +50,12 @@ def _manifest_path(base_dir: Path, dataset_id: str) -> Path:
     return resolve_import_paths(workspace=workspace, dataset_id=dataset_id).partition_manifest
 
 
-@pytest.fixture(scope="module")
-def client() -> rg.Argilla:
-    return rg.Argilla(api_url=_API_URL, api_key=_API_KEY)
-
-
 @pytest.fixture(autouse=True, scope="module")
 def clean_environment(client: rg.Argilla):
     teardown_resources(client, _SETTINGS)
     setup_workspaces(client, _SETTINGS)
     yield
     teardown_resources(client, _SETTINGS)
-
-
-@pytest.fixture()
-def base_dir(tmp_path: Path) -> Path:
-    """Per-test workspace so each test owns its partition manifest."""
-    return tmp_path
 
 
 # ---------------------------------------------------------------------------
@@ -255,20 +247,29 @@ class TestPerWorkspaceMinSubmitted:
         ``distribution.min_submitted`` must reflect the inherited value (4).
         """
         auto_id = "testcarveout"
-        carved_settings = AnnotationSettings(
-            dataset_id=auto_id,
-            production_min_submitted=1,
-            workspaces={
-                "retrieval": WorkspaceSettings(
-                    production_min_submitted=2,
-                    tasks={Task.RETRIEVAL: TaskSettings(production_min_submitted=4)},
-                ),
-                "grounding": WorkspaceSettings(tasks={Task.GROUNDING: TaskSettings()}),
-                "generation": WorkspaceSettings(tasks={Task.GENERATION: TaskSettings()}),
+        # Single source for the carve-out topology: deployment default 1, retrieval
+        # workspace 2, retrieval task 4. The same dict drives both setup/teardown
+        # (via resolve) and the lazy dataset creation inside import_records (via the
+        # YAML config) — datasets are created by import_records, not setup_workspaces,
+        # and a YAML config is the only user-facing channel for nested per-task
+        # overrides (import_records has no kwarg for them).
+        carveout = {
+            "production_min_submitted": 1,
+            "workspaces": {
+                "retrieval": {
+                    "production_min_submitted": 2,
+                    "tasks": {"retrieval": {"production_min_submitted": 4}},
+                },
+                "grounding": {"tasks": {"grounding": {}}},
+                "generation": {"tasks": {"generation": {}}},
             },
-        )
+        }
+        carved_settings = AnnotationSettings.resolve(config=carveout, overrides={"dataset_id": auto_id})
         teardown_resources(client, carved_settings)
         setup_workspaces(client, carved_settings)
+
+        config_path = base_dir / "carveout.yaml"
+        config_path.write_text(yaml.safe_dump(carveout), encoding="utf-8")
 
         try:
             records = [_make_raw(i) for i in range(3)]
@@ -276,6 +277,7 @@ class TestPerWorkspaceMinSubmitted:
                 records,
                 dataset_id=auto_id,
                 base_dir=base_dir,
+                config_path=config_path,
                 calibration_fraction=0.0,
                 **_CREDS,
             )

--- a/tests/integration/test_annotation_import.py
+++ b/tests/integration/test_annotation_import.py
@@ -1,8 +1,11 @@
 """Integration tests for annotation import against a live Argilla server.
 
 Run with: pytest tests/integration/test_annotation_import.py -m "integration and annotation" -v
-Requires: make setup (Argilla stack running on localhost:6900)
+Requires: an Argilla stack. `make test-integration` stands up an ephemeral one and
+targets it via PRAGMATA_TEST_ARGILLA_URL / PRAGMATA_TEST_ARGILLA_API_KEY.
 """
+
+from pathlib import Path
 
 import argilla as rg
 import pytest
@@ -10,12 +13,13 @@ import pytest
 from pragmata.api.annotation_import import ImportResult, import_records
 from pragmata.core.annotation.setup import setup_workspaces, teardown_resources
 from pragmata.core.settings.annotation_settings import AnnotationSettings
+from tests.conftest import argilla_api_key, argilla_api_url
 from tests.integration._argilla_cleanup import purge_workspace_datasets
 
 pytestmark = [pytest.mark.integration, pytest.mark.annotation]
 
-_API_URL = "http://localhost:6900"
-_API_KEY = "argilla.apikey"
+_API_URL = argilla_api_url()
+_API_KEY = argilla_api_key()
 _DATASET_ID = "testimport"
 _CREDS: dict[str, str] = {"api_url": _API_URL, "api_key": _API_KEY}
 
@@ -33,13 +37,6 @@ def _make_raw(n_chunks: int = 2, *, language: str | None = "de") -> dict:
         "context_set": "ctx-001",
         "language": language,
     }
-
-
-@pytest.fixture(scope="module")
-def client(annotation_stack_status) -> rg.Argilla:
-    if not annotation_stack_status.ready:
-        pytest.skip(annotation_stack_status.skip_reason or "annotation stack not ready")
-    return rg.Argilla(api_url=_API_URL, api_key=_API_KEY)
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -73,12 +70,12 @@ def sample_records() -> list[dict]:
 # ---------------------------------------------------------------------------
 
 
-def test_import_result_type(client: rg.Argilla, sample_records: list[dict]) -> None:
-    result = import_records(sample_records, dataset_id=_DATASET_ID, **_CREDS)
+def test_import_result_type(client: rg.Argilla, sample_records: list[dict], base_dir: Path) -> None:
+    result = import_records(sample_records, dataset_id=_DATASET_ID, base_dir=base_dir, **_CREDS)
     assert isinstance(result, ImportResult)
 
 
-def test_record_counts_per_dataset(client: rg.Argilla, sample_records: list[dict]) -> None:
+def test_record_counts_per_dataset(client: rg.Argilla, sample_records: list[dict], base_dir: Path) -> None:
     """Retrieval: sum(chunks), grounding: N, generation: N."""
     n_records = len(sample_records)
     n_retrieval = sum(len(r["chunks"]) for r in sample_records)  # 3 + 2 = 5
@@ -86,6 +83,7 @@ def test_record_counts_per_dataset(client: rg.Argilla, sample_records: list[dict
     result = import_records(
         sample_records,
         dataset_id=_DATASET_ID,
+        base_dir=base_dir,
         calibration_fraction=0.0,
         **_CREDS,
     )
@@ -102,9 +100,9 @@ def test_record_counts_per_dataset(client: rg.Argilla, sample_records: list[dict
     assert result.dataset_counts[gen_ds_name] == n_records
 
 
-def test_records_exist_in_argilla(client: rg.Argilla, sample_records: list[dict]) -> None:
+def test_records_exist_in_argilla(client: rg.Argilla, sample_records: list[dict], base_dir: Path) -> None:
     """After import, all three datasets contain records."""
-    import_records(sample_records, dataset_id=_DATASET_ID, calibration_fraction=0.0, **_CREDS)
+    import_records(sample_records, dataset_id=_DATASET_ID, base_dir=base_dir, calibration_fraction=0.0, **_CREDS)
 
     ret_ds = client.datasets(f"retrieval_production_{_DATASET_ID}", workspace="retrieval")
     gnd_ds = client.datasets(f"grounding_production_{_DATASET_ID}", workspace="grounding")
@@ -120,9 +118,9 @@ def test_records_exist_in_argilla(client: rg.Argilla, sample_records: list[dict]
     assert len(list(gen_ds.records)) > 0
 
 
-def test_record_uuid_linkage(client: rg.Argilla, sample_records: list[dict]) -> None:
+def test_record_uuid_linkage(client: rg.Argilla, sample_records: list[dict], base_dir: Path) -> None:
     """record_uuid metadata appears in all three datasets and intersects."""
-    import_records(sample_records, dataset_id=_DATASET_ID, calibration_fraction=0.0, **_CREDS)
+    import_records(sample_records, dataset_id=_DATASET_ID, base_dir=base_dir, calibration_fraction=0.0, **_CREDS)
 
     def _uuids(ds_name: str, ws_name: str) -> set[str]:
         ds = client.datasets(ds_name, workspace=ws_name)
@@ -137,15 +135,15 @@ def test_record_uuid_linkage(client: rg.Argilla, sample_records: list[dict]) -> 
     assert len(ret_uuids) == len(sample_records)
 
 
-def test_idempotent_reimport(client: rg.Argilla, sample_records: list[dict]) -> None:
+def test_idempotent_reimport(client: rg.Argilla, sample_records: list[dict], base_dir: Path) -> None:
     """Calling import_records twice with same data produces same record count.
 
     Idempotency relies on deterministic Record.id values derived from content hashes
     (derive_record_uuid). Argilla upserts on Record.id, so identical IDs on the second
     import overwrite existing records rather than creating duplicates.
     """
-    import_records(sample_records, dataset_id=_DATASET_ID, calibration_fraction=0.0, **_CREDS)
-    import_records(sample_records, dataset_id=_DATASET_ID, calibration_fraction=0.0, **_CREDS)
+    import_records(sample_records, dataset_id=_DATASET_ID, base_dir=base_dir, calibration_fraction=0.0, **_CREDS)
+    import_records(sample_records, dataset_id=_DATASET_ID, base_dir=base_dir, calibration_fraction=0.0, **_CREDS)
 
     ret_ds = client.datasets(f"retrieval_production_{_DATASET_ID}", workspace="retrieval")
     gnd_ds = client.datasets(f"grounding_production_{_DATASET_ID}", workspace="grounding")
@@ -159,11 +157,11 @@ def test_idempotent_reimport(client: rg.Argilla, sample_records: list[dict]) -> 
     assert len(list(gen_ds.records)) == n_records
 
 
-def test_invalid_records_skipped_with_errors(client: rg.Argilla) -> None:
+def test_invalid_records_skipped_with_errors(client: rg.Argilla, base_dir: Path) -> None:
     """Invalid dicts are reported as errors, not sent to Argilla."""
     raw = [{"query": "no answer or chunks"}, _make_raw(1)]
 
-    result = import_records(raw, dataset_id=_DATASET_ID, calibration_fraction=0.0, **_CREDS)
+    result = import_records(raw, dataset_id=_DATASET_ID, base_dir=base_dir, calibration_fraction=0.0, **_CREDS)
 
     assert result.total_records == 2
     assert len(result.errors) == 1
@@ -172,7 +170,7 @@ def test_invalid_records_skipped_with_errors(client: rg.Argilla) -> None:
     assert sum(result.dataset_counts.values()) > 0
 
 
-def test_dataset_auto_creation(client: rg.Argilla) -> None:
+def test_dataset_auto_creation(client: rg.Argilla, base_dir: Path) -> None:
     """Import auto-creates datasets when they don't exist."""
     auto_id = "autotest"
     auto_settings = AnnotationSettings(dataset_id=auto_id)
@@ -181,7 +179,7 @@ def test_dataset_auto_creation(client: rg.Argilla) -> None:
     teardown_resources(client, auto_settings)
 
     # Import without prior setup_datasets — datasets should be auto-created
-    result = import_records([_make_raw(1)], dataset_id=auto_id, calibration_fraction=0.0, **_CREDS)
+    result = import_records([_make_raw(1)], dataset_id=auto_id, base_dir=base_dir, calibration_fraction=0.0, **_CREDS)
 
     assert result.total_records == 1
     assert result.errors == []

--- a/tests/integration/test_annotation_setup.py
+++ b/tests/integration/test_annotation_setup.py
@@ -1,7 +1,8 @@
 """Integration tests for annotation setup against a live Argilla server.
 
 Run with: pytest tests/integration/test_annotation_setup.py -m "integration and annotation" -v
-Requires: make setup (Argilla stack running on localhost:6900)
+Requires: an Argilla stack. `make test-integration` stands up an ephemeral one and
+targets it via PRAGMATA_TEST_ARGILLA_URL / PRAGMATA_TEST_ARGILLA_API_KEY.
 """
 
 import argilla as rg
@@ -18,18 +19,9 @@ from tests.integration._argilla_cleanup import purge_workspace_datasets
 
 pytestmark = [pytest.mark.integration, pytest.mark.annotation]
 
-_API_URL = "http://localhost:6900"
-_API_KEY = "argilla.apikey"
 _TEST_USER = "test_annotator_integration"
 
 _DEFAULT_SETTINGS = AnnotationSettings()
-
-
-@pytest.fixture(scope="module")
-def client(annotation_stack_status) -> rg.Argilla:
-    if not annotation_stack_status.ready:
-        pytest.skip(annotation_stack_status.skip_reason or "annotation stack not ready")
-    return rg.Argilla(api_url=_API_URL, api_key=_API_KEY)
 
 
 @pytest.fixture(autouse=True, scope="module")

--- a/tests/integration/test_dev_stack_integration.py
+++ b/tests/integration/test_dev_stack_integration.py
@@ -10,14 +10,16 @@ import urllib.request
 
 import pytest
 
+from tests.conftest import argilla_api_key, argilla_api_url
+
 pytestmark = [pytest.mark.integration, pytest.mark.annotation]
 
 
 def test_argilla_api_authenticated_as_owner() -> None:
     """Argilla API accepts the configured API key and returns the owner account."""
     req = urllib.request.Request(
-        "http://localhost:6900/api/v1/me",
-        headers={"X-Argilla-Api-Key": "argilla.apikey"},
+        f"{argilla_api_url()}/api/v1/me",
+        headers={"X-Argilla-Api-Key": argilla_api_key()},
     )
     with urllib.request.urlopen(req, timeout=10) as resp:
         assert resp.status == 200

--- a/tests/unit/test_dev_stack.py
+++ b/tests/unit/test_dev_stack.py
@@ -22,7 +22,7 @@ EXPECTED_MAKE_TARGETS = {
     "docker-logs",
     "docker-status",
     "test-stack",
-    "test",
+    "test-unit",
     "test-integration",
     "test-all",
 }


### PR DESCRIPTION
### Summary

There were 3 failing integration tests failed on shared state & the annotation integration suite ran destructive setup/teardown against whatever was on `localhost:6900` (the live annotation stack). This makes suite run against an ephemeral, port-isolated stack that is never the live one, and fixes the failures.

### Changes

- **Fix the 3 failing tests (isolation bugs):**
  - Per-test `base_dir` gives each test a fresh partition manifest (previously all shared one under cwd), fixing the record-count and idempotency assertions.
  - The per-workspace `min_submitted` carve-out test now feeds its topology through a YAML config, so the dataset that `import_records` lazily creates actually gets the intended `min_submitted` (`setup_workspaces` only creates workspaces).
- **Ephemeral, isolated test stack:** tests resolve the target via `PRAGMATA_TEST_ARGILLA_URL` / `PRAGMATA_TEST_ARGILLA_API_KEY`. `make test-integration` / `test-all` / `test-stack` stand up a throwaway Compose project on a non-default port (`:6901`) and tear it down (`-v`) on exit. The `-p` project scope keeps containers/volumes disjoint from the live `annotation` stack on `:6900`.
- **Fail-closed guard:** unless `PRAGMATA_TEST_ARGILLA_URL` is set, a run that selects annotation tests **aborts at collection with a clear `pytest.UsageError` (exit 4)** - safe (raised before any fixture, so the destructive teardown never fires) and loud (a CI gate cannot pass having silently run zero annotation tests). Ordinary unit runs are unaffected: the default `-m 'not integration'` filter removes annotation items before the guard sees them.
- **Cohesion:** rename `make test` → `test-unit` (unit-only, no stack); share `client`/`base_dir` via a single `tests/integration/conftest.py` (also fixes a readiness-gate drift where the calibration client skipped the stack-ready check).

### Test plan

- [x] `make test-unit` - 1192 passed
- [x] `make test-integration` against ephemeral `:6901` - all annotation tests pass; ephemeral stack torn down; live `:6900` untouched (API still 200)
- [x] Fail-closed verified: with `PRAGMATA_TEST_ARGILLA_URL` unset, `pytest -m integration` errors with `UsageError` (exit 4) and runs no tests; `--setup-plan` confirms no fixture instantiates before the abort
- [x] `ruff check` clean
- [x] CI passes
