### PR TITLE
feat(eval): score prediction runs via prediction_id

### DIFF
--- a/docs/design/eval-scoring-metrics.md
+++ b/docs/design/eval-scoring-metrics.md
@@ -18,7 +18,7 @@ flowchart TD
     export["annotation export<br/>(CSV, row-level label columns)"]
     export --> human["human-labeled export"]
     export --> evalpath["evaluator-based path"]
-    evalpath -->|"pragmata eval train"| trained["trained evaluator"]
+    evalpath -->|"pragmata eval train-evaluator"| trained["trained evaluator"]
     trained -->|"pragmata eval predict-labels"| predicted["row-level predicted labels"]
     human -->|"pragmata eval score"| score
     predicted -->|"pragmata eval score"| score["SCORING<br/>row-level labels → corpus metrics + CIs<br/><b>MISSING - this doc</b>"]

--- a/docs/design/eval-scoring-metrics.md
+++ b/docs/design/eval-scoring-metrics.md
@@ -149,7 +149,7 @@ The input is selected by exactly one of three mutually-exclusive selectors:
 
 `score_id` is an **output** identifier, not an input selector: it names where score artifacts are written (`eval/scores/<score_id>/`) and defaults to the generated value from `EvalScoreSettings`. `export_id` is never reused for output naming.
 
