### PR TITLE
feat(eval): guard scoring against incomplete retrieval panels

### DIFF
--- a/src/pragmata/api/eval.py
+++ b/src/pragmata/api/eval.py
@@ -248,8 +248,8 @@ def score(
         ci: Confidence level for every interval. Defaults to 0.95.
         seed: Optional RNG seed for reproducible bootstrap intervals.
         allow_incomplete_panels: Score retrieval panels whose labeled chunks do not
-            cover ``n_retrieved_chunks``. Defaults to False: a partial panel changes
-            the @K denominators and biases the rank-sensitive metrics upward.
+            cover ``n_retrieved_chunks``. Defaults to ``False`` because a partial panel
+            changes the @K denominators and biases the rank-sensitive metrics upward.
         config_path: Path to a YAML configuration file.
 
     Returns:

--- a/src/pragmata/api/eval.py
+++ b/src/pragmata/api/eval.py
@@ -220,6 +220,7 @@ def score(
     n_resamples: int | Unset = UNSET,
     ci: float | Unset = UNSET,
     seed: int | Unset = UNSET,
+    skip_incomplete_panels: bool | Unset = UNSET,
     allow_incomplete_panels: bool | Unset = UNSET,
     config_path: str | Path | Unset = UNSET,
 ) -> ScoreReport:
@@ -247,9 +248,14 @@ def score(
         n_resamples: Bootstrap iterations for the continuous metrics. Defaults to 1000.
         ci: Confidence level for every interval. Defaults to 0.95.
         seed: Optional RNG seed for reproducible bootstrap intervals.
+        skip_incomplete_panels: Drop retrieval panels whose labeled chunks do not
+            cover ``n_retrieved_chunks`` and score the rest; the retrieval report
+            records the drop count as ``n_panels_skipped``. Defaults to ``False``.
+            Mutually exclusive with ``allow_incomplete_panels``.
         allow_incomplete_panels: Score retrieval panels whose labeled chunks do not
             cover ``n_retrieved_chunks``. Defaults to ``False`` because a partial panel
             changes the @K denominators and biases the rank-sensitive metrics upward.
+            Mutually exclusive with ``skip_incomplete_panels``.
         config_path: Path to a YAML configuration file.
 
     Returns:
@@ -275,6 +281,7 @@ def score(
             "n_resamples": n_resamples,
             "ci": ci,
             "seed": seed,
+            "skip_incomplete_panels": skip_incomplete_panels,
             "allow_incomplete_panels": allow_incomplete_panels,
         },
     )
@@ -289,10 +296,11 @@ def score(
             export_id=settings.export_id,
             prediction_id=settings.prediction_id,
         )
-        frame = import_eval_score_frame(
+        frame, n_panels_skipped = import_eval_score_frame(
             path=resolved.input_csv,
             task=settings.task,
             source=resolved.source,
+            skip_incomplete_panels=settings.skip_incomplete_panels,
             allow_incomplete_panels=settings.allow_incomplete_panels,
         )
         report = build_score_report(
@@ -303,6 +311,7 @@ def score(
             seed=settings.seed,
             source=resolved.source,
             created_at=datetime.now(UTC),
+            n_panels_skipped=n_panels_skipped,
         )
         match settings.task:
             case Task.RETRIEVAL:

--- a/src/pragmata/api/eval.py
+++ b/src/pragmata/api/eval.py
@@ -220,6 +220,7 @@ def score(
     n_resamples: int | Unset = UNSET,
     ci: float | Unset = UNSET,
     seed: int | Unset = UNSET,
+    allow_incomplete_panels: bool | Unset = UNSET,
     config_path: str | Path | Unset = UNSET,
 ) -> ScoreReport:
     """Score labeled eval data into corpus metrics with confidence intervals.
@@ -246,6 +247,9 @@ def score(
         n_resamples: Bootstrap iterations for the continuous metrics. Defaults to 1000.
         ci: Confidence level for every interval. Defaults to 0.95.
         seed: Optional RNG seed for reproducible bootstrap intervals.
+        allow_incomplete_panels: Score retrieval panels whose labeled chunks do not
+            cover ``n_retrieved_chunks``. Defaults to False: a partial panel changes
+            the @K denominators and biases the rank-sensitive metrics upward.
         config_path: Path to a YAML configuration file.
 
     Returns:
@@ -271,6 +275,7 @@ def score(
             "n_resamples": n_resamples,
             "ci": ci,
             "seed": seed,
+            "allow_incomplete_panels": allow_incomplete_panels,
         },
     )
     workspace = WorkspacePaths.from_base_dir(settings.base_dir)
@@ -284,7 +289,12 @@ def score(
             export_id=settings.export_id,
             prediction_id=settings.prediction_id,
         )
-        frame = import_eval_score_frame(path=resolved.input_csv, task=settings.task, source=resolved.source)
+        frame = import_eval_score_frame(
+            path=resolved.input_csv,
+            task=settings.task,
+            source=resolved.source,
+            allow_incomplete_panels=settings.allow_incomplete_panels,
+        )
         report = build_score_report(
             frame,
             task=settings.task,

--- a/src/pragmata/cli/commands/eval.py
+++ b/src/pragmata/cli/commands/eval.py
@@ -185,6 +185,12 @@ def score_command(
         "--seed",
         help="RNG seed for reproducible bootstrap intervals.",
     ),
+    allow_incomplete_panels: bool = typer.Option(
+        False,
+        "--allow-incomplete-panels",
+        help="Score retrieval panels whose labeled chunks do not cover the retrieval. "
+        "Off by default: partial panels bias every retrieval metric.",
+    ),
     config_path: str | None = typer.Option(
         None,
         "--config",
@@ -207,6 +213,7 @@ def score_command(
         n_resamples=UNSET if n_resamples is None else n_resamples,
         ci=UNSET if ci is None else ci,
         seed=UNSET if seed is None else seed,
+        allow_incomplete_panels=allow_incomplete_panels or UNSET,
         config_path=UNSET if config_path is None else config_path,
     )
 

--- a/src/pragmata/cli/commands/eval.py
+++ b/src/pragmata/cli/commands/eval.py
@@ -185,6 +185,12 @@ def score_command(
         "--seed",
         help="RNG seed for reproducible bootstrap intervals.",
     ),
+    skip_incomplete_panels: bool = typer.Option(
+        False,
+        "--skip-incomplete-panels",
+        help="Drop retrieval panels whose labeled chunks do not cover the retrieval and "
+        "score the rest; the report records how many were dropped.",
+    ),
     allow_incomplete_panels: bool = typer.Option(
         False,
         "--allow-incomplete-panels",
@@ -213,10 +219,17 @@ def score_command(
         n_resamples=UNSET if n_resamples is None else n_resamples,
         ci=UNSET if ci is None else ci,
         seed=UNSET if seed is None else seed,
+        skip_incomplete_panels=UNSET if not skip_incomplete_panels else True,
         allow_incomplete_panels=UNSET if not allow_incomplete_panels else True,
         config_path=UNSET if config_path is None else config_path,
     )
 
+    # getattr, not an isinstance check: the CLI layer does not import pragmata.core
+    # (enforced by test_cli_does_not_import_core), and only the retrieval report
+    # carries the field.
+    n_panels_skipped = getattr(report, "n_panels_skipped", 0)
+    if n_panels_skipped:
+        typer.echo(f"skipped {n_panels_skipped} incomplete panel(s); n counts completed panels only")
     typer.echo(f"\n{report.task.value} scores (n={report.n_examples}, {report.ci_level:.0%} CI):")
     for name, metric in report.metric_scores():
         if metric is None:

--- a/src/pragmata/cli/commands/eval.py
+++ b/src/pragmata/cli/commands/eval.py
@@ -213,7 +213,7 @@ def score_command(
         n_resamples=UNSET if n_resamples is None else n_resamples,
         ci=UNSET if ci is None else ci,
         seed=UNSET if seed is None else seed,
-        allow_incomplete_panels=allow_incomplete_panels or UNSET,
+        allow_incomplete_panels=UNSET if not allow_incomplete_panels else True,
         config_path=UNSET if config_path is None else config_path,
     )
 

--- a/src/pragmata/core/eval/imports.py
+++ b/src/pragmata/core/eval/imports.py
@@ -132,34 +132,31 @@ def _guard_complete_panels(frame: pd.DataFrame, *, task: Task, allow_incomplete:
     top-down, so the unjudged low-rank chunks can never lower the score.
 
     The check needs ``n_retrieved_chunks`` (the query's true K, carried by annotation
-    exports). Without that column the completeness of a panel is unknowable here, so
-    the frame passes with a warning rather than a hard failure - direct-path and
-    prediction inputs are not required to carry export metadata.
+    exports). Where no panel carries a known K the completeness of the input is
+    unknowable here, so the frame passes with a warning rather than a hard failure -
+    direct-path and prediction inputs are not required to carry export metadata.
 
     ``allow_incomplete=True`` (CLI: ``--allow-incomplete-panels``) skips the check for
     callers who accept the bias, e.g. to score everything for a coverage comparison.
     """
     if task != Task.RETRIEVAL or allow_incomplete:
         return
-    if "n_retrieved_chunks" not in frame.columns:
+    panels = _panels_with_known_k(frame)
+    if panels.empty:
         logger.warning(
-            "retrieval scoring input carries no n_retrieved_chunks column; panel "
-            "completeness cannot be verified. Metrics over partial panels are biased - "
+            "score input: retrieval panel completeness unverifiable (no panel carries "
+            "n_retrieved_chunks metadata) - metrics over partial panels are biased upward, "
             "see import_eval_score_frame."
         )
         return
-    per_query = frame.groupby("record_uuid").agg(
-        n_chunks=("chunk_id", "nunique"),
-        k=("n_retrieved_chunks", "max"),
-    )
-    short = per_query[per_query["n_chunks"] < per_query["k"]]
+    short = panels[panels["n_chunks"] < panels["k"]]
     if not short.empty:
         raise EvalInputSchemaError(
-            f"Scoring input for retrieval has {len(short)} panel(s) with fewer labeled "
-            f"chunks than n_retrieved_chunks (e.g. record_uuid {short.index[0]!r}: "
-            f"{int(short.iloc[0]['n_chunks'])} of {int(short.iloc[0]['k'])}). Partial "
-            f"panels bias every retrieval metric; filter them out, or pass "
-            f"allow_incomplete_panels=True (--allow-incomplete-panels) to score anyway."
+            f"Scoring input for {task.value} has {len(short)} panel(s) with fewer labeled chunks "
+            f"than n_retrieved_chunks (e.g. record_uuid {short.index[0]!r}: "
+            f"{int(short.iloc[0]['n_chunks'])} of {int(short.iloc[0]['k'])}); partial panels bias "
+            f"every retrieval metric, so filter them out or pass allow_incomplete_panels=True "
+            f"(--allow-incomplete-panels) to score anyway."
         )
 
 
@@ -170,3 +167,19 @@ def _reject_duplicates(frame: pd.DataFrame, keys: list[str], task: Task, unit: s
             f"Scoring input for {task.value} has {int(duplicated.sum())} row(s) with a duplicate "
             f"{unit} key {tuple(keys)}; each unit must be unique so metric denominators are not double-counted."
         )
+
+
+def _panels_with_known_k(frame: pd.DataFrame) -> pd.DataFrame:
+    """Count distinct labeled chunks and K per retrieval panel, keeping only panels with a known K.
+
+    ``n_retrieved_chunks`` is absent from direct-path and prediction inputs, and is the
+    ``-1`` sentinel on export records predating the metadata backfill; both mean "K
+    unknown here", so such panels cannot be checked for completeness.
+    """
+    if "n_retrieved_chunks" not in frame.columns:
+        return pd.DataFrame(columns=["n_chunks", "k"])
+    per_query = frame.groupby("record_uuid").agg(
+        n_chunks=("chunk_id", "nunique"),
+        k=("n_retrieved_chunks", "max"),
+    )
+    return per_query[per_query["k"] > 0]

--- a/src/pragmata/core/eval/imports.py
+++ b/src/pragmata/core/eval/imports.py
@@ -1,5 +1,6 @@
 """Dataframe imports for eval workflows."""
 
+import logging
 from pathlib import Path
 
 import pandas as pd
@@ -14,6 +15,8 @@ from pragmata.core.schemas.eval_input import (
     validate_eval_train_frame,
 )
 from pragmata.core.schemas.eval_output import ScoreInputSource
+
+logger = logging.getLogger(__name__)
 
 
 def import_eval_train_frame(
@@ -57,6 +60,7 @@ def import_eval_score_frame(
     path: Path,
     task: Task,
     source: ScoreInputSource,
+    allow_incomplete_panels: bool = False,
 ) -> pd.DataFrame:
     """Read, prepare, and validate a labeled eval scoring dataframe.
 
@@ -81,13 +85,17 @@ def import_eval_score_frame(
         task: Annotation task that determines the dataframe contract.
         source: Provenance of the input; ``source.kind`` decides whether the
             frame needs tlmtc text-column restoration.
+        allow_incomplete_panels: Permit retrieval panels whose labeled chunks do not
+            cover ``n_retrieved_chunks``. Off by default; see
+            ``_guard_complete_panels``.
 
     Returns:
         Validated dataframe with Pragmata task columns, one row per scoring unit.
 
     Raises:
-        EvalInputSchemaError: If the frame violates the score contract or retains a
-            duplicate scoring unit after majority consolidation.
+        EvalInputSchemaError: If the frame violates the score contract, retains a
+            duplicate scoring unit after majority consolidation, or contains an
+            incomplete retrieval panel without ``allow_incomplete_panels``.
     """
     frame = pd.read_csv(path, encoding="utf-8")
     if source.kind == "model_prediction":
@@ -95,6 +103,7 @@ def import_eval_score_frame(
     validated = validate_eval_score_frame(frame, task=task)
     consolidated = consolidate_labels_by_majority(validated, task=task)
     _guard_unique_scoring_units(consolidated, task=task)
+    _guard_complete_panels(consolidated, task=task, allow_incomplete=allow_incomplete_panels)
     return consolidated
 
 
@@ -111,6 +120,47 @@ def _guard_unique_scoring_units(frame: pd.DataFrame, *, task: Task) -> None:
         _reject_duplicates(frame, ["record_uuid", "chunk_rank"], task, "chunk rank")
     else:
         _reject_duplicates(frame, ["record_uuid"], task, "query")
+
+
+def _guard_complete_panels(frame: pd.DataFrame, *, task: Task, allow_incomplete: bool) -> None:
+    """Reject retrieval panels whose labeled chunks do not cover the retrieval.
+
+    Every retrieval metric averages over a query's chunk set, so a partial panel is
+    not a smaller sample of the same quantity - it changes the metric. Precision@K
+    over 2 labeled chunks of a K=5 retrieval has the wrong denominator, and the
+    rank-sensitive metrics (MRR, NDCG) are biased upward because annotators work
+    top-down, so the unjudged low-rank chunks can never lower the score.
+
+    The check needs ``n_retrieved_chunks`` (the query's true K, carried by annotation
+    exports). Without that column the completeness of a panel is unknowable here, so
+    the frame passes with a warning rather than a hard failure - direct-path and
+    prediction inputs are not required to carry export metadata.
+
+    ``allow_incomplete=True`` (CLI: ``--allow-incomplete-panels``) skips the check for
+    callers who accept the bias, e.g. to score everything for a coverage comparison.
+    """
+    if task != Task.RETRIEVAL or allow_incomplete:
+        return
+    if "n_retrieved_chunks" not in frame.columns:
+        logger.warning(
+            "retrieval scoring input carries no n_retrieved_chunks column; panel "
+            "completeness cannot be verified. Metrics over partial panels are biased - "
+            "see import_eval_score_frame."
+        )
+        return
+    per_query = frame.groupby("record_uuid").agg(
+        n_chunks=("chunk_id", "nunique"),
+        k=("n_retrieved_chunks", "max"),
+    )
+    short = per_query[per_query["n_chunks"] < per_query["k"]]
+    if not short.empty:
+        raise EvalInputSchemaError(
+            f"Scoring input for retrieval has {len(short)} panel(s) with fewer labeled "
+            f"chunks than n_retrieved_chunks (e.g. record_uuid {short.index[0]!r}: "
+            f"{int(short.iloc[0]['n_chunks'])} of {int(short.iloc[0]['k'])}). Partial "
+            f"panels bias every retrieval metric; filter them out, or pass "
+            f"allow_incomplete_panels=True (--allow-incomplete-panels) to score anyway."
+        )
 
 
 def _reject_duplicates(frame: pd.DataFrame, keys: list[str], task: Task, unit: str) -> None:

--- a/src/pragmata/core/eval/imports.py
+++ b/src/pragmata/core/eval/imports.py
@@ -60,8 +60,9 @@ def import_eval_score_frame(
     path: Path,
     task: Task,
     source: ScoreInputSource,
+    skip_incomplete_panels: bool = False,
     allow_incomplete_panels: bool = False,
-) -> pd.DataFrame:
+) -> tuple[pd.DataFrame, int]:
     """Read, prepare, and validate a labeled eval scoring dataframe.
 
     Direct paths and annotation exports are already Pragmata-shaped and are read
@@ -85,17 +86,25 @@ def import_eval_score_frame(
         task: Annotation task that determines the dataframe contract.
         source: Provenance of the input; ``source.kind`` decides whether the
             frame needs tlmtc text-column restoration.
-        allow_incomplete_panels: Permit retrieval panels whose labeled chunks do not
-            cover ``n_retrieved_chunks``. Off by default; see
-            ``_guard_complete_panels``.
+        skip_incomplete_panels: Drop retrieval panels whose labeled chunks do not
+            cover ``n_retrieved_chunks`` and score the rest. Mutually exclusive
+            with ``allow_incomplete_panels``; see ``_guard_complete_panels``.
+        allow_incomplete_panels: Score such panels as-is. Mutually exclusive with
+            ``skip_incomplete_panels``; see ``_guard_complete_panels``.
 
     Returns:
-        Validated dataframe with Pragmata task columns, one row per scoring unit.
+        Tuple of the validated dataframe with Pragmata task columns, one row per
+        scoring unit, and the number of incomplete retrieval panels dropped
+        (non-zero only with ``skip_incomplete_panels``; reported so the score
+        artifact records that its population was reduced).
 
     Raises:
         EvalInputSchemaError: If the frame violates the score contract, retains a
-            duplicate scoring unit after majority consolidation, or contains an
-            incomplete retrieval panel without ``allow_incomplete_panels``.
+            duplicate scoring unit after majority consolidation, contains an
+            incomplete retrieval panel in the default mode, or if skipping removes
+            every panel.
+        ValueError: If both ``skip_incomplete_panels`` and
+            ``allow_incomplete_panels`` are set.
     """
     frame = pd.read_csv(path, encoding="utf-8")
     if source.kind == "model_prediction":
@@ -103,8 +112,12 @@ def import_eval_score_frame(
     validated = validate_eval_score_frame(frame, task=task)
     consolidated = consolidate_labels_by_majority(validated, task=task)
     _guard_unique_scoring_units(consolidated, task=task)
-    _guard_complete_panels(consolidated, task=task, allow_incomplete=allow_incomplete_panels)
-    return consolidated
+    return _guard_complete_panels(
+        consolidated,
+        task=task,
+        skip_incomplete=skip_incomplete_panels,
+        allow_incomplete=allow_incomplete_panels,
+    )
 
 
 def _restore_pragmata_text_columns(frame: pd.DataFrame, *, task: Task) -> pd.DataFrame:
@@ -122,8 +135,14 @@ def _guard_unique_scoring_units(frame: pd.DataFrame, *, task: Task) -> None:
         _reject_duplicates(frame, ["record_uuid"], task, "query")
 
 
-def _guard_complete_panels(frame: pd.DataFrame, *, task: Task, allow_incomplete: bool) -> None:
-    """Reject retrieval panels whose labeled chunks do not cover the retrieval.
+def _guard_complete_panels(
+    frame: pd.DataFrame,
+    *,
+    task: Task,
+    skip_incomplete: bool,
+    allow_incomplete: bool,
+) -> tuple[pd.DataFrame, int]:
+    """Apply the incomplete-retrieval-panel policy; return the frame and drop count.
 
     Every retrieval metric averages over a query's chunk set, so a partial panel is
     not a smaller sample of the same quantity - it changes the metric. Precision@K
@@ -131,16 +150,26 @@ def _guard_complete_panels(frame: pd.DataFrame, *, task: Task, allow_incomplete:
     rank-sensitive metrics (MRR, NDCG) are biased upward because annotators work
     top-down, so the unjudged low-rank chunks can never lower the score.
 
+    Three mutually exclusive modes, chosen by the caller because neither remedy is
+    safe to apply on their behalf:
+
+    - default: fail, naming the first short panel.
+    - ``skip_incomplete`` (CLI: ``--skip-incomplete-panels``): drop short panels and
+      score the rest. Each retained panel's metric is then computed correctly, but
+      the population becomes "queries whose panels were completed" - completion is
+      not random, so the drop count is returned and reported on the score artifact.
+    - ``allow_incomplete`` (CLI: ``--allow-incomplete-panels``): score everything
+      as-is, for callers who accept the bias, e.g. coverage comparisons.
+
     The check needs ``n_retrieved_chunks`` (the query's true K, carried by annotation
     exports). Where no panel carries a known K the completeness of the input is
     unknowable here, so the frame passes with a warning rather than a hard failure -
     direct-path and prediction inputs are not required to carry export metadata.
-
-    ``allow_incomplete=True`` (CLI: ``--allow-incomplete-panels``) skips the check for
-    callers who accept the bias, e.g. to score everything for a coverage comparison.
     """
+    if skip_incomplete and allow_incomplete:
+        raise ValueError("skip_incomplete_panels and allow_incomplete_panels are mutually exclusive; pass at most one.")
     if task != Task.RETRIEVAL or allow_incomplete:
-        return
+        return frame, 0
     panels = _panels_with_known_k(frame)
     if panels.empty:
         logger.warning(
@@ -148,16 +177,32 @@ def _guard_complete_panels(frame: pd.DataFrame, *, task: Task, allow_incomplete:
             "n_retrieved_chunks metadata) - metrics over partial panels are biased upward, "
             "see import_eval_score_frame."
         )
-        return
+        return frame, 0
     short = panels[panels["n_chunks"] < panels["k"]]
-    if not short.empty:
-        raise EvalInputSchemaError(
-            f"Scoring input for {task.value} has {len(short)} panel(s) with fewer labeled chunks "
-            f"than n_retrieved_chunks (e.g. record_uuid {short.index[0]!r}: "
-            f"{int(short.iloc[0]['n_chunks'])} of {int(short.iloc[0]['k'])}); partial panels bias "
-            f"every retrieval metric, so filter them out or pass allow_incomplete_panels=True "
-            f"(--allow-incomplete-panels) to score anyway."
+    if short.empty:
+        return frame, 0
+    if skip_incomplete:
+        kept = frame[~frame["record_uuid"].isin(short.index)]
+        if kept.empty:
+            raise EvalInputSchemaError(
+                f"Scoring input for {task.value} has no complete panel to score: all "
+                f"{len(short)} panel(s) have fewer labeled chunks than n_retrieved_chunks."
+            )
+        logger.info(
+            "score input: skipped %d incomplete retrieval panel(s) of %d; the reported "
+            "population is queries whose panels were completed.",
+            len(short),
+            len(panels),
         )
+        return kept, len(short)
+    raise EvalInputSchemaError(
+        f"Scoring input for {task.value} has {len(short)} panel(s) with fewer labeled chunks "
+        f"than n_retrieved_chunks (e.g. record_uuid {short.index[0]!r}: "
+        f"{int(short.iloc[0]['n_chunks'])} of {int(short.iloc[0]['k'])}); partial panels bias "
+        f"every retrieval metric, so pass skip_incomplete_panels=True "
+        f"(--skip-incomplete-panels) to score only the complete panels, or "
+        f"allow_incomplete_panels=True (--allow-incomplete-panels) to score anyway."
+    )
 
 
 def _reject_duplicates(frame: pd.DataFrame, keys: list[str], task: Task, unit: str) -> None:

--- a/src/pragmata/core/eval/scoring.py
+++ b/src/pragmata/core/eval/scoring.py
@@ -67,8 +67,13 @@ def build_score_report(
     seed: int | None,
     source: ScoreInputSource,
     created_at: datetime,
+    n_panels_skipped: int = 0,
 ) -> ScoreReport:
-    """Assemble the task-specific report from per-query values (pure, I/O-free)."""
+    """Assemble the task-specific report from per-query values (pure, I/O-free).
+
+    ``n_panels_skipped`` is recorded on the retrieval report only; the other tasks
+    have no panel notion and reject the field by schema.
+    """
     alpha = 1.0 - ci
 
     def bootstrap(values: list[float]) -> MetricScore:
@@ -85,6 +90,7 @@ def build_score_report(
         return RetrievalScoreReport(
             source=source,
             created_at=created_at,
+            n_panels_skipped=n_panels_skipped,
             n_examples=len(values["topical_precision_at_k"]),
             # chunk_rank is 1-based (enforced by Field(ge=1) on import), so its max is the
             # number of retrieved chunks.

--- a/src/pragmata/core/schemas/eval_output.py
+++ b/src/pragmata/core/schemas/eval_output.py
@@ -3,7 +3,7 @@
 from datetime import UTC, datetime
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, PositiveInt, model_validator
+from pydantic import BaseModel, ConfigDict, Field, NonNegativeInt, PositiveInt, model_validator
 
 from pragmata.core.schemas.annotation_task import Task
 
@@ -82,6 +82,10 @@ class RetrievalScoreReport(BaseModel):
     n_examples: PositiveInt
     top_k: PositiveInt
     ci_level: CiLevel
+    # Incomplete panels dropped by skip_incomplete_panels before scoring. Recorded on
+    # the artifact because skipping changes the population: n_examples then counts
+    # queries whose panels were completed, not the corpus.
+    n_panels_skipped: NonNegativeInt = 0
     topical_precision_at_k: MetricScore
     sufficiency_hit_at_k: MetricScore
     sufficiency_rate_at_k: MetricScore

--- a/src/pragmata/core/settings/eval_settings.py
+++ b/src/pragmata/core/settings/eval_settings.py
@@ -122,6 +122,10 @@ class EvalScoreSettings(ResolveSettings):
         n_resamples: Bootstrap iterations for the continuous metrics' CIs.
         ci: Confidence level for every reported interval (e.g. 0.95 for 95%).
         seed: Optional RNG seed for reproducible bootstrap intervals.
+        allow_incomplete_panels: Score retrieval panels whose labeled chunks do not
+            cover ``n_retrieved_chunks``. Off by default because every retrieval
+            metric averages over a query's chunk set, so a partial panel changes the
+            @K denominators and biases the rank-sensitive metrics.
     """
 
     base_dir: Path = Field(default_factory=Path.cwd)
@@ -133,3 +137,4 @@ class EvalScoreSettings(ResolveSettings):
     n_resamples: PositiveInt = 1000
     ci: float = Field(default=0.95, gt=0.0, lt=1.0)
     seed: int | None = None
+    allow_incomplete_panels: bool = False

--- a/src/pragmata/core/settings/eval_settings.py
+++ b/src/pragmata/core/settings/eval_settings.py
@@ -123,9 +123,9 @@ class EvalScoreSettings(ResolveSettings):
         ci: Confidence level for every reported interval (e.g. 0.95 for 95%).
         seed: Optional RNG seed for reproducible bootstrap intervals.
         allow_incomplete_panels: Score retrieval panels whose labeled chunks do not
-            cover ``n_retrieved_chunks``. Off by default because every retrieval
-            metric averages over a query's chunk set, so a partial panel changes the
-            @K denominators and biases the rank-sensitive metrics.
+            cover `n_retrieved_chunks`. Off by default because every retrieval metric
+            averages over a query's chunk set, so a partial panel changes the @K
+            denominators and biases the rank-sensitive metrics.
     """
 
     base_dir: Path = Field(default_factory=Path.cwd)

--- a/src/pragmata/core/settings/eval_settings.py
+++ b/src/pragmata/core/settings/eval_settings.py
@@ -137,4 +137,13 @@ class EvalScoreSettings(ResolveSettings):
     n_resamples: PositiveInt = 1000
     ci: float = Field(default=0.95, gt=0.0, lt=1.0)
     seed: int | None = None
+    skip_incomplete_panels: bool = False
     allow_incomplete_panels: bool = False
+
+    @model_validator(mode="after")
+    def _at_most_one_incomplete_panel_mode(self) -> "EvalScoreSettings":
+        if self.skip_incomplete_panels and self.allow_incomplete_panels:
+            raise ValueError(
+                "skip_incomplete_panels and allow_incomplete_panels are mutually exclusive; pass at most one."
+            )
+        return self

--- a/tests/unit/cli/test_cli_eval.py
+++ b/tests/unit/cli/test_cli_eval.py
@@ -426,6 +426,7 @@ class TestScoreCommand:
             "--n-resamples",
             "--ci",
             "--seed",
+            "--allow-incomplete-panels",
             "--config",
         ):
             assert option in output
@@ -453,6 +454,7 @@ class TestScoreCommand:
             "n_resamples",
             "ci",
             "seed",
+            "allow_incomplete_panels",
             "config_path",
         }
         assert all(value is UNSET for value in captured.values())
@@ -504,6 +506,7 @@ class TestScoreCommand:
             "n_resamples": 500,
             "ci": 0.9,
             "seed": 7,
+            "allow_incomplete_panels": UNSET,
             "config_path": "eval.yml",
         }
 

--- a/tests/unit/cli/test_cli_eval.py
+++ b/tests/unit/cli/test_cli_eval.py
@@ -426,6 +426,7 @@ class TestScoreCommand:
             "--n-resamples",
             "--ci",
             "--seed",
+            "--skip-incomplete-panels",
             "--allow-incomplete-panels",
             "--config",
         ):
@@ -454,6 +455,7 @@ class TestScoreCommand:
             "n_resamples",
             "ci",
             "seed",
+            "skip_incomplete_panels",
             "allow_incomplete_panels",
             "config_path",
         }
@@ -506,6 +508,7 @@ class TestScoreCommand:
             "n_resamples": 500,
             "ci": 0.9,
             "seed": 7,
+            "skip_incomplete_panels": UNSET,
             "allow_incomplete_panels": UNSET,
             "config_path": "eval.yml",
         }

--- a/tests/unit/core/eval/test_imports.py
+++ b/tests/unit/core/eval/test_imports.py
@@ -189,7 +189,7 @@ class TestImportEvalScoreFrame:
             ],
         )
 
-        frame = import_eval_score_frame(path=path, task=Task.RETRIEVAL, source=self._DIRECT)
+        frame, _ = import_eval_score_frame(path=path, task=Task.RETRIEVAL, source=self._DIRECT)
 
         assert list(frame["query"]) == ["q1", "q1"]
         assert set(["query", "chunk", "record_uuid", "chunk_id", "chunk_rank"]).issubset(frame.columns)
@@ -218,7 +218,7 @@ class TestImportEvalScoreFrame:
             ],
         )
 
-        frame = import_eval_score_frame(path=path, task=Task.RETRIEVAL, source=self._DIRECT)
+        frame, _ = import_eval_score_frame(path=path, task=Task.RETRIEVAL, source=self._DIRECT)
 
         assert len(frame) == 1
         row = frame.iloc[0]
@@ -255,7 +255,7 @@ class TestImportEvalScoreFrame:
             ],
         )
 
-        frame = import_eval_score_frame(path=path, task=Task.GROUNDING, source=self._DIRECT)
+        frame, _ = import_eval_score_frame(path=path, task=Task.GROUNDING, source=self._DIRECT)
 
         assert len(frame) == 1
         row = frame.iloc[0]
@@ -274,7 +274,7 @@ class TestImportEvalScoreFrame:
             ],
         )
 
-        frame = import_eval_score_frame(path=path, task=Task.RETRIEVAL, source=self._PREDICTION)
+        frame, _ = import_eval_score_frame(path=path, task=Task.RETRIEVAL, source=self._PREDICTION)
 
         assert {"query", "chunk"}.issubset(frame.columns)
         assert "text" not in frame.columns and "text_pair" not in frame.columns
@@ -307,7 +307,7 @@ class TestImportEvalScoreFrame:
             ],
         )
 
-        frame = import_eval_score_frame(path=path, task=Task.RETRIEVAL, source=self._DIRECT)
+        frame, _ = import_eval_score_frame(path=path, task=Task.RETRIEVAL, source=self._DIRECT)
 
         assert len(frame) == 2
 
@@ -321,11 +321,71 @@ class TestImportEvalScoreFrame:
             ],
         )
 
-        frame = import_eval_score_frame(
+        frame, n_panels_skipped = import_eval_score_frame(
             path=path, task=Task.RETRIEVAL, source=self._DIRECT, allow_incomplete_panels=True
         )
 
         assert len(frame) == 1
+        assert n_panels_skipped == 0
+
+    def test_skip_incomplete_panels_drops_short_panels_and_reports_the_count(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        # One complete K=2 panel, one short K=5 panel: the short one is dropped and
+        # counted so the score artifact records the reduced population.
+        path = self._write(
+            tmp_path,
+            [
+                "query,chunk,topically_relevant,evidence_sufficient,misleading,"
+                "record_uuid,chunk_id,chunk_rank,n_retrieved_chunks",
+                "q1,c1,1,1,0,r1,ch1,1,2",
+                "q1,c2,0,0,1,r1,ch2,2,2",
+                "q2,c3,1,0,0,r2,ch3,1,5",
+            ],
+        )
+
+        frame, n_panels_skipped = import_eval_score_frame(
+            path=path, task=Task.RETRIEVAL, source=self._DIRECT, skip_incomplete_panels=True
+        )
+
+        assert n_panels_skipped == 1
+        assert set(frame["record_uuid"]) == {"r1"}
+
+    def test_skip_incomplete_panels_rejects_an_input_with_no_complete_panel(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        path = self._write(
+            tmp_path,
+            [
+                "query,chunk,topically_relevant,evidence_sufficient,misleading,"
+                "record_uuid,chunk_id,chunk_rank,n_retrieved_chunks",
+                "q1,c1,1,1,0,r1,ch1,1,5",
+            ],
+        )
+
+        with pytest.raises(EvalInputSchemaError, match="no complete panel"):
+            import_eval_score_frame(path=path, task=Task.RETRIEVAL, source=self._DIRECT, skip_incomplete_panels=True)
+
+    def test_skip_and_allow_are_mutually_exclusive(self, tmp_path: Path) -> None:
+        path = self._write(
+            tmp_path,
+            [
+                "query,chunk,topically_relevant,evidence_sufficient,misleading,"
+                "record_uuid,chunk_id,chunk_rank,n_retrieved_chunks",
+                "q1,c1,1,1,0,r1,ch1,1,1",
+            ],
+        )
+
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            import_eval_score_frame(
+                path=path,
+                task=Task.RETRIEVAL,
+                source=self._DIRECT,
+                skip_incomplete_panels=True,
+                allow_incomplete_panels=True,
+            )
 
     def test_warns_instead_of_failing_without_an_n_retrieved_chunks_column(
         self,
@@ -343,7 +403,7 @@ class TestImportEvalScoreFrame:
         )
 
         with caplog.at_level(logging.WARNING, logger="pragmata.core.eval.imports"):
-            frame = import_eval_score_frame(path=path, task=Task.RETRIEVAL, source=self._DIRECT)
+            frame, _ = import_eval_score_frame(path=path, task=Task.RETRIEVAL, source=self._DIRECT)
 
         assert len(frame) == 1
         assert any("n_retrieved_chunks" in message for message in caplog.messages)
@@ -364,7 +424,7 @@ class TestImportEvalScoreFrame:
         )
 
         with caplog.at_level(logging.WARNING, logger="pragmata.core.eval.imports"):
-            frame = import_eval_score_frame(path=path, task=Task.RETRIEVAL, source=self._DIRECT)
+            frame, _ = import_eval_score_frame(path=path, task=Task.RETRIEVAL, source=self._DIRECT)
 
         assert len(frame) == 1
         assert any("n_retrieved_chunks" in message for message in caplog.messages)
@@ -379,6 +439,6 @@ class TestImportEvalScoreFrame:
             ],
         )
 
-        frame = import_eval_score_frame(path=path, task=Task.GROUNDING, source=self._DIRECT)
+        frame, _ = import_eval_score_frame(path=path, task=Task.GROUNDING, source=self._DIRECT)
 
         assert len(frame) == 1

--- a/tests/unit/core/eval/test_imports.py
+++ b/tests/unit/core/eval/test_imports.py
@@ -1,5 +1,6 @@
 """Tests for eval dataframe import workflows."""
 
+import logging
 from pathlib import Path
 
 import pandas as pd
@@ -280,28 +281,13 @@ class TestImportEvalScoreFrame:
         assert frame.loc[0, "query"] == "q1"
         assert frame.loc[0, "chunk"] == "c1"
 
-
-class TestGuardCompletePanels:
-    """Tests for the retrieval panel-completeness guard."""
-
-    _DIRECT = ScoreInputSource(kind="direct_path", ref="in.csv", resolved_path="in.csv")
-
-    _HEADER = (
-        "query,chunk,topically_relevant,evidence_sufficient,misleading,"
-        "record_uuid,chunk_id,chunk_rank,n_retrieved_chunks"
-    )
-
-    def _write(self, tmp_path: Path, rows: list[str]) -> Path:
-        path = tmp_path / "score.csv"
-        path.write_text("\n".join(rows) + "\n", encoding="utf-8")
-        return path
-
-    def test_rejects_partial_panel(self, tmp_path: Path) -> None:
+    def test_rejects_retrieval_panel_short_of_n_retrieved_chunks(self, tmp_path: Path) -> None:
         # Two labeled chunks of a K=5 retrieval: the @K denominators would be wrong.
         path = self._write(
             tmp_path,
             [
-                self._HEADER,
+                "query,chunk,topically_relevant,evidence_sufficient,misleading,"
+                "record_uuid,chunk_id,chunk_rank,n_retrieved_chunks",
                 "q1,c1,1,1,0,r1,ch1,1,5",
                 "q1,c2,0,0,1,r1,ch2,2,5",
             ],
@@ -310,11 +296,12 @@ class TestGuardCompletePanels:
         with pytest.raises(EvalInputSchemaError, match="fewer labeled chunks"):
             import_eval_score_frame(path=path, task=Task.RETRIEVAL, source=self._DIRECT)
 
-    def test_accepts_complete_panel(self, tmp_path: Path) -> None:
+    def test_accepts_retrieval_panel_covering_n_retrieved_chunks(self, tmp_path: Path) -> None:
         path = self._write(
             tmp_path,
             [
-                self._HEADER,
+                "query,chunk,topically_relevant,evidence_sufficient,misleading,"
+                "record_uuid,chunk_id,chunk_rank,n_retrieved_chunks",
                 "q1,c1,1,1,0,r1,ch1,1,2",
                 "q1,c2,0,0,1,r1,ch2,2,2",
             ],
@@ -324,11 +311,12 @@ class TestGuardCompletePanels:
 
         assert len(frame) == 2
 
-    def test_allow_incomplete_panels_skips_the_guard(self, tmp_path: Path) -> None:
+    def test_allow_incomplete_panels_skips_the_completeness_guard(self, tmp_path: Path) -> None:
         path = self._write(
             tmp_path,
             [
-                self._HEADER,
+                "query,chunk,topically_relevant,evidence_sufficient,misleading,"
+                "record_uuid,chunk_id,chunk_rank,n_retrieved_chunks",
                 "q1,c1,1,1,0,r1,ch1,1,5",
             ],
         )
@@ -339,40 +327,56 @@ class TestGuardCompletePanels:
 
         assert len(frame) == 1
 
-    def test_missing_k_column_warns_instead_of_failing(self, tmp_path: Path, caplog) -> None:
+    def test_warns_instead_of_failing_without_an_n_retrieved_chunks_column(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
         # Direct-path inputs are not required to carry export metadata; completeness is
         # unknowable without K, so the frame passes with a warning.
-        path = tmp_path / "score.csv"
-        path.write_text(
-            "\n".join(
-                [
-                    "query,chunk,topically_relevant,evidence_sufficient,misleading,"
-                    "record_uuid,chunk_id,chunk_rank",
-                    "q1,c1,1,1,0,r1,ch1,1",
-                ]
-            )
-            + "\n",
-            encoding="utf-8",
+        path = self._write(
+            tmp_path,
+            [
+                "query,chunk,topically_relevant,evidence_sufficient,misleading,record_uuid,chunk_id,chunk_rank",
+                "q1,c1,1,1,0,r1,ch1,1",
+            ],
         )
 
-        with caplog.at_level("WARNING"):
+        with caplog.at_level(logging.WARNING, logger="pragmata.core.eval.imports"):
             frame = import_eval_score_frame(path=path, task=Task.RETRIEVAL, source=self._DIRECT)
 
         assert len(frame) == 1
         assert any("n_retrieved_chunks" in message for message in caplog.messages)
 
-    def test_guard_does_not_apply_to_grounding(self, tmp_path: Path) -> None:
-        path = tmp_path / "score.csv"
-        path.write_text(
-            "\n".join(
-                [
-                    "answer,context_set,support_present,unsupported_claim_present,"
-                    "contradicted_claim_present,source_cited,fabricated_source,record_uuid",
-                    "a1,ctx,1,0,0,1,0,r1",
-                ]
-            )
-            + "\n",
-            encoding="utf-8",
+    def test_warns_instead_of_failing_when_every_panel_carries_the_absent_k_sentinel(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        # Pre-backfill exports carry n_retrieved_chunks=-1; K is unknown, not violated.
+        path = self._write(
+            tmp_path,
+            [
+                "query,chunk,topically_relevant,evidence_sufficient,misleading,"
+                "record_uuid,chunk_id,chunk_rank,n_retrieved_chunks",
+                "q1,c1,1,1,0,r1,ch1,1,-1",
+            ],
+        )
+
+        with caplog.at_level(logging.WARNING, logger="pragmata.core.eval.imports"):
+            frame = import_eval_score_frame(path=path, task=Task.RETRIEVAL, source=self._DIRECT)
+
+        assert len(frame) == 1
+        assert any("n_retrieved_chunks" in message for message in caplog.messages)
+
+    def test_completeness_guard_does_not_apply_to_grounding(self, tmp_path: Path) -> None:
+        path = self._write(
+            tmp_path,
+            [
+                "answer,context_set,support_present,unsupported_claim_present,"
+                "contradicted_claim_present,source_cited,fabricated_source,record_uuid",
+                "a1,ctx,1,0,0,1,0,r1",
+            ],
         )
 
         frame = import_eval_score_frame(path=path, task=Task.GROUNDING, source=self._DIRECT)

--- a/tests/unit/core/eval/test_imports.py
+++ b/tests/unit/core/eval/test_imports.py
@@ -279,3 +279,102 @@ class TestImportEvalScoreFrame:
         assert "text" not in frame.columns and "text_pair" not in frame.columns
         assert frame.loc[0, "query"] == "q1"
         assert frame.loc[0, "chunk"] == "c1"
+
+
+class TestGuardCompletePanels:
+    """Tests for the retrieval panel-completeness guard."""
+
+    _DIRECT = ScoreInputSource(kind="direct_path", ref="in.csv", resolved_path="in.csv")
+
+    _HEADER = (
+        "query,chunk,topically_relevant,evidence_sufficient,misleading,"
+        "record_uuid,chunk_id,chunk_rank,n_retrieved_chunks"
+    )
+
+    def _write(self, tmp_path: Path, rows: list[str]) -> Path:
+        path = tmp_path / "score.csv"
+        path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+        return path
+
+    def test_rejects_partial_panel(self, tmp_path: Path) -> None:
+        # Two labeled chunks of a K=5 retrieval: the @K denominators would be wrong.
+        path = self._write(
+            tmp_path,
+            [
+                self._HEADER,
+                "q1,c1,1,1,0,r1,ch1,1,5",
+                "q1,c2,0,0,1,r1,ch2,2,5",
+            ],
+        )
+
+        with pytest.raises(EvalInputSchemaError, match="fewer labeled chunks"):
+            import_eval_score_frame(path=path, task=Task.RETRIEVAL, source=self._DIRECT)
+
+    def test_accepts_complete_panel(self, tmp_path: Path) -> None:
+        path = self._write(
+            tmp_path,
+            [
+                self._HEADER,
+                "q1,c1,1,1,0,r1,ch1,1,2",
+                "q1,c2,0,0,1,r1,ch2,2,2",
+            ],
+        )
+
+        frame = import_eval_score_frame(path=path, task=Task.RETRIEVAL, source=self._DIRECT)
+
+        assert len(frame) == 2
+
+    def test_allow_incomplete_panels_skips_the_guard(self, tmp_path: Path) -> None:
+        path = self._write(
+            tmp_path,
+            [
+                self._HEADER,
+                "q1,c1,1,1,0,r1,ch1,1,5",
+            ],
+        )
+
+        frame = import_eval_score_frame(
+            path=path, task=Task.RETRIEVAL, source=self._DIRECT, allow_incomplete_panels=True
+        )
+
+        assert len(frame) == 1
+
+    def test_missing_k_column_warns_instead_of_failing(self, tmp_path: Path, caplog) -> None:
+        # Direct-path inputs are not required to carry export metadata; completeness is
+        # unknowable without K, so the frame passes with a warning.
+        path = tmp_path / "score.csv"
+        path.write_text(
+            "\n".join(
+                [
+                    "query,chunk,topically_relevant,evidence_sufficient,misleading,"
+                    "record_uuid,chunk_id,chunk_rank",
+                    "q1,c1,1,1,0,r1,ch1,1",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        with caplog.at_level("WARNING"):
+            frame = import_eval_score_frame(path=path, task=Task.RETRIEVAL, source=self._DIRECT)
+
+        assert len(frame) == 1
+        assert any("n_retrieved_chunks" in message for message in caplog.messages)
+
+    def test_guard_does_not_apply_to_grounding(self, tmp_path: Path) -> None:
+        path = tmp_path / "score.csv"
+        path.write_text(
+            "\n".join(
+                [
+                    "answer,context_set,support_present,unsupported_claim_present,"
+                    "contradicted_claim_present,source_cited,fabricated_source,record_uuid",
+                    "a1,ctx,1,0,0,1,0,r1",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        frame = import_eval_score_frame(path=path, task=Task.GROUNDING, source=self._DIRECT)
+
+        assert len(frame) == 1

--- a/tests/unit/core/settings/test_eval_settings.py
+++ b/tests/unit/core/settings/test_eval_settings.py
@@ -211,6 +211,18 @@ def test_eval_score_settings_construction_with_prediction_id() -> None:
     assert settings.task == Task.GROUNDING
 
 
+def test_eval_score_settings_rejects_both_incomplete_panel_modes() -> None:
+    """skip_incomplete_panels and allow_incomplete_panels are mutually exclusive."""
+    with pytest.raises(ValidationError, match="mutually exclusive"):
+        EvalScoreSettings.model_validate(
+            {
+                "task": "retrieval",
+                "skip_incomplete_panels": True,
+                "allow_incomplete_panels": True,
+            }
+        )
+
+
 def test_eval_score_settings_generates_distinct_score_ids() -> None:
     """EvalScoreSettings generates a default score_id for each instance."""
     first = EvalScoreSettings.model_validate({"task": "retrieval"})


### PR DESCRIPTION
## Summary

- `eval score` silently accepts partial retrieval panels. 
- -Annotation exports carry `panel_complete` and `n_retrieved_chunks`, but nothing in the scoring path reads either - the score schema doesn't require them, and `grouping.py` averages whatever chunks are present. 
- A partial panel is not a smaller sample of the same quantity, it changes the metric: precision@K over 2 labeled chunks of a K=5 retrieval has the wrong denominator, and the rank-sensitive metrics (MRR, NDCG) are biased upward because annotators work top-down, so unjudged low-rank chunks can never lower the score.

## Behaviour: three mutually exclusive modes

| Mode | Result |
|---|---|
| default | `EvalInputSchemaError` naming the first short panel |
| `--skip-incomplete-panels` | drop short panels, score the rest; the retrieval report records `n_panels_skipped` and the CLI echoes it |
| `--allow-incomplete-panels` | score everything as-is, for callers who accept the bias |

Passing both flags raises (guard + `EvalScoreSettings` validator). Skipping every panel is an error, not an empty success. Frames without a usable K (column absent on direct-path/prediction inputs, or the `-1` pre-backfill sentinel) pass with a `logger.warning`: completeness is unknowable there rather than violated. Grounding/generation are unaffected (no panel notion).

The default stays **fail** because neither remedy is safe to apply on the caller's behalf: skipping changes the population (completion is not random), allowing changes the metric.

## Test plan

- [x] Guard: rejects a partial panel; accepts a complete one; skip drops and counts; skip-with-nothing-left raises; both-flags raises; missing-K and `-1`-sentinel warning paths; grounding unaffected
- [x] Settings: mutual-exclusion validator test
- [x] CLI: help listing, UNSET mapping, delegation for both flags
- [x] Full suite: 1261 passed; ruff format/check and mypy clean