-`EvalScoreSettings` carries `path`, `export_id`, `prediction_id`, and `score_id`. The selectors are mutually exclusive, with the latest annotation export as the no-selector fallback (resolved; see below). `prediction_id` is not yet wired - a `find_latest_prediction_run` resolver still needs writing in `eval_paths.py` (deferred, tracked in #303).
+`EvalScoreSettings` carries `path`, `export_id`, `prediction_id`, and `score_id`. The selectors are mutually exclusive, with the latest annotation export as the no-selector fallback (resolved; see below). `prediction_id` resolves directly to `prediction_outputs/<prediction_id>/predictions.csv`, whose `pragmata_predict.meta.json` sidecar is read only to confirm the run was produced for the requested task.
 
 ### CLI - `pragmata eval score`
 
@@ -191,4 +191,4 @@ Input-source selection and path resolution belong in `core/paths/eval_paths.py`,
 
 1. ~~**Input selection semantics.**~~ **Resolved.** `path` / `export_id` / `prediction_id` are mutually exclusive with no precedence - passing more than one raises `ValueError` (`_require_at_most_one_selector` in `eval_paths.py`). None is required; with no selector the latest annotation export is used. (The earlier proposal of a precedence order was dropped in favour of mutual exclusivity.)
 2. **Incomplete and degenerate scoring data.** Retrieval metrics assume complete ranked chunk labels per query. If some chunks are unlabeled we need a deliberate policy: fail with an informative message, skip affected queries, or compute a caveated fallback. Similarly, all-0/all-1 or otherwise degenerate labels can make some estimates uninformative and should be handled explicitly. Ideally the validation/guard logic is reusable between `eval train` and `eval score` where the constraints overlap.
-3. **`find_latest_prediction_run` resolver** to be added in `eval_paths.py`, mirroring `find_latest_annotation_export_id`. Deferred alongside `prediction_id` scoring - tracked in #303.
+3. ~~**`find_latest_prediction_run` resolver.**~~ **Resolved.** Not needed and not added: `prediction_id` is always an explicit selector, and the no-selector fallback stays the latest annotation export, so nothing calls for a latest-prediction finder.

--- a/docs/design/eval-scoring-metrics.md
+++ b/docs/design/eval-scoring-metrics.md
@@ -19,7 +19,7 @@ flowchart TD
     export --> human["human-labeled export"]
     export --> evalpath["evaluator-based path"]
     evalpath -->|"pragmata eval train"| trained["trained evaluator"]
-    trained -->|"pragmata eval predict"| predicted["row-level predicted labels"]
+    trained -->|"pragmata eval predict-labels"| predicted["row-level predicted labels"]
     human -->|"pragmata eval score"| score
     predicted -->|"pragmata eval score"| score["SCORING<br/>row-level labels → corpus metrics + CIs<br/><b>MISSING - this doc</b>"]
     score --> out["*_scores.json<br/>core/schemas/eval_output.py"]
@@ -145,7 +145,7 @@ The input is selected by exactly one of three mutually-exclusive selectors:
 |---|---|---|
 | `path` | direct labeled data | human-annotated or externally-prepared labeled records that score without going through prediction |
 | `export_id` | annotation export | convenience selector; resolves to the task-specific CSV (mirrors `find_latest_annotation_export_id`) |
-| `prediction_id` | prediction output | labels produced by `pragmata eval predict`; a **pragmata** prediction run, even though the underlying output is tlmtc-managed |
+| `prediction_id` | prediction output | labels produced by `pragmata eval predict-labels`; a **pragmata** prediction run, even though the underlying output is tlmtc-managed |
 
 `score_id` is an **output** identifier, not an input selector: it names where score artifacts are written (`eval/scores/<score_id>/`) and defaults to the generated value from `EvalScoreSettings`. `export_id` is never reused for output naming.
 

--- a/src/pragmata/api/eval.py
+++ b/src/pragmata/api/eval.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from pragmata.api._error_log import error_log
-from pragmata.core.eval.export import export_eval_predict_meta, export_eval_train_meta
+from pragmata.core.eval.export import export_eval_meta
 from pragmata.core.eval.imports import (
     import_eval_predict_frame,
     import_eval_score_frame,
@@ -126,7 +126,7 @@ def train_evaluator(
         sequence_length=settings.sequence_length,
         train_kwargs=settings.train_kwargs,
     )
-    export_eval_train_meta(
+    export_eval_meta(
         meta=EvalTrainMeta(
             run_id=result.paths.run_id,
             task=settings.task,
@@ -211,7 +211,7 @@ def predict_labels(
         evaluator_run_id=resolved_evaluator_run_id,
         predict_kwargs=settings.predict_kwargs,
     )
-    export_eval_predict_meta(
+    export_eval_meta(
         meta=EvalPredictMeta(
             run_id=result.paths.run_id,
             task=settings.task,
@@ -256,8 +256,8 @@ def score(
         path: Direct path to the labeled CSV to score.
         export_id: Annotation export identifier; resolves to the task-specific
             exported CSV.
-        prediction_id: Pragmata prediction run identifier. Not yet supported -
-            prediction-output scoring lands with ``pragmata eval predict``.
+        prediction_id: Pragmata prediction run identifier (the evaluator run id
+            that produced it); scores that run's ``predictions.csv``.
         task: Annotation task to score (``"retrieval"``, ``"grounding"``, or
             ``"generation"``).
         n_resamples: Bootstrap iterations for the continuous metrics. Defaults to 1000.

--- a/src/pragmata/api/eval.py
+++ b/src/pragmata/api/eval.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from pragmata.api._error_log import error_log
-from pragmata.core.eval.export import export_eval_train_meta
+from pragmata.core.eval.export import export_eval_predict_meta, export_eval_train_meta
 from pragmata.core.eval.imports import (
     import_eval_predict_frame,
     import_eval_score_frame,
@@ -15,6 +15,7 @@ from pragmata.core.eval.scoring import ScoreReport, build_score_report
 from pragmata.core.eval.tlmtc_adapters import run_tlmtc_predict, run_tlmtc_train
 from pragmata.core.eval.transforms import build_tlmtc_frame
 from pragmata.core.paths.eval_paths import (
+    resolve_eval_predict_meta_path,
     resolve_eval_predict_paths,
     resolve_eval_score_input,
     resolve_eval_score_paths,
@@ -24,7 +25,7 @@ from pragmata.core.paths.eval_paths import (
 )
 from pragmata.core.paths.paths import WorkspacePaths
 from pragmata.core.schemas.annotation_task import Task
-from pragmata.core.schemas.eval_output import EvalTrainMeta
+from pragmata.core.schemas.eval_output import EvalPredictMeta, EvalTrainMeta
 from pragmata.core.settings.eval_settings import (
     EvalPredictSettings,
     EvalScoreSettings,
@@ -167,7 +168,10 @@ def predict_labels(
     Returns:
         Result metadata for the completed tlmtc prediction run. Its ``paths``
         attribute contains the resolved prediction filesystem layout, including
-        the generated probabilities and predictions CSV artifacts.
+        the generated probabilities and predictions CSV artifacts. A
+        ``pragmata_predict.meta.json`` sidecar is written beside those artifacts
+        so the run can be discovered and scored (``pragmata eval score
+        --prediction-id``).
     """
     settings = EvalPredictSettings.resolve(
         config=load_config_file(config_path) if isinstance(config_path, (str, Path)) else None,
@@ -201,12 +205,25 @@ def predict_labels(
         mode="predict",
     )
 
-    return run_tlmtc_predict(
+    result = run_tlmtc_predict(
         unlabeled_data=tlmtc_frame,
         work_dir=predict_paths.tool_root,
         evaluator_run_id=resolved_evaluator_run_id,
         predict_kwargs=settings.predict_kwargs,
     )
+    export_eval_predict_meta(
+        meta=EvalPredictMeta(
+            run_id=result.paths.run_id,
+            task=settings.task,
+            unlabeled_data_path=str(predict_paths.prediction_input_csv),
+        ),
+        path=resolve_eval_predict_meta_path(
+            workspace=workspace,
+            run_id=result.paths.run_id,
+        ),
+    )
+
+    return result
 
 
 def score(
@@ -255,8 +272,8 @@ def score(
         ValueError: If more than one input selector (``path`` / ``export_id`` /
             ``prediction_id``) is given.
         EvalInputSchemaError: If the input violates the score contract.
-        FileNotFoundError: If the selected input CSV or annotation export is missing.
-        NotImplementedError: If ``prediction_id`` is used before predict lands.
+        FileNotFoundError: If the selected input CSV, annotation export, or
+            prediction run is missing.
     """
     settings = EvalScoreSettings.resolve(
         config=load_config_file(config_path) if isinstance(config_path, (str, Path)) else None,

--- a/src/pragmata/cli/commands/eval.py
+++ b/src/pragmata/cli/commands/eval.py
@@ -158,7 +158,7 @@ def score_command(
     prediction_id: str | None = typer.Option(
         None,
         "--prediction-id",
-        help="Prediction run identifier. Not yet supported (lands with eval predict).",
+        help="Prediction run identifier; resolves to the predictions CSV written by eval predict-labels.",
     ),
     score_id: str | None = typer.Option(
         None,

--- a/src/pragmata/cli/commands/eval.py
+++ b/src/pragmata/cli/commands/eval.py
@@ -193,9 +193,9 @@ def score_command(
 ) -> None:
     """Score labeled eval data into corpus metrics with confidence intervals.
 
-    The input is selected by one of ``--path`` / ``--export-id`` /
-    ``--prediction-id`` (precedence in that order); with none, the latest
-    annotation export is used.
+    The input is selected by at most one of ``--path`` / ``--export-id`` /
+    ``--prediction-id`` - they are mutually exclusive with no precedence, and
+    passing more than one raises. With none, the latest annotation export is used.
     """
     report = eval.score(
         task=UNSET if task is None else task,

--- a/src/pragmata/core/eval/export.py
+++ b/src/pragmata/core/eval/export.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 
 from pragmata.core.atomic_io import atomic_write_json
-from pragmata.core.schemas.eval_output import EvalTrainMeta
+from pragmata.core.schemas.eval_output import EvalPredictMeta, EvalTrainMeta
 
 
 def export_eval_train_meta(
@@ -18,5 +18,22 @@ def export_eval_train_meta(
     """
     if not path.parent.is_dir():
         raise FileNotFoundError(f"Eval train metadata parent directory does not exist: {path.parent}")
+
+    atomic_write_json(meta.model_dump(mode="json"), path)
+
+
+def export_eval_predict_meta(
+    meta: EvalPredictMeta,
+    path: Path,
+) -> None:
+    """Write Pragmata-owned evaluator prediction metadata to disk as JSON.
+
+    Args:
+        meta: Validated evaluator prediction metadata to persist.
+        path: Destination path for the JSON sidecar, under the tlmtc
+            prediction-run directory.
+    """
+    if not path.parent.is_dir():
+        raise FileNotFoundError(f"Eval predict metadata parent directory does not exist: {path.parent}")
 
     atomic_write_json(meta.model_dump(mode="json"), path)

--- a/src/pragmata/core/eval/export.py
+++ b/src/pragmata/core/eval/export.py
@@ -2,38 +2,22 @@
 
 from pathlib import Path
 
+from pydantic import BaseModel
+
 from pragmata.core.atomic_io import atomic_write_json
-from pragmata.core.schemas.eval_output import EvalPredictMeta, EvalTrainMeta
 
 
-def export_eval_train_meta(
-    meta: EvalTrainMeta,
-    path: Path,
-) -> None:
-    """Write Pragmata-owned evaluator training metadata to disk as JSON.
+def export_eval_meta(meta: BaseModel, path: Path) -> None:
+    """Write Pragmata-owned evaluator run metadata to disk as JSON.
+
+    Shared by train and predict runs (``EvalTrainMeta`` / ``EvalPredictMeta``);
+    the sidecar is written beside the run's tlmtc artifacts.
 
     Args:
-        meta: Validated evaluator training metadata to persist.
+        meta: Validated evaluator run metadata to persist.
         path: Destination path for the JSON sidecar.
     """
     if not path.parent.is_dir():
-        raise FileNotFoundError(f"Eval train metadata parent directory does not exist: {path.parent}")
-
-    atomic_write_json(meta.model_dump(mode="json"), path)
-
-
-def export_eval_predict_meta(
-    meta: EvalPredictMeta,
-    path: Path,
-) -> None:
-    """Write Pragmata-owned evaluator prediction metadata to disk as JSON.
-
-    Args:
-        meta: Validated evaluator prediction metadata to persist.
-        path: Destination path for the JSON sidecar, under the tlmtc
-            prediction-run directory.
-    """
-    if not path.parent.is_dir():
-        raise FileNotFoundError(f"Eval predict metadata parent directory does not exist: {path.parent}")
+        raise FileNotFoundError(f"Eval metadata parent directory does not exist: {path.parent}")
 
     atomic_write_json(meta.model_dump(mode="json"), path)

--- a/src/pragmata/core/eval/export.py
+++ b/src/pragmata/core/eval/export.py
@@ -2,12 +2,11 @@
 
 from pathlib import Path
 
-from pydantic import BaseModel
-
 from pragmata.core.atomic_io import atomic_write_json
+from pragmata.core.schemas.eval_output import EvalPredictMeta, EvalTrainMeta
 
 
-def export_eval_meta(meta: BaseModel, path: Path) -> None:
+def export_eval_meta(meta: EvalTrainMeta | EvalPredictMeta, path: Path) -> None:
     """Write Pragmata-owned evaluator run metadata to disk as JSON.
 
     Shared by train and predict runs (``EvalTrainMeta`` / ``EvalPredictMeta``);

--- a/src/pragmata/core/paths/eval_paths.py
+++ b/src/pragmata/core/paths/eval_paths.py
@@ -9,7 +9,7 @@ from pragmata.core.paths.annotation_paths import AnnotationExportPaths, resolve_
 from pragmata.core.paths.paths import WorkspacePaths
 from pragmata.core.schemas.annotation_export import AnnotationExportMeta
 from pragmata.core.schemas.annotation_task import Task
-from pragmata.core.schemas.eval_output import EvalTrainMeta, ScoreInputSource
+from pragmata.core.schemas.eval_output import EvalPredictMeta, EvalTrainMeta, ScoreInputSource
 
 
 @dataclass(frozen=True, slots=True)
@@ -219,6 +219,25 @@ def resolve_eval_train_meta_path(
     return workspace.tool_root("eval") / "train_outputs" / run_id / "pragmata_train.meta.json"
 
 
+def resolve_eval_predict_meta_path(
+    *,
+    workspace: WorkspacePaths,
+    run_id: str,
+) -> Path:
+    """Build the Pragmata-owned metadata path for a completed eval prediction run.
+
+    Args:
+        workspace: Workspace path bundle.
+        run_id: tlmtc prediction run identifier (the evaluator run id, which
+            tlmtc also uses to name the prediction-output directory).
+
+    Returns:
+        Path to the Pragmata predict metadata sidecar under the tlmtc
+        prediction-run directory.
+    """
+    return workspace.tool_root("eval") / "prediction_outputs" / run_id / "pragmata_predict.meta.json"
+
+
 def resolve_eval_predict_paths(
     *,
     workspace: WorkspacePaths,
@@ -415,16 +434,19 @@ def resolve_eval_score_input(
     for the task is used, mirroring ``resolve_eval_train_paths``.
 
     Direct paths and annotation exports are already Pragmata-shaped and score
-    without further preparation. Scoring a prediction run (``prediction_id``) is
-    not currently supported and raises ``NotImplementedError`` (see #303). With no
-    selector, the latest annotation export is used.
+    without further preparation. A ``prediction_id`` selects a completed
+    prediction run's ``predictions.csv`` (tlmtc-shaped; the importer restores the
+    task text columns); the run's persisted ``pragmata_predict.meta.json`` is
+    checked to confirm it was produced for the requested task. With no selector,
+    the latest annotation export is used.
 
     Args:
         workspace: Workspace path bundle.
         task: Annotation task that determines which exported task CSV is required.
         path: Direct labeled CSV path.
         export_id: Annotation export identifier.
-        prediction_id: Pragmata prediction run identifier.
+        prediction_id: Pragmata prediction run identifier (the evaluator run id
+            that produced the run; see ``EvalPredictMeta``).
 
     Returns:
         The resolved input CSV and its ``ScoreInputSource`` provenance. The
@@ -432,9 +454,10 @@ def resolve_eval_score_input(
         how the input was selected without re-running selection.
 
     Raises:
-        ValueError: If more than one of ``path`` / ``export_id`` / ``prediction_id`` is given.
-        FileNotFoundError: If the selected input CSV or annotation export is missing.
-        NotImplementedError: If a prediction run is selected; not yet supported (see #303).
+        ValueError: If more than one of ``path`` / ``export_id`` / ``prediction_id``
+            is given, or if the prediction run was produced for a different task.
+        FileNotFoundError: If the selected input CSV, annotation export, or
+            prediction run is missing.
     """
     _require_at_most_one_selector(path=path, export_id=export_id, prediction_id=prediction_id)
 
@@ -451,12 +474,35 @@ def resolve_eval_score_input(
             ),
         )
 
+    if prediction_id is not None:
+        meta_path = resolve_eval_predict_meta_path(workspace=workspace, run_id=prediction_id)
+        if not meta_path.is_file():
+            raise FileNotFoundError(
+                f"Prediction run {prediction_id!r} metadata does not exist. "
+                f"Expected pragmata_predict.meta.json at {meta_path}."
+            )
+        meta = EvalPredictMeta.model_validate_json(meta_path.read_text(encoding="utf-8"))
+        if meta.task != task:
+            raise ValueError(
+                f"Prediction run {prediction_id!r} was produced for task={meta.task.value!r}, "
+                f"not requested task={task.value!r}."
+            )
+        predictions_csv = meta_path.parent / "predictions.csv"
+        if not predictions_csv.is_file():
+            raise FileNotFoundError(
+                f"Prediction run {prediction_id!r} does not contain predictions.csv. Expected {predictions_csv}."
+            )
+        return EvalScoreInput(
+            input_csv=predictions_csv,
+            source=ScoreInputSource(
+                kind="model_prediction",
+                ref=prediction_id,
+                resolved_path=provenance_path(input_csv=predictions_csv, base_dir=workspace.base_dir),
+            ),
+        )
+
     if export_id is not None:
         resolved_export_id = export_id
-    elif prediction_id is not None:
-        raise NotImplementedError(
-            "Scoring a prediction run is not yet supported (see issue #303). Pass path or export_id instead."
-        )
     else:
         resolved_export_id = find_latest_annotation_export_id(workspace=workspace, task=task)
 

--- a/src/pragmata/core/paths/eval_paths.py
+++ b/src/pragmata/core/paths/eval_paths.py
@@ -243,7 +243,7 @@ def resolve_eval_predict_paths(
     workspace: WorkspacePaths,
     unlabeled_data_path: Path,
 ) -> EvalPredictPaths:
-    """Resolve the explicit unlabeled input CSV consumed by eval predict.
+    """Resolve the explicit unlabeled input CSV consumed by eval predict-labels.
 
     Args:
         workspace: Workspace path bundle.

--- a/src/pragmata/core/schemas/eval_output.py
+++ b/src/pragmata/core/schemas/eval_output.py
@@ -70,6 +70,24 @@ class EvalTrainMeta(BaseModel):
     annotation_export_id: str | None = None
 
 
+class EvalPredictMeta(BaseModel):
+    """Pragmata-owned metadata for a completed evaluator prediction run.
+
+    Persisted beside tlmtc's prediction artifacts so a prediction run is
+    discoverable and task-checkable when scored. ``run_id`` is the evaluator
+    training run id: tlmtc keys prediction output by the same ``run_id`` it
+    loads the evaluator from (``prediction_outputs/<run_id>/``), so a prediction
+    run is identified by which evaluator produced it.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    run_id: str
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    task: Task
+    unlabeled_data_path: str | None = None
+
+
 class RetrievalScoreReport(BaseModel):
     """Schema for retrieval_scores.json."""
 

--- a/src/pragmata/core/schemas/eval_output.py
+++ b/src/pragmata/core/schemas/eval_output.py
@@ -73,11 +73,9 @@ class EvalTrainMeta(BaseModel):
 class EvalPredictMeta(BaseModel):
     """Pragmata-owned metadata for a completed evaluator prediction run.
 
-    Persisted beside tlmtc's prediction artifacts so a prediction run is
-    discoverable and task-checkable when scored. ``run_id`` is the evaluator
-    training run id: tlmtc keys prediction output by the same ``run_id`` it
-    loads the evaluator from (``prediction_outputs/<run_id>/``), so a prediction
-    run is identified by which evaluator produced it.
+    ``run_id`` is the evaluator training run id: tlmtc keys prediction output by
+    the same ``run_id`` it loads the evaluator from, so a run is identified by
+    which evaluator produced it.
     """
 
     model_config = ConfigDict(extra="forbid", frozen=True)

--- a/src/pragmata/core/schemas/eval_output.py
+++ b/src/pragmata/core/schemas/eval_output.py
@@ -76,6 +76,10 @@ class EvalPredictMeta(BaseModel):
     ``run_id`` is the evaluator training run id: tlmtc keys prediction output by
     the same ``run_id`` it loads the evaluator from, so a run is identified by
     which evaluator produced it.
+
+    ``unlabeled_data_path`` is required: prediction input is mandatory on
+    ``EvalPredictSettings`` and resolved before inference, so a completed run
+    always knows which input it labeled.
     """
 
     model_config = ConfigDict(extra="forbid", frozen=True)
@@ -83,7 +87,7 @@ class EvalPredictMeta(BaseModel):
     run_id: str
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     task: Task
-    unlabeled_data_path: str | None = None
+    unlabeled_data_path: str
 
 
 class RetrievalScoreReport(BaseModel):

--- a/src/pragmata/core/settings/eval_settings.py
+++ b/src/pragmata/core/settings/eval_settings.py
@@ -102,8 +102,7 @@ class EvalScoreSettings(ResolveSettings):
     Input selectors are mutually exclusive (enforced by
     ``resolve_eval_score_input``): at most one of ``path`` / ``export_id`` /
     ``prediction_id`` may be given, and more than one raises. With no selector,
-    the latest annotation export for the task is used (interim, until
-    ``eval predict`` and its output layout land).
+    the latest annotation export for the task is used.
 
     Attributes:
         base_dir: Workspace base directory. Pragmata resolves score artifacts under
@@ -116,7 +115,8 @@ class EvalScoreSettings(ResolveSettings):
         export_id: Optional annotation export identifier; resolves to the
             task-specific exported CSV.
         prediction_id: Optional Pragmata prediction run identifier for labels
-            produced by `pragmata eval predict`. Not yet supported.
+            produced by `pragmata eval predict-labels`; resolves to that run's
+            `predictions.csv`.
         task: Annotation task to score. The task determines which task-specific
             label contract and score metrics are applied.
         n_resamples: Bootstrap iterations for the continuous metrics' CIs.

--- a/tests/integration/test_eval.py
+++ b/tests/integration/test_eval.py
@@ -703,4 +703,5 @@ class TestPredictLabels:
         assert report.source.kind == "model_prediction"
         assert report.source.ref == run_id
         assert report.source.resolved_path == f"eval/prediction_outputs/{run_id}/predictions.csv"
-        assert report.n_examples == len(pd.read_csv(unlabeled_data_path))
+        # n_examples counts scoring units (queries), not chunk rows.
+        assert report.n_examples == pd.read_csv(unlabeled_data_path)["record_uuid"].nunique()

--- a/tests/integration/test_eval.py
+++ b/tests/integration/test_eval.py
@@ -434,6 +434,14 @@ def _assert_prediction_artifacts(
     assert probabilities[list(expected_label_columns)].ge(0).all().all()
     assert probabilities[list(expected_label_columns)].le(1).all().all()
 
+    predict_meta_path = expected_run_dir / "pragmata_predict.meta.json"
+    assert predict_meta_path.is_file()
+    predict_meta = json.loads(predict_meta_path.read_text(encoding="utf-8"))
+    assert predict_meta["run_id"] == run_id
+    assert predict_meta["task"] == "retrieval"
+    assert predict_meta["unlabeled_data_path"] == str(unlabeled_data_path.expanduser().resolve())
+    assert isinstance(predict_meta["created_at"], str)
+
 
 @pytest.fixture(scope="module")
 def trained_prediction_evaluator(
@@ -669,3 +677,30 @@ class TestPredictLabels:
             )
 
         assert not (tmp_path / "eval" / "prediction_outputs").exists()
+
+    def test_score_round_trip_from_prediction_run(
+        self,
+        trained_prediction_evaluator: tuple[Path, str],
+    ) -> None:
+        """A prediction run's output scores end-to-end via prediction_id (predict -> score)."""
+        base_dir, run_id = trained_prediction_evaluator
+        unlabeled_data_path = base_dir / "inputs" / "retrieval-predict-roundtrip.csv"
+        _write_retrieval_predict_csv(unlabeled_data_path, marker="roundtrip-predict")
+
+        _predict_labels(
+            base_dir=base_dir,
+            unlabeled_data_path=unlabeled_data_path,
+            evaluator_run_id=run_id,
+        )
+
+        report = eval.score(
+            base_dir=base_dir,
+            task=Task.RETRIEVAL,
+            prediction_id=run_id,
+        )
+
+        assert report.task == Task.RETRIEVAL
+        assert report.source.kind == "model_prediction"
+        assert report.source.ref == run_id
+        assert report.source.resolved_path == f"eval/prediction_outputs/{run_id}/predictions.csv"
+        assert report.n_examples == len(pd.read_csv(unlabeled_data_path))

--- a/tests/unit/api/test_eval.py
+++ b/tests/unit/api/test_eval.py
@@ -230,7 +230,7 @@ def test_predict_labels_orchestrates_direct_unlabeled_input(
     input_csv.write_text("placeholder\nvalue\n", encoding="utf-8")
     eval_frame = pd.DataFrame({"source": ["eval"]})
     tlmtc_frame = pd.DataFrame({"text": ["query"], "text_pair": ["chunk"]})
-    expected_result = object()
+    expected_result = SimpleNamespace(paths=SimpleNamespace(run_id="evaluator-1"))
     calls: dict[str, Any] = {}
 
     def resolve_eval_train_run_id(
@@ -273,6 +273,7 @@ def test_predict_labels_orchestrates_direct_unlabeled_input(
     monkeypatch.setattr(eval_api, "import_eval_predict_frame", import_eval_predict_frame)
     monkeypatch.setattr(eval_api, "build_tlmtc_frame", build_tlmtc_frame)
     monkeypatch.setattr(eval_api, "run_tlmtc_predict", run_tlmtc_predict)
+    monkeypatch.setattr(eval_api, "export_eval_predict_meta", lambda **kwargs: calls.setdefault("export", kwargs))
 
     result = eval_api.predict_labels(
         unlabeled_data_path=input_csv,
@@ -283,6 +284,10 @@ def test_predict_labels_orchestrates_direct_unlabeled_input(
     )
 
     assert result is expected_result
+    predict_meta = calls["export"]["meta"]
+    assert predict_meta.run_id == "evaluator-1"
+    assert predict_meta.task == Task.RETRIEVAL
+    assert predict_meta.unlabeled_data_path == str(input_csv.resolve())
     assert calls["select"] == {
         "workspace_base_dir": tmp_path.resolve(),
         "task": Task.RETRIEVAL,
@@ -322,7 +327,7 @@ def test_predict_labels_combines_config_and_explicit_overrides(
         encoding="utf-8",
     )
     tlmtc_frame = pd.DataFrame({"text": ["query"], "text_pair": ["answer"]})
-    expected_result = object()
+    expected_result = SimpleNamespace(paths=SimpleNamespace(run_id="latest-generation-evaluator"))
     calls: dict[str, Any] = {}
 
     def resolve_eval_train_run_id(
@@ -348,6 +353,7 @@ def test_predict_labels_combines_config_and_explicit_overrides(
     monkeypatch.setattr(eval_api, "import_eval_predict_frame", lambda *, path, task: pd.DataFrame({"path": [path]}))
     monkeypatch.setattr(eval_api, "build_tlmtc_frame", lambda frame, *, task, mode: tlmtc_frame)
     monkeypatch.setattr(eval_api, "run_tlmtc_predict", run_tlmtc_predict)
+    monkeypatch.setattr(eval_api, "export_eval_predict_meta", lambda **kwargs: None)
 
     result = eval_api.predict_labels(
         unlabeled_data_path=override_input_csv,

--- a/tests/unit/api/test_eval.py
+++ b/tests/unit/api/test_eval.py
@@ -58,7 +58,7 @@ def test_train_evaluator_orchestrates_direct_labeled_input(
     monkeypatch.setattr(eval_api, "import_eval_train_frame", import_eval_train_frame)
     monkeypatch.setattr(eval_api, "build_tlmtc_frame", build_tlmtc_frame)
     monkeypatch.setattr(eval_api, "run_tlmtc_train", run_tlmtc_train)
-    monkeypatch.setattr(eval_api, "export_eval_train_meta", lambda **kwargs: calls.setdefault("export", kwargs))
+    monkeypatch.setattr(eval_api, "export_eval_meta", lambda **kwargs: calls.setdefault("export", kwargs))
 
     result = eval_api.train_evaluator(
         labeled_data_path=input_csv,
@@ -120,7 +120,7 @@ def test_train_evaluator_combines_config_and_explicit_overrides(
 
     monkeypatch.setattr(eval_api, "import_eval_train_frame", lambda *, path, task: pd.DataFrame({"path": [path]}))
     monkeypatch.setattr(eval_api, "build_tlmtc_frame", lambda frame, *, task, mode: tlmtc_frame)
-    monkeypatch.setattr(eval_api, "export_eval_train_meta", lambda **kwargs: None)
+    monkeypatch.setattr(eval_api, "export_eval_meta", lambda **kwargs: None)
 
     def run_tlmtc_train(
         **kwargs: Any,
@@ -196,7 +196,7 @@ def test_train_evaluator_resolves_annotation_export_for_selected_task(
     monkeypatch.setattr(eval_api, "import_eval_train_frame", lambda *, path, task: pd.DataFrame({"path": [path]}))
     monkeypatch.setattr(eval_api, "build_tlmtc_frame", lambda frame, *, task, mode: tlmtc_frame)
     monkeypatch.setattr(eval_api, "run_tlmtc_train", lambda **kwargs: expected_result)
-    monkeypatch.setattr(eval_api, "export_eval_train_meta", lambda **kwargs: export_call.update(kwargs))
+    monkeypatch.setattr(eval_api, "export_eval_meta", lambda **kwargs: export_call.update(kwargs))
 
     result = eval_api.train_evaluator(
         export_id="export-1",
@@ -273,7 +273,7 @@ def test_predict_labels_orchestrates_direct_unlabeled_input(
     monkeypatch.setattr(eval_api, "import_eval_predict_frame", import_eval_predict_frame)
     monkeypatch.setattr(eval_api, "build_tlmtc_frame", build_tlmtc_frame)
     monkeypatch.setattr(eval_api, "run_tlmtc_predict", run_tlmtc_predict)
-    monkeypatch.setattr(eval_api, "export_eval_predict_meta", lambda **kwargs: calls.setdefault("export", kwargs))
+    monkeypatch.setattr(eval_api, "export_eval_meta", lambda **kwargs: calls.setdefault("export", kwargs))
 
     result = eval_api.predict_labels(
         unlabeled_data_path=input_csv,
@@ -353,7 +353,7 @@ def test_predict_labels_combines_config_and_explicit_overrides(
     monkeypatch.setattr(eval_api, "import_eval_predict_frame", lambda *, path, task: pd.DataFrame({"path": [path]}))
     monkeypatch.setattr(eval_api, "build_tlmtc_frame", lambda frame, *, task, mode: tlmtc_frame)
     monkeypatch.setattr(eval_api, "run_tlmtc_predict", run_tlmtc_predict)
-    monkeypatch.setattr(eval_api, "export_eval_predict_meta", lambda **kwargs: None)
+    monkeypatch.setattr(eval_api, "export_eval_meta", lambda **kwargs: None)
 
     result = eval_api.predict_labels(
         unlabeled_data_path=override_input_csv,

--- a/tests/unit/api/test_eval_score.py
+++ b/tests/unit/api/test_eval_score.py
@@ -11,6 +11,7 @@ from pragmata.core.schemas.annotation_export import AnnotationExportMeta
 from pragmata.core.schemas.annotation_task import Task
 from pragmata.core.schemas.eval_input import EvalInputSchemaError
 from pragmata.core.schemas.eval_output import (
+    EvalPredictMeta,
     GenerationScoreReport,
     GroundingScoreReport,
     MetricScore,
@@ -126,6 +127,26 @@ def _write_retrieval_export(base_dir: Path, export_id: str) -> None:
         constraint_summary={},
     )
     (export_dir / "annotation_export.meta.json").write_text(meta.model_dump_json(), encoding="utf-8")
+
+
+def _write_retrieval_prediction_run(base_dir: Path, run_id: str) -> None:
+    """Write a tlmtc-shaped retrieval prediction run (predictions.csv + meta) under ``base_dir``.
+
+    Prediction artifacts are tlmtc-shaped: the task text columns arrive as
+    ``text``/``text_pair`` and are restored on import.
+    """
+    run_dir = base_dir / "eval" / "prediction_outputs" / run_id
+    rows = [
+        {
+            **{key: value for key, value in row.items() if key not in {"query", "chunk"}},
+            "text": row["query"],
+            "text_pair": row["chunk"],
+        }
+        for row in _retrieval_rows()
+    ]
+    _write(run_dir / "predictions.csv", rows)
+    meta = EvalPredictMeta(run_id=run_id, task=Task.RETRIEVAL, created_at=datetime(2026, 1, 1, tzinfo=UTC))
+    (run_dir / "pragmata_predict.meta.json").write_text(meta.model_dump_json(), encoding="utf-8")
 
 
 class TestScoreRetrieval:
@@ -280,9 +301,20 @@ class TestScoreInput:
         with pytest.raises(ValueError, match="At most one input selector"):
             score(base_dir=tmp_path, path=csv, export_id="ignored", task="retrieval", seed=1)
 
-    def test_prediction_id_not_supported(self, tmp_path: Path):
-        with pytest.raises(NotImplementedError, match="not yet supported"):
-            score(base_dir=tmp_path, prediction_id="predict-001", task="retrieval")
+    def test_scores_via_prediction_id(self, tmp_path: Path):
+        _write_retrieval_prediction_run(tmp_path, "run-1")
+
+        report = score(base_dir=tmp_path, prediction_id="run-1", task="retrieval", seed=1)
+
+        assert isinstance(report, RetrievalScoreReport)
+        assert report.n_examples == 2
+        assert report.source.kind == "model_prediction"
+        assert report.source.ref == "run-1"
+        assert report.source.resolved_path == str(Path("eval") / "prediction_outputs" / "run-1" / "predictions.csv")
+
+    def test_prediction_id_missing_run_errors(self, tmp_path: Path):
+        with pytest.raises(FileNotFoundError, match="Prediction run 'nope' metadata does not exist"):
+            score(base_dir=tmp_path, prediction_id="nope", task="retrieval")
 
 
 class TestScoreConsolidationAndGuard:

--- a/tests/unit/api/test_eval_score.py
+++ b/tests/unit/api/test_eval_score.py
@@ -145,7 +145,12 @@ def _write_retrieval_prediction_run(base_dir: Path, run_id: str) -> None:
         for row in _retrieval_rows()
     ]
     _write(run_dir / "predictions.csv", rows)
-    meta = EvalPredictMeta(run_id=run_id, task=Task.RETRIEVAL, created_at=datetime(2026, 1, 1, tzinfo=UTC))
+    meta = EvalPredictMeta(
+        run_id=run_id,
+        task=Task.RETRIEVAL,
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        unlabeled_data_path="/inputs/unlabeled.csv",
+    )
     (run_dir / "pragmata_predict.meta.json").write_text(meta.model_dump_json(), encoding="utf-8")
 
 

--- a/tests/unit/cli/test_cli_eval.py
+++ b/tests/unit/cli/test_cli_eval.py
@@ -410,8 +410,8 @@ class TestScoreCommand:
         assert "retrieval scores" in strip_ansi(result.output)
         assert next((tmp_path / "eval" / "scores").glob("*/retrieval_scores.json")).is_file()
 
-    def test_prediction_id_exits_nonzero(self, tmp_path: Path) -> None:
-        # Prediction-run scoring is not yet supported; it must fail rather than silently no-op.
+    def test_missing_prediction_id_exits_nonzero(self, tmp_path: Path) -> None:
+        # A prediction id with no persisted run must fail rather than silently no-op.
         result = runner.invoke(
             eval_app, ["score", "--task", "retrieval", "--prediction-id", "p1", "--base-dir", str(tmp_path)]
         )

--- a/tests/unit/core/eval/test_export.py
+++ b/tests/unit/core/eval/test_export.py
@@ -4,9 +4,9 @@ import json
 from datetime import UTC, datetime
 from pathlib import Path
 
-from pragmata.core.eval.export import export_eval_train_meta
+from pragmata.core.eval.export import export_eval_predict_meta, export_eval_train_meta
 from pragmata.core.schemas.annotation_task import Task
-from pragmata.core.schemas.eval_output import EvalTrainMeta
+from pragmata.core.schemas.eval_output import EvalPredictMeta, EvalTrainMeta
 
 
 def test_export_eval_train_meta_serializes_metadata_json_values(
@@ -28,4 +28,26 @@ def test_export_eval_train_meta_serializes_metadata_json_values(
         "created_at": "2026-05-28T13:30:00Z",
         "task": "retrieval",
         "annotation_export_id": "export-1",
+    }
+
+
+def test_export_eval_predict_meta_serializes_metadata_json_values(
+    tmp_path: Path,
+) -> None:
+    """export_eval_predict_meta should serialize metadata using JSON-compatible model_dump output."""
+    meta = EvalPredictMeta(
+        run_id="prediction-evaluator",
+        created_at=datetime(2026, 5, 28, 13, 30, tzinfo=UTC),
+        task=Task.RETRIEVAL,
+        unlabeled_data_path="/work/eval/inputs/retrieval-predict.csv",
+    )
+    meta_path = tmp_path / "pragmata_predict.meta.json"
+
+    export_eval_predict_meta(meta=meta, path=meta_path)
+
+    assert json.loads(meta_path.read_text(encoding="utf-8")) == {
+        "run_id": "prediction-evaluator",
+        "created_at": "2026-05-28T13:30:00Z",
+        "task": "retrieval",
+        "unlabeled_data_path": "/work/eval/inputs/retrieval-predict.csv",
     }

--- a/tests/unit/core/eval/test_export.py
+++ b/tests/unit/core/eval/test_export.py
@@ -4,7 +4,7 @@ import json
 from datetime import UTC, datetime
 from pathlib import Path
 
-from pragmata.core.eval.export import export_eval_predict_meta, export_eval_train_meta
+from pragmata.core.eval.export import export_eval_meta
 from pragmata.core.schemas.annotation_task import Task
 from pragmata.core.schemas.eval_output import EvalPredictMeta, EvalTrainMeta
 
@@ -21,7 +21,7 @@ def test_export_eval_train_meta_serializes_metadata_json_values(
     )
     meta_path = tmp_path / "pragmata_train.meta.json"
 
-    export_eval_train_meta(meta=meta, path=meta_path)
+    export_eval_meta(meta=meta, path=meta_path)
 
     assert json.loads(meta_path.read_text(encoding="utf-8")) == {
         "run_id": "train-run-1",
@@ -43,7 +43,7 @@ def test_export_eval_predict_meta_serializes_metadata_json_values(
     )
     meta_path = tmp_path / "pragmata_predict.meta.json"
 
-    export_eval_predict_meta(meta=meta, path=meta_path)
+    export_eval_meta(meta=meta, path=meta_path)
 
     assert json.loads(meta_path.read_text(encoding="utf-8")) == {
         "run_id": "prediction-evaluator",

--- a/tests/unit/core/eval/test_export.py
+++ b/tests/unit/core/eval/test_export.py
@@ -9,10 +9,10 @@ from pragmata.core.schemas.annotation_task import Task
 from pragmata.core.schemas.eval_output import EvalPredictMeta, EvalTrainMeta
 
 
-def test_export_eval_train_meta_serializes_metadata_json_values(
+def test_export_eval_meta_serializes_train_meta_json_values(
     tmp_path: Path,
 ) -> None:
-    """export_eval_train_meta should serialize metadata using JSON-compatible model_dump output."""
+    """export_eval_meta should serialize train metadata using JSON-compatible model_dump output."""
     meta = EvalTrainMeta(
         run_id="train-run-1",
         created_at=datetime(2026, 5, 28, 13, 30, tzinfo=UTC),
@@ -31,10 +31,10 @@ def test_export_eval_train_meta_serializes_metadata_json_values(
     }
 
 
-def test_export_eval_predict_meta_serializes_metadata_json_values(
+def test_export_eval_meta_serializes_predict_meta_json_values(
     tmp_path: Path,
 ) -> None:
-    """export_eval_predict_meta should serialize metadata using JSON-compatible model_dump output."""
+    """export_eval_meta should serialize predict metadata using JSON-compatible model_dump output."""
     meta = EvalPredictMeta(
         run_id="prediction-evaluator",
         created_at=datetime(2026, 5, 28, 13, 30, tzinfo=UTC),

--- a/tests/unit/core/paths/test_eval_paths.py
+++ b/tests/unit/core/paths/test_eval_paths.py
@@ -12,6 +12,7 @@ from pragmata.core.paths.eval_paths import (
     find_latest_annotation_export_id,
     find_latest_eval_train_run_id,
     provenance_path,
+    resolve_eval_predict_meta_path,
     resolve_eval_predict_paths,
     resolve_eval_score_input,
     resolve_eval_score_paths,
@@ -22,7 +23,7 @@ from pragmata.core.paths.eval_paths import (
 from pragmata.core.paths.paths import WorkspacePaths
 from pragmata.core.schemas.annotation_export import AnnotationExportMeta
 from pragmata.core.schemas.annotation_task import Task
-from pragmata.core.schemas.eval_output import EvalTrainMeta
+from pragmata.core.schemas.eval_output import EvalPredictMeta, EvalTrainMeta
 
 
 @pytest.fixture()
@@ -92,6 +93,25 @@ def _write_eval_train_meta(
         task=task,
     )
     meta_path.write_text(meta.model_dump_json(), encoding="utf-8")
+
+
+def _write_prediction_run(
+    *,
+    workspace: WorkspacePaths,
+    run_id: str,
+    task: Task,
+    write_predictions_csv: bool = True,
+) -> Path:
+    """Write a minimal prediction run (meta sidecar + predictions.csv) for score tests."""
+    meta_path = resolve_eval_predict_meta_path(workspace=workspace, run_id=run_id)
+    meta_path.parent.mkdir(parents=True)
+    meta = EvalPredictMeta(run_id=run_id, task=task)
+    meta_path.write_text(meta.model_dump_json(), encoding="utf-8")
+
+    if write_predictions_csv:
+        (meta_path.parent / "predictions.csv").write_text("record_uuid\nr1\n", encoding="utf-8")
+
+    return meta_path.parent
 
 
 def test_resolve_eval_train_paths_uses_direct_labeled_data_path(
@@ -659,11 +679,50 @@ def test_resolve_eval_score_input_falls_back_to_latest_export(
     assert resolved.source.ref == "newer"
 
 
-def test_resolve_eval_score_input_prediction_run_not_supported(
+def test_resolve_eval_score_input_resolves_prediction_run(
     workspace: WorkspacePaths,
 ) -> None:
-    """A prediction run as the only selector is deferred until eval predict lands."""
-    with pytest.raises(NotImplementedError, match="prediction run is not yet supported"):
+    """A prediction id resolves to the run's predictions.csv with model_prediction provenance."""
+    run_dir = _write_prediction_run(workspace=workspace, run_id="run-1", task=Task.RETRIEVAL)
+
+    resolved = resolve_eval_score_input(workspace=workspace, task=Task.RETRIEVAL, prediction_id="run-1")
+
+    assert resolved.input_csv == run_dir / "predictions.csv"
+    assert resolved.source.kind == "model_prediction"
+    assert resolved.source.ref == "run-1"
+    assert resolved.source.resolved_path == "eval/prediction_outputs/run-1/predictions.csv"
+
+
+def test_resolve_eval_score_input_rejects_missing_prediction_run(
+    workspace: WorkspacePaths,
+) -> None:
+    """A prediction id with no persisted run metadata is an error."""
+    with pytest.raises(FileNotFoundError, match="Prediction run 'run-1' metadata does not exist"):
+        resolve_eval_score_input(workspace=workspace, task=Task.RETRIEVAL, prediction_id="run-1")
+
+
+def test_resolve_eval_score_input_rejects_task_mismatched_prediction_run(
+    workspace: WorkspacePaths,
+) -> None:
+    """Scoring a prediction run produced for a different task is rejected."""
+    _write_prediction_run(workspace=workspace, run_id="run-1", task=Task.GROUNDING)
+
+    with pytest.raises(ValueError, match="was produced for task='grounding'"):
+        resolve_eval_score_input(workspace=workspace, task=Task.RETRIEVAL, prediction_id="run-1")
+
+
+def test_resolve_eval_score_input_rejects_prediction_run_missing_predictions_csv(
+    workspace: WorkspacePaths,
+) -> None:
+    """A prediction run whose predictions.csv is absent is an error."""
+    _write_prediction_run(
+        workspace=workspace,
+        run_id="run-1",
+        task=Task.RETRIEVAL,
+        write_predictions_csv=False,
+    )
+
+    with pytest.raises(FileNotFoundError, match="does not contain predictions.csv"):
         resolve_eval_score_input(workspace=workspace, task=Task.RETRIEVAL, prediction_id="run-1")
 
 

--- a/tests/unit/core/paths/test_eval_paths.py
+++ b/tests/unit/core/paths/test_eval_paths.py
@@ -105,7 +105,7 @@ def _write_prediction_run(
     """Write a minimal prediction run (meta sidecar + predictions.csv) for score tests."""
     meta_path = resolve_eval_predict_meta_path(workspace=workspace, run_id=run_id)
     meta_path.parent.mkdir(parents=True)
-    meta = EvalPredictMeta(run_id=run_id, task=task)
+    meta = EvalPredictMeta(run_id=run_id, task=task, unlabeled_data_path="/inputs/unlabeled.csv")
     meta_path.write_text(meta.model_dump_json(), encoding="utf-8")
 
     if write_predictions_csv:


### PR DESCRIPTION
## Summary

- `pragmata eval score --prediction-id <id>` now works: `resolve_eval_score_input` resolves a completed prediction run's `predictions.csv` and returns `ScoreInputSource(kind="model_prediction", ...)`, replacing the `NotImplementedError` branch. The importer already handled that kind, so no import-layer change was needed.
- Gives prediction runs a discoverable identity: new `EvalPredictMeta` schema, and `predict_labels` persists a `pragmata_predict.meta.json` sidecar into `prediction_outputs/<run_id>/` beside the tlmtc artifacts (mirrors the existing train-meta pattern). `prediction_id` is the evaluator run id, per tlmtc's single-`run_id` constraint. `unlabeled_data_path` is a required field: prediction input is mandatory on `EvalPredictSettings` and resolved before inference, so a completed run always records which input it labeled.
- Resolution reads that sidecar and rejects a run produced for a different task (`ValueError`), rather than silently scoring mismatched labels. Missing sidecar or missing `predictions.csv` raise `FileNotFoundError`.
- `export_eval_train_meta` generalised to `export_eval_meta(meta: EvalTrainMeta | EvalPredictMeta, path)` so train and predict share one writer without widening the type boundary.
- Stale documentation brought in line with the implementation: the `--prediction-id` CLI help, the `EvalScoreSettings` docstring, and `docs/design/eval-scoring-metrics.md` no longer describe `prediction_id` as unsupported or the annotation-export fallback as interim. The `eval score` docstring's claim that the selectors have a precedence order is also corrected - they are mutually exclusive, matching Open decision 1.

Deviation from the issue's original plan (I updated #303 body so now aligned): no `find_latest_prediction_run` resolver was added. The no-selector fallback stays "latest annotation export" (unchanged), so nothing needs to glob for a latest prediction run - `--prediction-id` is always explicit.

Closes #303
